### PR TITLE
Extract shared CodeEditor with wider YAML indent

### DIFF
--- a/apps/dashboard/src/client/ui/components/code-editor.tsx
+++ b/apps/dashboard/src/client/ui/components/code-editor.tsx
@@ -1,0 +1,41 @@
+import CodeMirror from "@uiw/react-codemirror";
+import { yaml as yamlLang } from "@codemirror/lang-yaml";
+import { cn } from "@hermeum/components/lib/utils";
+
+interface CodeEditorProps {
+  value: string;
+  onChange?: (value: string) => void;
+  readOnly?: boolean;
+  invalid?: boolean;
+  maxHeight?: string;
+}
+
+export function CodeEditor({
+  value,
+  onChange,
+  readOnly = false,
+  invalid = false,
+  maxHeight,
+}: CodeEditorProps) {
+  return (
+    <CodeMirror
+      value={value}
+      extensions={[yamlLang()]}
+      {...(onChange !== undefined && { onChange })}
+      editable={!readOnly}
+      {...(maxHeight !== undefined && { maxHeight })}
+      style={{ wordSpacing: "2.5px" }}
+      basicSetup={{
+        lineNumbers: false,
+        foldGutter: readOnly,
+        searchKeymap: false,
+        autocompletion: false,
+        lintKeymap: false,
+      }}
+      className={cn(
+        "overflow-hidden rounded-[0.25rem] border text-sm [&_.cm-content]:outline-none [&_.cm-editor.cm-focused]:outline-none [&_.cm-scroller]:font-sans!",
+        invalid && "border-destructive"
+      )}
+    />
+  );
+}

--- a/apps/dashboard/src/client/ui/components/create-agent-dialog.tsx
+++ b/apps/dashboard/src/client/ui/components/create-agent-dialog.tsx
@@ -1,8 +1,6 @@
 import { useState, useEffect } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { stringify, parse } from "yaml";
-import CodeMirror from "@uiw/react-codemirror";
-import { yaml as yamlLang } from "@codemirror/lang-yaml";
 
 import { cn } from "@hermeum/components/lib/utils";
 import { Button } from "@hermeum/components/ui/button";
@@ -21,6 +19,7 @@ import { toast } from "sonner";
 import { useTRPC } from "@/router";
 import type { Template, AgentInput } from "@/entities";
 import { AgentInputSchema } from "@/entities";
+import { CodeEditor } from "@/client/ui/components/code-editor";
 
 const DEFAULT_YAML = stringify({
   name: "Untitled agent",
@@ -152,21 +151,10 @@ export function CreateAgentDialog({ open, onOpenChange, onSuccess }: CreateAgent
           {/* Agent config section */}
           <div className="space-y-2">
             <p className="text-sm font-medium">Agent config</p>
-            <CodeMirror
+            <CodeEditor
               value={editorValue}
-              extensions={[yamlLang()]}
               onChange={setEditorValue}
-              className={cn(
-                "overflow-hidden rounded-[0.25rem] border text-sm [&_.cm-content]:outline-none [&_.cm-editor.cm-focused]:outline-none [&_.cm-scroller]:font-sans!",
-                validationError && "border-destructive"
-              )}
-              basicSetup={{
-                lineNumbers: false,
-                foldGutter: false,
-                searchKeymap: false,
-                autocompletion: false,
-                lintKeymap: false,
-              }}
+              invalid={!!validationError}
               maxHeight="360px"
             />
             {validationError && <p className="text-sm text-destructive">{validationError}</p>}

--- a/apps/dashboard/src/client/ui/components/edit-agent-dialog.tsx
+++ b/apps/dashboard/src/client/ui/components/edit-agent-dialog.tsx
@@ -1,13 +1,11 @@
 import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { stringify, parse } from "yaml";
-import CodeMirror from "@uiw/react-codemirror";
-import { yaml as yamlLang } from "@codemirror/lang-yaml";
 import { toast } from "sonner";
 import { useTRPC } from "@/router";
 import type { Agent } from "@/entities";
 import { AgentInputSchema } from "@/entities";
-import { cn } from "@hermeum/components/lib/utils";
+import { CodeEditor } from "@/client/ui/components/code-editor";
 import { Button } from "@hermeum/components/ui/button";
 import {
   Dialog,
@@ -90,21 +88,10 @@ export function EditInstanceDialog({ instance, open, onOpenChange }: EditInstanc
         </DialogHeader>
 
         <div className="min-h-0 flex-1 overflow-y-auto space-y-2">
-          <CodeMirror
+          <CodeEditor
             value={editorValue}
-            extensions={[yamlLang()]}
             onChange={setEditorValue}
-            className={cn(
-              "overflow-hidden rounded-[0.25rem] border text-sm [&_.cm-content]:outline-none [&_.cm-editor.cm-focused]:outline-none [&_.cm-scroller]:font-sans!",
-              validationError && "border-destructive"
-            )}
-            basicSetup={{
-              lineNumbers: false,
-              foldGutter: false,
-              searchKeymap: false,
-              autocompletion: false,
-              lintKeymap: false,
-            }}
+            invalid={!!validationError}
             maxHeight="420px"
           />
           {validationError && <p className="text-sm text-destructive">{validationError}</p>}

--- a/apps/dashboard/src/client/ui/routes/agents/$id.tsx
+++ b/apps/dashboard/src/client/ui/routes/agents/$id.tsx
@@ -2,8 +2,6 @@ import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { Eye, EyeOff, MoreHorizontal } from "lucide-react";
-import CodeMirror from "@uiw/react-codemirror";
-import { yaml as yamlLang } from "@codemirror/lang-yaml";
 import { stringify as stringifyYaml } from "yaml";
 import { toast } from "sonner";
 
@@ -14,6 +12,7 @@ import { useTRPC } from "@/router";
 import { PhaseBadge } from "@/client/ui/components/phase-badge";
 import { Button } from "@hermeum/components/ui/button";
 import { EditInstanceDialog } from "@/client/ui/components/edit-agent-dialog";
+import { CodeEditor } from "@/client/ui/components/code-editor";
 import { CopyButton } from "@/client/ui/components/copy-button";
 import {
   Dialog,
@@ -178,20 +177,7 @@ function AgentDetailPage() {
             {agent.config && (
               <div className="py-6 flex flex-col gap-3">
                 <p className="text-sm font-medium">Configuration</p>
-                <CodeMirror
-                  value={stringifyYaml(agent.config)}
-                  extensions={[yamlLang()]}
-                  editable={false}
-                  maxHeight="300px"
-                  basicSetup={{
-                    lineNumbers: true,
-                    foldGutter: true,
-                    searchKeymap: false,
-                    autocompletion: false,
-                    lintKeymap: false,
-                  }}
-                  className="overflow-hidden rounded-[0.25rem] border text-sm [&_.cm-content]:outline-none [&_.cm-editor.cm-focused]:outline-none [&_.cm-scroller]:font-sans!"
-                />
+                <CodeEditor value={stringifyYaml(agent.config)} readOnly maxHeight="300px" />
               </div>
             )}
 
@@ -254,11 +240,7 @@ function AgentDetailPage() {
           </DialogHeader>
           <DialogFooter>
             <DialogClose render={<Button variant="outline" />}>Cancel</DialogClose>
-            <Button
-              variant="destructive"
-              disabled={isDeleting}
-              onClick={() => deleteAgent({ id })}
-            >
+            <Button variant="destructive" disabled={isDeleting} onClick={() => deleteAgent({ id })}>
               Delete
             </Button>
           </DialogFooter>


### PR DESCRIPTION
## Summary
- Extracts the three duplicated `@uiw/react-codemirror` instances (Edit agent dialog, Create agent dialog, agent detail Configuration viewer) into a single `CodeEditor` component (`apps/dashboard/src/client/ui/components/code-editor.tsx`)
- Widens YAML indentation readability via `word-spacing: 2.5px` on the editor content
- Removes the numeric line-number gutter from the read-only Configuration viewer, keeping only the fold arrow

## Test plan
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm format:check`
- [x] Verified in browser preview: Edit agent dialog, Create agent dialog, and agent detail Configuration viewer all render with wider indentation and no gutter/typing regressions