### PR TITLE
feat: remove direct envVars from Agent, enforce secrets-only env injection

### DIFF
--- a/apps/dashboard/src/client/ui/components/create-agent-dialog.tsx
+++ b/apps/dashboard/src/client/ui/components/create-agent-dialog.tsx
@@ -41,7 +41,6 @@ and concisely, help with tasks, and make the user's work easier.
 ## Core Principles
 - Ask for clarification when a request is ambiguous.
 - Admit when you don't know something rather than guessing.`,
-  envVars: [],
   skills: [],
   plugins: [],
 } as AgentInput);

--- a/apps/dashboard/src/client/ui/routes/agents/$id.tsx
+++ b/apps/dashboard/src/client/ui/routes/agents/$id.tsx
@@ -15,14 +15,6 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@hermeum/components/ui/accordion";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@hermeum/components/ui/table";
 import { authClient } from "@/client/auth-client";
 import { useTRPC } from "@/router";
 import { PhaseBadge } from "@/client/ui/components/phase-badge";
@@ -227,33 +219,6 @@ function AgentDetailPage() {
                     </AccordionContent>
                   </AccordionItem>
                 </Accordion>
-              </CardContent>
-            </Card>
-          )}
-
-          {/* envVars */}
-          {agent.envVars && agent.envVars.length > 0 && (
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-sm font-medium">Environment Variables</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead>Name</TableHead>
-                      <TableHead>Value</TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {agent.envVars.map((e) => (
-                      <TableRow key={e.name}>
-                        <TableCell className="font-mono text-xs">{e.name}</TableCell>
-                        <TableCell className="font-mono text-xs">{e.value}</TableCell>
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
               </CardContent>
             </Card>
           )}

--- a/apps/dashboard/src/entities/agent.ts
+++ b/apps/dashboard/src/entities/agent.ts
@@ -38,7 +38,7 @@ export const ConfigSchema = z.record(z.string(), z.unknown()).optional();
 
 export type Config = z.infer<typeof ConfigSchema>;
 
-export const SelfConfigActionSchema = z.enum(["skills", "config", "soul", "envVars"]);
+export const SelfConfigActionSchema = z.enum(["skills", "config", "soul"]);
 
 export type SelfConfigAction = z.infer<typeof SelfConfigActionSchema>;
 
@@ -51,26 +51,12 @@ export const SelfConfigureSchema = z
 
 export type SelfConfigure = z.infer<typeof SelfConfigureSchema>;
 
-export const EnvVarSchema = z.object({
-  name: z
-    .string()
-    .min(1)
-    .regex(
-      /^[-._a-zA-Z0-9]+$/,
-      "A environment variable name must consist of alphanumeric characters, '-', '_' or '.'"
-    ),
-  value: z.string(),
-});
-
-export type EnvVar = z.infer<typeof EnvVarSchema>;
-
 export const AgentInputSchema = z.object({
   name: z.string().optional(),
   description: z.string().optional(),
   type: z.string().optional(),
   version: z.string().optional(),
   config: ConfigSchema,
-  envVars: z.array(EnvVarSchema).optional(),
   secrets: z.array(z.string()).optional(),
   soul: z.string().optional(),
   skills: SkillsSchema,

--- a/apps/dashboard/src/entities/secret.ts
+++ b/apps/dashboard/src/entities/secret.ts
@@ -1,5 +1,18 @@
 import { z } from "zod";
 
+export const EnvVarSchema = z.object({
+  name: z
+    .string()
+    .min(1)
+    .regex(
+      /^[-._a-zA-Z0-9]+$/,
+      "A environment variable name must consist of alphanumeric characters, '-', '_' or '.'"
+    ),
+  value: z.string(),
+});
+
+export type EnvVar = z.infer<typeof EnvVarSchema>;
+
 export const SecretEnvVarSchema = z.object({
   name: z
     .string()

--- a/apps/dashboard/src/server/infras/kubernetes/client.ts
+++ b/apps/dashboard/src/server/infras/kubernetes/client.ts
@@ -63,9 +63,6 @@ export function agentToHermesAgent(agent: Agent): HermesAgent {
   if (agent.config !== undefined) {
     hermes.config = { raw: agent.config };
   }
-  if (agent.envVars !== undefined) {
-    hermes.env = agent.envVars.map((e) => ({ name: e.name, value: e.value }));
-  }
   if (agent.secrets !== undefined) {
     hermes.envFrom = agent.secrets.map((name) => ({ secretRef: { name } }));
   }
@@ -109,7 +106,6 @@ export function mapHermesAgent(raw: HermesAgent): Agent {
     type: raw.metadata?.annotations?.[HermeumAnnotation.AgentType],
     version: raw.spec.hermes?.image?.tag,
     config: raw.spec.hermes?.config?.raw,
-    envVars: raw.spec.hermes?.env?.map((e) => ({ name: e.name, value: e.value ?? "" })),
     secrets: raw.spec.hermes?.envFrom?.flatMap((e) =>
       e.secretRef?.name ? [e.secretRef.name] : []
     ),

--- a/apps/dashboard/src/server/infras/kubernetes/types/hermes-agent.ts
+++ b/apps/dashboard/src/server/infras/kubernetes/types/hermes-agent.ts
@@ -184,7 +184,6 @@ export interface Hermes {
   skills?: HermesSkill[] | undefined;
   crons?: HermesCron[] | undefined;
   bundles?: HermesBundle[] | undefined;
-  env?: k8s.V1EnvVar[] | undefined;
   envFrom?: k8s.V1EnvFromSource[] | undefined;
   resources?: k8s.V1ResourceRequirements | undefined;
   probes?: Probes | undefined;

--- a/apps/dashboard/src/server/routers/trpc/agent.ts
+++ b/apps/dashboard/src/server/routers/trpc/agent.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import { Agent, AgentInputSchema, SkillSchema, EnvVarSchema } from "@/entities";
+import { Agent, AgentInputSchema, SkillSchema } from "@/entities";
 import { AgentUseCase } from "@/server/usecases/agent";
 import { protectedProcedure, t } from "./shared.js";
 
@@ -44,24 +44,6 @@ export const agentRouter = t.router({
     .input(z.object({ agentId: z.string().min(1), skill: SkillSchema }))
     .mutation(async ({ ctx, input }): Promise<Agent> => {
       return await usecase.uninstallSkill(ctx, input.agentId, input.skill);
-    }),
-
-  addEnv: protectedProcedure
-    .input(z.object({ id: z.string().min(1), envVar: EnvVarSchema }))
-    .mutation(async ({ ctx, input }): Promise<Agent> => {
-      return await usecase.addEnv(ctx, input.id, input.envVar);
-    }),
-
-  updateEnv: protectedProcedure
-    .input(z.object({ id: z.string().min(1), envVar: EnvVarSchema }))
-    .mutation(async ({ ctx, input }): Promise<Agent> => {
-      return await usecase.updateEnv(ctx, input.id, input.envVar);
-    }),
-
-  removeEnv: protectedProcedure
-    .input(z.object({ id: z.string().min(1), envName: z.string().min(1) }))
-    .mutation(async ({ ctx, input }): Promise<Agent> => {
-      return await usecase.removeEnv(ctx, input.id, input.envName);
     }),
 
   suspend: protectedProcedure

--- a/apps/dashboard/src/server/usecases/agent.ts
+++ b/apps/dashboard/src/server/usecases/agent.ts
@@ -5,7 +5,6 @@ import {
   AgentInput,
   AgentInputSchema,
   Context,
-  EnvVar,
   JsonPatchOp,
   Skill,
   SkillSchema,
@@ -93,54 +92,6 @@ export class AgentUseCase {
     }
     this.verifyOwnership(ctx, agent);
     return this.runtime.deleteHermesAgent(id);
-  }
-
-  async addEnv(ctx: Context, agentId: string, envVar: EnvVar): Promise<Agent> {
-    const agent = await this.runtime.getHermesAgent(agentId);
-    if (!agent) {
-      throw new Error(`HermesAgent ${agentId} not found`);
-    }
-    this.verifyOwnership(ctx, agent);
-    const alreadyExists = agent.envVars?.some((e) => e.name === envVar.name);
-    if (alreadyExists) {
-      throw new Error(`Env var "${envVar.name}" already exists`);
-    }
-    return this.runtime.patchHermesAgent({
-      id: agentId,
-      patch: { envVars: [...(agent.envVars ?? []), envVar] },
-    });
-  }
-
-  async updateEnv(ctx: Context, agentId: string, envVar: EnvVar): Promise<Agent> {
-    const agent = await this.runtime.getHermesAgent(agentId);
-    if (!agent) {
-      throw new Error(`HermesAgent ${agentId} not found`);
-    }
-    this.verifyOwnership(ctx, agent);
-    const envVarExists = agent.envVars?.some((e) => e.name === envVar.name);
-    if (!envVarExists) {
-      throw new Error(`Env var "${envVar.name}" not found`);
-    }
-    return this.runtime.patchHermesAgent({
-      id: agentId,
-      patch: { envVars: agent.envVars?.map((e) => (e.name === envVar.name ? envVar : e)) },
-    });
-  }
-
-  async removeEnv(ctx: Context, agentId: string, envName: string): Promise<Agent> {
-    const agent = await this.runtime.getHermesAgent(agentId);
-    if (!agent) {
-      throw new Error(`HermesAgent ${agentId} not found`);
-    }
-    this.verifyOwnership(ctx, agent);
-    const envVarExists = agent.envVars?.some((e) => e.name === envName);
-    if (!envVarExists) {
-      throw new Error(`Env var "${envName}" not found`);
-    }
-    return this.runtime.patchHermesAgent({
-      id: agentId,
-      patch: { envVars: agent.envVars?.filter((e) => e.name !== envName) },
-    });
   }
 
   async installSkill(ctx: Context, agentId: string, skill: Skill): Promise<Agent> {


### PR DESCRIPTION
## Summary

- Removes the `envVars` field from `Agent`/`AgentInputSchema` and all plaintext key/value env var management from the agent subsystem
- Drops `addEnv`, `updateEnv`, `removeEnv` tRPC routes and use-case methods
- Removes the `env` field from the `Hermes` Kubernetes spec interface and its mapping in `agentToHermesAgent`/`mapHermesAgent`
- Moves `EnvVarSchema` / `EnvVar` type from `entities/agent.ts` to `entities/secret.ts`, where they now exclusively belong (still used by the secrets workflow)
- Cleans up the agent detail UI (env vars display table + unused `Table` imports) and the default YAML template in the create dialog

## Why

Plaintext env vars on the Agent spec store sensitive values in the Kubernetes custom resource without any secret protection. Secrets (`envFrom`) are the correct mechanism — this change makes them the only supported path.

## Reviewer notes

- `EnvVarDialog` and the secrets env var routes (`secret.addEnvVar` / `secret.removeEnvVar`) are unchanged — they drive the secrets-based workflow that remains the sole supported path
- TypeScript typecheck passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)