### PR TITLE
refactor: consolidate annotations and filter `archived` secrets server-side

### DIFF
--- a/apps/dashboard/src/client/ui/routes/secrets/index.tsx
+++ b/apps/dashboard/src/client/ui/routes/secrets/index.tsx
@@ -72,8 +72,10 @@ function SecretsPage() {
   const [tab, setTab] = useState<"all" | "active">("all");
   const navigate = useNavigate();
 
-  const { data: secrets, isPending, error } = useQuery(trpc.secret.list.queryOptions());
-  const visibleSecrets = tab === "active" ? secrets?.filter((s) => !s.archived) : secrets;
+  const { data: secrets, isPending, error } = useQuery(
+    trpc.secret.list.queryOptions(tab === "active" ? { archived: false } : undefined)
+  );
+  const visibleSecrets = secrets;
 
   const { mutate: archiveSecret, isPending: isArchiving } = useMutation(
     trpc.secret.archive.mutationOptions({

--- a/apps/dashboard/src/server/infras/kubernetes/client.ts
+++ b/apps/dashboard/src/server/infras/kubernetes/client.ts
@@ -5,6 +5,7 @@ import { config } from "@/server/libs/config";
 import {
   CreateAgentInput,
   CreateSecretInput,
+  ListSecretParams,
   PatchAgentInput,
   Runtime,
   SecretPatch,
@@ -29,6 +30,7 @@ const enum HermeumLabel {
   // https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels
   ManagedBy = "app.kubernetes.io/managed-by",
   UserId = "hermeum.app/user-id",
+  Archived = "hermeum.app/archived",
 }
 const enum HermeumLabelValue {
   ManagedBy = "hermeum",
@@ -37,7 +39,6 @@ const enum HermeumAnnotation {
   Name = "hermeum.app/name",
   Description = "hermeum.app/description",
   Type = "hermeum.app/type",
-  Archived = "hermeum.app/archived",
 }
 
 export function agentToHermesAgent(agent: Agent): HermesAgent {
@@ -127,14 +128,12 @@ export function secretToKubernetesSecret(
       labels: {
         [HermeumLabel.ManagedBy]: HermeumLabelValue.ManagedBy,
         [HermeumLabel.UserId]: secret.userId,
+        [HermeumLabel.Archived]: String(secret.archived ?? false),
       },
       annotations: {
         [HermeumAnnotation.Name]: secret.name,
         ...(secret.description !== undefined && {
           [HermeumAnnotation.Description]: secret.description,
-        }),
-        ...(secret.archived !== undefined && {
-          [HermeumAnnotation.Archived]: String(secret.archived),
         }),
       },
     },
@@ -158,7 +157,7 @@ function mapKubernetesSecret(raw: k8s.V1Secret): Secret {
     name: raw.metadata?.annotations?.[HermeumAnnotation.Name] ?? "",
     description: raw.metadata?.annotations?.[HermeumAnnotation.Description],
     envVars,
-    archived: raw.metadata?.annotations?.[HermeumAnnotation.Archived] === "true",
+    archived: raw.metadata?.labels?.[HermeumLabel.Archived] === "true",
     createdAt: raw.metadata?.creationTimestamp,
   };
 }
@@ -257,10 +256,14 @@ export class KubernetesClient implements Runtime {
     });
   }
 
-  async listSecrets(): Promise<Secret[]> {
+  async listSecrets(params?: ListSecretParams): Promise<Secret[]> {
+    const selector = [`${HermeumLabel.ManagedBy}=${HermeumLabelValue.ManagedBy}`];
+    if (params?.archived !== undefined) {
+      selector.push(`${HermeumLabel.Archived}=${String(params.archived)}`);
+    }
     const body = await this.coreV1Api.listNamespacedSecret({
       namespace: config.kubernetesNamespace,
-      labelSelector: `${HermeumLabel.ManagedBy}=${HermeumLabelValue.ManagedBy}`,
+      labelSelector: selector.join(","),
     });
     return (body.items ?? []).map(mapKubernetesSecret);
   }

--- a/apps/dashboard/src/server/infras/kubernetes/client.ts
+++ b/apps/dashboard/src/server/infras/kubernetes/client.ts
@@ -34,12 +34,10 @@ const enum HermeumLabelValue {
   ManagedBy = "hermeum",
 }
 const enum HermeumAnnotation {
-  Name = "hermeum.app/agent-name",
-  Description = "hermeum.app/agent-description",
-  AgentType = "hermeum.app/agent-type",
-  SecretName = "hermeum.app/secret-name",
-  SecretDescription = "hermeum.app/secret-description",
-  SecretArchived = "hermeum.app/secret-archived",
+  Name = "hermeum.app/name",
+  Description = "hermeum.app/description",
+  Type = "hermeum.app/type",
+  Archived = "hermeum.app/archived",
 }
 
 export function agentToHermesAgent(agent: Agent): HermesAgent {
@@ -56,7 +54,7 @@ export function agentToHermesAgent(agent: Agent): HermesAgent {
     annotations[HermeumAnnotation.Description] = agent.description;
   }
   if (agent.type !== undefined) {
-    annotations[HermeumAnnotation.AgentType] = agent.type;
+    annotations[HermeumAnnotation.Type] = agent.type;
   }
 
   const hermes: Partial<HermesAgentSpec["hermes"]> = {};
@@ -101,7 +99,7 @@ export function mapHermesAgent(raw: HermesAgent): Agent {
     userId: raw.metadata?.labels?.[HermeumLabel.UserId] ?? "",
     name: raw.metadata?.annotations?.[HermeumAnnotation.Name],
     description: raw.metadata?.annotations?.[HermeumAnnotation.Description],
-    type: raw.metadata?.annotations?.[HermeumAnnotation.AgentType],
+    type: raw.metadata?.annotations?.[HermeumAnnotation.Type],
     config: raw.spec.hermes?.config?.raw,
     secrets: raw.spec.hermes?.envFrom?.flatMap((e) =>
       e.secretRef?.name ? [e.secretRef.name] : []
@@ -131,12 +129,12 @@ export function secretToKubernetesSecret(
         [HermeumLabel.UserId]: secret.userId,
       },
       annotations: {
-        [HermeumAnnotation.SecretName]: secret.name,
+        [HermeumAnnotation.Name]: secret.name,
         ...(secret.description !== undefined && {
-          [HermeumAnnotation.SecretDescription]: secret.description,
+          [HermeumAnnotation.Description]: secret.description,
         }),
         ...(secret.archived !== undefined && {
-          [HermeumAnnotation.SecretArchived]: String(secret.archived),
+          [HermeumAnnotation.Archived]: String(secret.archived),
         }),
       },
     },
@@ -157,10 +155,10 @@ function mapKubernetesSecret(raw: k8s.V1Secret): Secret {
   return {
     id: raw.metadata?.name ?? "",
     userId: raw.metadata?.labels?.[HermeumLabel.UserId] ?? "",
-    name: raw.metadata?.annotations?.[HermeumAnnotation.SecretName] ?? "",
-    description: raw.metadata?.annotations?.[HermeumAnnotation.SecretDescription],
+    name: raw.metadata?.annotations?.[HermeumAnnotation.Name] ?? "",
+    description: raw.metadata?.annotations?.[HermeumAnnotation.Description],
     envVars,
-    archived: raw.metadata?.annotations?.[HermeumAnnotation.SecretArchived] === "true",
+    archived: raw.metadata?.annotations?.[HermeumAnnotation.Archived] === "true",
     createdAt: raw.metadata?.creationTimestamp,
   };
 }

--- a/apps/dashboard/src/server/infras/kubernetes/client.ts
+++ b/apps/dashboard/src/server/infras/kubernetes/client.ts
@@ -5,7 +5,7 @@ import { config } from "@/server/libs/config";
 import {
   CreateAgentInput,
   CreateSecretInput,
-  ListSecretParams,
+  ListSecretsFilter,
   PatchAgentInput,
   Runtime,
   SecretPatch,
@@ -256,7 +256,7 @@ export class KubernetesClient implements Runtime {
     });
   }
 
-  async listSecrets(params?: ListSecretParams): Promise<Secret[]> {
+  async listSecrets(params?: ListSecretsFilter): Promise<Secret[]> {
     const selector = [`${HermeumLabel.ManagedBy}=${HermeumLabelValue.ManagedBy}`];
     if (params?.archived !== undefined) {
       selector.push(`${HermeumLabel.Archived}=${String(params.archived)}`);

--- a/apps/dashboard/src/server/routers/trpc/secret.ts
+++ b/apps/dashboard/src/server/routers/trpc/secret.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { EnvVarSchema, Secret } from "@/entities";
 import {
   CreateSecretInputSchema,
+  ListSecretsInputSchema,
   SecretUseCase,
   UpdateSecretInputSchema,
 } from "@/server/usecases/secret";
@@ -11,9 +12,11 @@ import { protectedProcedure, t } from "./shared.js";
 const usecase = new SecretUseCase();
 
 export const secretRouter = t.router({
-  list: protectedProcedure.query(async ({ ctx }): Promise<Secret[]> => {
-    return usecase.listSecrets(ctx);
-  }),
+  list: protectedProcedure
+    .input(ListSecretsInputSchema.optional())
+    .query(async ({ ctx, input }): Promise<Secret[]> => {
+      return usecase.listSecrets(ctx, input);
+    }),
 
   get: protectedProcedure
     .input(z.object({ id: z.string().min(1) }))

--- a/apps/dashboard/src/server/routers/trpc/secret.ts
+++ b/apps/dashboard/src/server/routers/trpc/secret.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { EnvVarSchema, Secret } from "@/entities";
 import {
   CreateSecretInputSchema,
-  ListSecretsInputSchema,
+  ListSecretsFilterSchema,
   SecretUseCase,
   UpdateSecretInputSchema,
 } from "@/server/usecases/secret";
@@ -13,7 +13,7 @@ const usecase = new SecretUseCase();
 
 export const secretRouter = t.router({
   list: protectedProcedure
-    .input(ListSecretsInputSchema.optional())
+    .input(ListSecretsFilterSchema.optional())
     .query(async ({ ctx, input }): Promise<Secret[]> => {
       return usecase.listSecrets(ctx, input);
     }),

--- a/apps/dashboard/src/server/usecases/adaptors/runtime.ts
+++ b/apps/dashboard/src/server/usecases/adaptors/runtime.ts
@@ -8,6 +8,7 @@ export type PatchAgentInput = {
 
 export type CreateSecretInput = Pick<Secret, "userId" | "name" | "description">;
 export type SecretPatch = Partial<Pick<Secret, "name" | "description" | "archived">>;
+export type ListSecretParams = { archived?: boolean | undefined };
 
 export interface Runtime {
   listHermesAgents: () => Promise<Agent[]>;
@@ -18,7 +19,7 @@ export interface Runtime {
 
   getGatewayToken: (agentId: string) => Promise<string | null>;
 
-  listSecrets: () => Promise<Secret[]>;
+  listSecrets: (params?: ListSecretParams) => Promise<Secret[]>;
   getSecret: (id: string) => Promise<Secret | null>;
   createSecret: (input: CreateSecretInput) => Promise<Secret>;
   archiveSecret: (id: string) => Promise<Secret>;

--- a/apps/dashboard/src/server/usecases/adaptors/runtime.ts
+++ b/apps/dashboard/src/server/usecases/adaptors/runtime.ts
@@ -8,7 +8,7 @@ export type PatchAgentInput = {
 
 export type CreateSecretInput = Pick<Secret, "userId" | "name" | "description">;
 export type SecretPatch = Partial<Pick<Secret, "name" | "description" | "archived">>;
-export type ListSecretParams = { archived?: boolean | undefined };
+export type ListSecretsFilter = { archived?: boolean | undefined };
 
 export interface Runtime {
   listHermesAgents: () => Promise<Agent[]>;
@@ -19,7 +19,7 @@ export interface Runtime {
 
   getGatewayToken: (agentId: string) => Promise<string | null>;
 
-  listSecrets: (params?: ListSecretParams) => Promise<Secret[]>;
+  listSecrets: (params?: ListSecretsFilter) => Promise<Secret[]>;
   getSecret: (id: string) => Promise<Secret | null>;
   createSecret: (input: CreateSecretInput) => Promise<Secret>;
   archiveSecret: (id: string) => Promise<Secret>;

--- a/apps/dashboard/src/server/usecases/secret.ts
+++ b/apps/dashboard/src/server/usecases/secret.ts
@@ -10,6 +10,11 @@ export const CreateSecretInputSchema = z.object({
 });
 export type CreateSecretInput = z.infer<typeof CreateSecretInputSchema>;
 
+export const ListSecretsInputSchema = z.object({
+  archived: z.boolean().optional(),
+});
+export type ListSecretsInput = z.infer<typeof ListSecretsInputSchema>;
+
 export const UpdateSecretInputSchema = z.object({
   name: z.string().min(1).optional(),
   description: z.string().optional(),
@@ -19,8 +24,8 @@ export type UpdateSecretInput = z.infer<typeof UpdateSecretInputSchema>;
 export class SecretUseCase {
   constructor(private readonly runtime: Runtime = new KubernetesClient()) {}
 
-  async listSecrets(ctx: Context): Promise<Secret[]> {
-    return this.runtime.listSecrets();
+  async listSecrets(ctx: Context, input?: ListSecretsInput): Promise<Secret[]> {
+    return this.runtime.listSecrets(input);
   }
 
   async getSecret(ctx: Context, id: string): Promise<Secret | null> {

--- a/apps/dashboard/src/server/usecases/secret.ts
+++ b/apps/dashboard/src/server/usecases/secret.ts
@@ -10,10 +10,10 @@ export const CreateSecretInputSchema = z.object({
 });
 export type CreateSecretInput = z.infer<typeof CreateSecretInputSchema>;
 
-export const ListSecretsInputSchema = z.object({
+export const ListSecretsFilterSchema = z.object({
   archived: z.boolean().optional(),
 });
-export type ListSecretsInput = z.infer<typeof ListSecretsInputSchema>;
+export type ListSecretsInput = z.infer<typeof ListSecretsFilterSchema>;
 
 export const UpdateSecretInputSchema = z.object({
   name: z.string().min(1).optional(),


### PR DESCRIPTION
## Summary
- Consolidated per-resource-type `hermeum.app/*` annotations (`agent-name`/`secret-name`, `agent-description`/`secret-description`, `agent-type`, `secret-archived`) into a single generic set (`hermeum.app/name`, `hermeum.app/description`, `hermeum.app/type`, `hermeum.app/archived`) in the Kubernetes client, since these values never coexist on the same resource and the resource kind already disambiguates them.
- Moved `archived` from an annotation to a label (`hermeum.app/archived`) so secret listing can filter server-side via a Kubernetes `labelSelector` instead of fetching every secret and filtering client-side.
- Threaded an optional `archived` filter end-to-end: `KubernetesClient.listSecrets` → `Runtime` interface (`ListSecretsFilter`) → `SecretUseCase.listSecrets` (`ListSecretsFilterSchema`) → the `secret.list` tRPC procedure → the Secrets page, where the "Active" tab now queries the server instead of filtering an unfiltered result client-side.

## Notes for reviewers
- Secrets/Agents already provisioned in a cluster before this change carry the old annotation keys (or `archived` as an annotation rather than a label). Reading those existing resources will show `name`/`description`/`type`/`archived` as unset/`false` until they're recreated or patched through this code path, which rewrites them with the new keys.
- `secretToKubernetesSecret()` now always sets the `hermeum.app/archived` label (defaulting to `false` when unset) rather than conditionally, since `createSecret` never passes `archived` and the label needs to be present on every secret for the `archived=false`/`archived=true` selector to match consistently.

## Test plan
- [x] `pnpm exec tsc --noEmit` (apps/dashboard) — passes
- [x] `pnpm lint` — no new errors (same pre-existing baseline as main)
- [x] `pnpm format:check` — no new formatting issues (same pre-existing baseline as main)
- [ ] Manual verification against a live cluster (not performed — would require creating/mutating cluster state, which was out of scope for this session)