### PR TITLE
feat: fix Hermes image to server config, remove version from Agent

### DIFF
--- a/apps/dashboard/src/entities/agent.ts
+++ b/apps/dashboard/src/entities/agent.ts
@@ -55,7 +55,6 @@ export const AgentInputSchema = z.object({
   name: z.string().optional(),
   description: z.string().optional(),
   type: z.string().optional(),
-  version: z.string().optional(),
   config: ConfigSchema,
   secrets: z.array(z.string()).optional(),
   soul: z.string().optional(),

--- a/apps/dashboard/src/server/infras/kubernetes/client.ts
+++ b/apps/dashboard/src/server/infras/kubernetes/client.ts
@@ -75,9 +75,7 @@ export function agentToHermesAgent(agent: Agent): HermesAgent {
   if (agent.plugins !== undefined) {
     hermes.plugins = agent.plugins.map((identifier) => ({ identifier }));
   }
-  if (agent.version !== undefined) {
-    hermes.image = { tag: agent.version };
-  }
+  hermes.image = { repository: config.hermesImageRepository, tag: config.hermesImageTag };
 
   const spec: HermesAgentSpec = {
     ...(agent.suspended !== undefined && { suspend: agent.suspended }),
@@ -104,7 +102,6 @@ export function mapHermesAgent(raw: HermesAgent): Agent {
     name: raw.metadata?.annotations?.[HermeumAnnotation.Name],
     description: raw.metadata?.annotations?.[HermeumAnnotation.Description],
     type: raw.metadata?.annotations?.[HermeumAnnotation.AgentType],
-    version: raw.spec.hermes?.image?.tag,
     config: raw.spec.hermes?.config?.raw,
     secrets: raw.spec.hermes?.envFrom?.flatMap((e) =>
       e.secretRef?.name ? [e.secretRef.name] : []

--- a/apps/dashboard/src/server/libs/config.ts
+++ b/apps/dashboard/src/server/libs/config.ts
@@ -9,6 +9,8 @@ export const ConfigSchema = z.object({
   kubernetesNamespace: z.string().default("hermeum"),
   smtpUrl: z.url().optional(),
   allowedEmailDomain: z.string().optional(),
+  hermesImageRepository: z.string().default("nousresearch/hermes-agent"),
+  hermesImageTag: z.string().default("v2026.6.19"),
 });
 
 export const config = ConfigSchema.parse({
@@ -17,4 +19,6 @@ export const config = ConfigSchema.parse({
   kubernetesNamespace: process.env.HERMEUM_KUBERNETES_NAMESPACE,
   smtpUrl: process.env.HERMEUM_SMTP_URL,
   allowedEmailDomain: process.env.HERMEUM_ALLOWED_EMAIL_DOMAIN,
+  hermesImageRepository: process.env.HERMEUM_HERMES_IMAGE_REPOSITORY,
+  hermesImageTag: process.env.HERMEUM_HERMES_IMAGE_TAG,
 });


### PR DESCRIPTION
## What changed

- Added `HERMEUM_HERMES_IMAGE_REPOSITORY` and `HERMEUM_HERMES_IMAGE_TAG` to `config.ts`, defaulting to `nousresearch/hermes-agent` and `v2026.6.19`
- Removed `version` from `AgentInputSchema` (and by extension `AgentSchema` / `Agent` type)
- `agentToHermesAgent` now always sets `hermes.image` from server config instead of the per-agent `version` field
- `mapHermesAgent` no longer reads `image.tag` back as `version`

## Why

Hermeum controls which Hermes version it deploys — the image tag is a deployment concern, not something individual agents should override. This centralises the image coordinates in server config so they can be pinned or overridden via environment variables (`HERMEUM_HERMES_IMAGE_REPOSITORY`, `HERMEUM_HERMES_IMAGE_TAG`) without touching agent definitions.

## Reviewer notes

The cascade from removing `version` in `AgentInputSchema` is fully handled by TypeScript — tRPC routers, use cases, and UI dialogs all reference the schema directly and required no manual changes. `tsc --noEmit` passes clean.