### PR TITLE
feat: redesign agent detail page and polish config editors

### DIFF
--- a/apps/dashboard/src/client/ui/components/create-agent-dialog.tsx
+++ b/apps/dashboard/src/client/ui/components/create-agent-dialog.tsx
@@ -158,7 +158,7 @@ export function CreateAgentDialog({ open, onOpenChange, onSuccess }: CreateAgent
               extensions={[yamlLang(), indentationMarkers()]}
               onChange={setEditorValue}
               className={cn(
-                "overflow-hidden rounded-lg border text-sm [&_.cm-content]:outline-none [&_.cm-editor.cm-focused]:outline-none",
+                "overflow-hidden rounded-[0.25rem] border text-sm [&_.cm-content]:outline-none [&_.cm-editor.cm-focused]:outline-none [&_.cm-scroller]:font-sans!",
                 validationError && "border-destructive"
               )}
               basicSetup={{

--- a/apps/dashboard/src/client/ui/components/create-agent-dialog.tsx
+++ b/apps/dashboard/src/client/ui/components/create-agent-dialog.tsx
@@ -3,7 +3,6 @@ import { useMutation, useQuery } from "@tanstack/react-query";
 import { stringify, parse } from "yaml";
 import CodeMirror from "@uiw/react-codemirror";
 import { yaml as yamlLang } from "@codemirror/lang-yaml";
-import { indentationMarkers } from "@replit/codemirror-indentation-markers";
 
 import { cn } from "@hermeum/components/lib/utils";
 import { Button } from "@hermeum/components/ui/button";
@@ -155,7 +154,7 @@ export function CreateAgentDialog({ open, onOpenChange, onSuccess }: CreateAgent
             <p className="text-sm font-medium">Agent config</p>
             <CodeMirror
               value={editorValue}
-              extensions={[yamlLang(), indentationMarkers()]}
+              extensions={[yamlLang()]}
               onChange={setEditorValue}
               className={cn(
                 "overflow-hidden rounded-[0.25rem] border text-sm [&_.cm-content]:outline-none [&_.cm-editor.cm-focused]:outline-none [&_.cm-scroller]:font-sans!",
@@ -168,7 +167,7 @@ export function CreateAgentDialog({ open, onOpenChange, onSuccess }: CreateAgent
                 autocompletion: false,
                 lintKeymap: false,
               }}
-              height="360px"
+              maxHeight="360px"
             />
             {validationError && <p className="text-sm text-destructive">{validationError}</p>}
           </div>

--- a/apps/dashboard/src/client/ui/components/edit-agent-dialog.tsx
+++ b/apps/dashboard/src/client/ui/components/edit-agent-dialog.tsx
@@ -3,7 +3,6 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { stringify, parse } from "yaml";
 import CodeMirror from "@uiw/react-codemirror";
 import { yaml as yamlLang } from "@codemirror/lang-yaml";
-import { indentationMarkers } from "@replit/codemirror-indentation-markers";
 import { toast } from "sonner";
 import { useTRPC } from "@/router";
 import type { Agent } from "@/entities";
@@ -93,7 +92,7 @@ export function EditInstanceDialog({ instance, open, onOpenChange }: EditInstanc
         <div className="min-h-0 flex-1 overflow-y-auto space-y-2">
           <CodeMirror
             value={editorValue}
-            extensions={[yamlLang(), indentationMarkers()]}
+            extensions={[yamlLang()]}
             onChange={setEditorValue}
             className={cn(
               "overflow-hidden rounded-[0.25rem] border text-sm [&_.cm-content]:outline-none [&_.cm-editor.cm-focused]:outline-none [&_.cm-scroller]:font-sans!",
@@ -106,7 +105,7 @@ export function EditInstanceDialog({ instance, open, onOpenChange }: EditInstanc
               autocompletion: false,
               lintKeymap: false,
             }}
-            height="420px"
+            maxHeight="420px"
           />
           {validationError && <p className="text-sm text-destructive">{validationError}</p>}
         </div>

--- a/apps/dashboard/src/client/ui/components/edit-agent-dialog.tsx
+++ b/apps/dashboard/src/client/ui/components/edit-agent-dialog.tsx
@@ -96,7 +96,7 @@ export function EditInstanceDialog({ instance, open, onOpenChange }: EditInstanc
             extensions={[yamlLang(), indentationMarkers()]}
             onChange={setEditorValue}
             className={cn(
-              "overflow-hidden rounded-lg border text-sm [&_.cm-content]:outline-none [&_.cm-editor.cm-focused]:outline-none",
+              "overflow-hidden rounded-[0.25rem] border text-sm [&_.cm-content]:outline-none [&_.cm-editor.cm-focused]:outline-none [&_.cm-scroller]:font-sans!",
               validationError && "border-destructive"
             )}
             basicSetup={{

--- a/apps/dashboard/src/client/ui/routes/agents/$id.tsx
+++ b/apps/dashboard/src/client/ui/routes/agents/$id.tsx
@@ -31,7 +31,6 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@hermeum/components/ui/dropdown-menu";
-import { indentationMarkers } from "@replit/codemirror-indentation-markers";
 
 export const Route = createFileRoute("/agents/$id")({
   component: AgentDetailPage,
@@ -181,7 +180,7 @@ function AgentDetailPage() {
                 <p className="text-sm font-medium">Configuration</p>
                 <CodeMirror
                   value={stringifyYaml(agent.config)}
-                  extensions={[yamlLang(), indentationMarkers()]}
+                  extensions={[yamlLang()]}
                   editable={false}
                   maxHeight="300px"
                   basicSetup={{

--- a/apps/dashboard/src/client/ui/routes/agents/$id.tsx
+++ b/apps/dashboard/src/client/ui/routes/agents/$id.tsx
@@ -3,18 +3,12 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { Eye, EyeOff, MoreHorizontal } from "lucide-react";
 import CodeMirror from "@uiw/react-codemirror";
-import { json as jsonLang } from "@codemirror/lang-json";
+import { yaml as yamlLang } from "@codemirror/lang-yaml";
+import { stringify as stringifyYaml } from "yaml";
 import { toast } from "sonner";
 
 import { Badge } from "@hermeum/components/ui/badge";
-import { Card, CardContent, CardHeader, CardTitle } from "@hermeum/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@hermeum/components/ui/tabs";
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from "@hermeum/components/ui/accordion";
 import { authClient } from "@/client/auth-client";
 import { useTRPC } from "@/router";
 import { PhaseBadge } from "@/client/ui/components/phase-badge";
@@ -163,98 +157,68 @@ function AgentDetailPage() {
       </div>
 
       {/* Tabs */}
-      <Tabs defaultValue="config">
+      <Tabs defaultValue="agent">
         <TabsList>
-          <TabsTrigger value="config">Config</TabsTrigger>
+          <TabsTrigger value="agent">Agent</TabsTrigger>
           <TabsTrigger value="connect">Connect</TabsTrigger>
         </TabsList>
 
-        <TabsContent value="config" className="mt-4 flex flex-col gap-4">
-          {/* config */}
-          {agent.config && (
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-sm font-medium">Configuration</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <Accordion>
-                  <AccordionItem value="config">
-                    <AccordionTrigger className="font-mono text-xs">config.json</AccordionTrigger>
-                    <AccordionContent>
-                      <CodeMirror
-                        value={JSON.stringify(agent.config, null, 2)}
-                        extensions={[jsonLang(), indentationMarkers()]}
-                        editable={false}
-                        maxHeight="300px"
-                        basicSetup={{
-                          lineNumbers: true,
-                          foldGutter: true,
-                          searchKeymap: false,
-                          autocompletion: false,
-                          lintKeymap: false,
-                        }}
-                        className="overflow-hidden rounded-lg border text-sm [&_.cm-content]:outline-none [&_.cm-editor.cm-focused]:outline-none"
-                      />
-                    </AccordionContent>
-                  </AccordionItem>
-                </Accordion>
-              </CardContent>
-            </Card>
-          )}
+        <TabsContent value="agent" className="mt-4">
+          <div className="flex flex-col divide-y">
+            {/* soul */}
+            {agent.soul && (
+              <div className="py-6 flex flex-col gap-3">
+                <p className="text-sm font-medium">Soul</p>
+                <pre className="rounded bg-muted p-3 text-xs overflow-auto max-h-64">
+                  {agent.soul}
+                </pre>
+              </div>
+            )}
 
-          {/* soul */}
-          {agent.soul && (
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-sm font-medium">Soul</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <Accordion>
-                  <AccordionItem value="SOUL.md">
-                    <AccordionTrigger className="font-mono text-xs">SOUL.md</AccordionTrigger>
-                    <AccordionContent>
-                      <pre className="rounded bg-muted p-3 text-xs overflow-auto max-h-64">
-                        {agent.soul}
-                      </pre>
-                    </AccordionContent>
-                  </AccordionItem>
-                </Accordion>
-              </CardContent>
-            </Card>
-          )}
+            {/* config */}
+            {agent.config && (
+              <div className="py-6 flex flex-col gap-3">
+                <p className="text-sm font-medium">Configuration</p>
+                <CodeMirror
+                  value={stringifyYaml(agent.config)}
+                  extensions={[yamlLang(), indentationMarkers()]}
+                  editable={false}
+                  maxHeight="300px"
+                  basicSetup={{
+                    lineNumbers: true,
+                    foldGutter: true,
+                    searchKeymap: false,
+                    autocompletion: false,
+                    lintKeymap: false,
+                  }}
+                  className="overflow-hidden rounded-lg border text-sm [&_.cm-content]:outline-none [&_.cm-editor.cm-focused]:outline-none"
+                />
+              </div>
+            )}
 
-          {/* skills */}
-          {agent.skills && agent.skills.length > 0 && (
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-sm font-medium">Skills</CardTitle>
-              </CardHeader>
-              <CardContent>
+            {/* skills */}
+            {agent.skills && agent.skills.length > 0 && (
+              <div className="py-6 flex flex-col gap-3">
+                <p className="text-sm font-medium">Skills</p>
                 <BadgeList items={agent.skills} max={10} />
-              </CardContent>
-            </Card>
-          )}
+              </div>
+            )}
 
-          {/* plugins */}
-          {agent.plugins && agent.plugins.length > 0 && (
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-sm font-medium">Plugins</CardTitle>
-              </CardHeader>
-              <CardContent>
+            {/* plugins */}
+            {agent.plugins && agent.plugins.length > 0 && (
+              <div className="py-6 flex flex-col gap-3">
+                <p className="text-sm font-medium">Plugins</p>
                 <BadgeList items={agent.plugins} max={10} />
-              </CardContent>
-            </Card>
-          )}
+              </div>
+            )}
+          </div>
         </TabsContent>
 
-        <TabsContent value="connect" className="mt-4 flex flex-col gap-4">
-          {gatewayToken && (
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-sm font-medium">Gateway Token</CardTitle>
-              </CardHeader>
-              <CardContent>
+        <TabsContent value="connect" className="mt-4">
+          <div className="flex flex-col divide-y">
+            {gatewayToken && (
+              <div className="py-6 flex flex-col gap-3">
+                <p className="text-sm font-medium">Gateway Token</p>
                 <div className="group flex items-center gap-2">
                   <span className="font-mono text-sm text-muted-foreground">
                     {tokenVisible ? gatewayToken : "•".repeat(32)}
@@ -270,9 +234,9 @@ function AgentDetailPage() {
                   </Button>
                   <CopyButton text={gatewayToken} className="opacity-0 group-hover:opacity-100" />
                 </div>
-              </CardContent>
-            </Card>
-          )}
+              </div>
+            )}
+          </div>
         </TabsContent>
       </Tabs>
 

--- a/apps/dashboard/src/client/ui/routes/agents/$id.tsx
+++ b/apps/dashboard/src/client/ui/routes/agents/$id.tsx
@@ -191,7 +191,7 @@ function AgentDetailPage() {
                     autocompletion: false,
                     lintKeymap: false,
                   }}
-                  className="overflow-hidden rounded-lg border text-sm [&_.cm-content]:outline-none [&_.cm-editor.cm-focused]:outline-none"
+                  className="overflow-hidden rounded-[0.25rem] border text-sm [&_.cm-content]:outline-none [&_.cm-editor.cm-focused]:outline-none [&_.cm-scroller]:font-sans!"
                 />
               </div>
             )}

--- a/apps/dashboard/src/entities/agent.ts
+++ b/apps/dashboard/src/entities/agent.ts
@@ -56,11 +56,11 @@ export const AgentInputSchema = z.object({
   description: z.string().optional(),
   type: z.string().optional(),
   version: z.string().optional(),
-  config: ConfigSchema,
-  secrets: z.array(z.string()).optional(),
   soul: z.string().optional(),
+  config: ConfigSchema,
   skills: SkillsSchema,
   plugins: PluginsSchema,
+  secrets: z.array(z.string()).optional(),
 });
 
 export type AgentInput = z.infer<typeof AgentInputSchema>;


### PR DESCRIPTION
## Summary
- Redesign the agent detail page (`$id.tsx`): rename the "Config" tab to "Agent", replace card-wrapped sections with a flat divide-y layout, and show soul, config, skills, and plugins in order.
- Render agent config as YAML (previously JSON) across the detail page and create/edit dialogs.
- Style CodeMirror editors to match the app's font (Inter Variable) and design-system border radius (0.25rem), and remove the vertical indentation guide lines.
- Switch create/edit dialog editors from a fixed height to maxHeight so they size to content.
- Reorder `AgentInputSchema` fields (soul before config, secrets last) to match the new page layout.

## Test plan
- [x] Verified agent detail page: Agent tab shows Soul → Configuration → Skills → Plugins with flat divide-y sections, no cards.
- [x] Verified Configuration renders as YAML with syntax highlighting.
- [x] Verified create-agent and edit-agent dialogs render YAML with the app font, 0.25rem radius, no vertical guide lines, and content-sized height.
- [x] Verified field order in generated YAML matches soul → config → skills → plugins → secrets.