### PR TITLE
fix: reselect first template when create-agent dialog reopens

### DIFF
--- a/apps/dashboard/src/client/ui/components/create-agent-dialog.tsx
+++ b/apps/dashboard/src/client/ui/components/create-agent-dialog.tsx
@@ -61,10 +61,10 @@ export function CreateAgentDialog({ open, onOpenChange, onSuccess }: CreateAgent
   const { data: templates } = useQuery(trpc.template.list.queryOptions());
 
   useEffect(() => {
-    if (templates && templates.length > 0 && selectedTemplateId === null) {
+    if (open && templates && templates.length > 0 && selectedTemplateId === null) {
       handleSelectTemplate(templates[0]!);
     }
-  }, [templates]);
+  }, [open, templates]);
 
   const { mutate: createAgent, isPending: isCreating } = useMutation(
     trpc.agent.create.mutationOptions({


### PR DESCRIPTION
## Summary

- The `useEffect` in `CreateAgentDialog` had `[templates]` as its only dependency, so resetting `selectedTemplateId` to `null` on dialog close didn't trigger a re-run when the dialog reopened
- Added `open` to the effect's condition and dependency array so the first template is auto-selected each time the dialog opens

## Test plan

- [x] Open the create-agent dialog — first template should be auto-selected
- [ ] Close the dialog, reopen it — first template should still be auto-selected (not the blank default YAML)
- [ ] Select a different template, close, reopen — first template should be selected again on reopen