### PR TITLE
feat: replace agent delete with archive (permanent suspend)

### DIFF
--- a/apps/dashboard/src/client/ui/routes/agents/$id.tsx
+++ b/apps/dashboard/src/client/ui/routes/agents/$id.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router";
 import { Eye, EyeOff, MoreHorizontal } from "lucide-react";
 import { stringify as stringifyYaml } from "yaml";
 import { toast } from "sonner";
@@ -60,7 +60,6 @@ function AgentDetailPage() {
   const { id } = Route.useParams();
   const trpc = useTRPC();
   const queryClient = useQueryClient();
-  const navigate = useNavigate();
   const { data: agent, isPending, error } = useQuery(trpc.agent.get.queryOptions({ id }));
   const { data: session } = authClient.useSession();
   const isOwner = !!session?.user && session.user.id === agent?.userId;
@@ -69,7 +68,7 @@ function AgentDetailPage() {
     enabled: isOwner,
   });
   const [editOpen, setEditOpen] = useState(false);
-  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [archiveOpen, setArchiveOpen] = useState(false);
   const [tokenVisible, setTokenVisible] = useState(false);
 
   const invalidateDetail = () =>
@@ -93,11 +92,12 @@ function AgentDetailPage() {
       onError: (e) => toast.error(e.message),
     })
   );
-  const { mutate: deleteAgent, isPending: isDeleting } = useMutation(
-    trpc.agent.delete.mutationOptions({
+  const { mutate: archiveAgent, isPending: isArchiving } = useMutation(
+    trpc.agent.archive.mutationOptions({
       onSuccess: () => {
-        toast.success("Agent deleted");
-        navigate({ to: "/agents" });
+        toast.success("Agent archived");
+        setArchiveOpen(false);
+        setTimeout(invalidateDetail, 500);
       },
       onError: (e) => toast.error(e.message),
     })
@@ -114,7 +114,11 @@ function AgentDetailPage() {
         <div className="flex flex-col gap-1">
           <div className="flex items-center gap-3">
             <h1 className="text-2xl font-bold">{agent.name ?? agent.id}</h1>
-            <PhaseBadge phase={agent.phase} />
+            {agent.archived ? (
+              <Badge variant="secondary">Archived</Badge>
+            ) : (
+              <PhaseBadge phase={agent.phase} />
+            )}
           </div>
           <div className="group flex items-center gap-1">
             <p className="text-sm text-muted-foreground font-mono">{agent.id}</p>
@@ -133,24 +137,26 @@ function AgentDetailPage() {
           <Button variant="outline" onClick={() => setEditOpen(true)}>
             Edit
           </Button>
-          <DropdownMenu>
-            <DropdownMenuTrigger
-              render={<Button variant="outline" size="icon" aria-label="Open actions menu" />}
-            >
-              <MoreHorizontal className="size-4" />
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              {agent.suspended ? (
-                <DropdownMenuItem onClick={() => resumeAgent({ id })}>Resume</DropdownMenuItem>
-              ) : (
-                <DropdownMenuItem onClick={() => suspendAgent({ id })}>Pause</DropdownMenuItem>
-              )}
-              <DropdownMenuSeparator />
-              <DropdownMenuItem variant="destructive" onClick={() => setDeleteOpen(true)}>
-                Delete
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+          {!agent.archived && (
+            <DropdownMenu>
+              <DropdownMenuTrigger
+                render={<Button variant="outline" size="icon" aria-label="Open actions menu" />}
+              >
+                <MoreHorizontal className="size-4" />
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                {agent.suspended ? (
+                  <DropdownMenuItem onClick={() => resumeAgent({ id })}>Resume</DropdownMenuItem>
+                ) : (
+                  <DropdownMenuItem onClick={() => suspendAgent({ id })}>Pause</DropdownMenuItem>
+                )}
+                <DropdownMenuSeparator />
+                <DropdownMenuItem variant="destructive" onClick={() => setArchiveOpen(true)}>
+                  Archive
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
         </div>
       </div>
 
@@ -226,22 +232,27 @@ function AgentDetailPage() {
       </Tabs>
 
       <Dialog
-        open={deleteOpen}
+        open={archiveOpen}
         onOpenChange={(open) => {
-          if (!open) setDeleteOpen(false);
+          if (!open) setArchiveOpen(false);
         }}
       >
         <DialogContent showCloseButton={false}>
           <DialogHeader>
-            <DialogTitle>Delete agent</DialogTitle>
+            <DialogTitle>Archive agent</DialogTitle>
             <DialogDescription>
-              Are you sure you want to delete this agent? This action cannot be undone.
+              The agent will be permanently suspended and cannot be resumed. This action cannot be
+              undone.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
             <DialogClose render={<Button variant="outline" />}>Cancel</DialogClose>
-            <Button variant="destructive" disabled={isDeleting} onClick={() => deleteAgent({ id })}>
-              Delete
+            <Button
+              variant="destructive"
+              disabled={isArchiving}
+              onClick={() => archiveAgent({ id })}
+            >
+              Archive
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/apps/dashboard/src/client/ui/routes/agents/index.tsx
+++ b/apps/dashboard/src/client/ui/routes/agents/index.tsx
@@ -8,7 +8,9 @@ import { useTRPC } from "@/router";
 import { CreateAgentDialog } from "@/client/ui/components/create-agent-dialog";
 import { CopyButton } from "@/client/ui/components/copy-button";
 import { PhaseBadge } from "@/client/ui/components/phase-badge";
+import { Badge } from "@hermeum/components/ui/badge";
 import { Button } from "@hermeum/components/ui/button";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@hermeum/components/ui/tabs";
 import {
   Dialog,
   DialogClose,
@@ -42,7 +44,8 @@ function DashboardPage() {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
   const [dialogOpen, setDialogOpen] = useState(false);
-  const [deleteId, setDeleteId] = useState<string | null>(null);
+  const [archiveId, setArchiveId] = useState<string | null>(null);
+  const [tab, setTab] = useState<"all" | "active">("all");
   const navigate = useNavigate();
 
   const {
@@ -50,7 +53,7 @@ function DashboardPage() {
     isPending,
     isFetching,
     error,
-  } = useQuery(trpc.agent.list.queryOptions());
+  } = useQuery(trpc.agent.list.queryOptions(tab === "active" ? { archived: false } : undefined));
 
   const invalidateList = () =>
     queryClient.invalidateQueries({ queryKey: trpc.agent.list.queryKey() });
@@ -75,12 +78,12 @@ function DashboardPage() {
     })
   );
 
-  const { mutate: deleteAgent, isPending: isDeleting } = useMutation(
-    trpc.agent.delete.mutationOptions({
+  const { mutate: archiveAgent, isPending: isArchiving } = useMutation(
+    trpc.agent.archive.mutationOptions({
       onSuccess: () => {
-        toast.success("Agent deleted");
+        toast.success("Agent archived");
         invalidateList();
-        setDeleteId(null);
+        setArchiveId(null);
       },
       onError: (e) => toast.error(e.message),
     })
@@ -124,104 +127,121 @@ function DashboardPage() {
       />
 
       <Dialog
-        open={deleteId !== null}
+        open={archiveId !== null}
         onOpenChange={(open) => {
-          if (!open) setDeleteId(null);
+          if (!open) setArchiveId(null);
         }}
       >
         <DialogContent showCloseButton={false}>
           <DialogHeader>
-            <DialogTitle>Delete agent</DialogTitle>
+            <DialogTitle>Archive agent</DialogTitle>
             <DialogDescription>
-              Are you sure you want to delete this agent? This action cannot be undone.
+              The agent will be permanently suspended and cannot be resumed. This action cannot be
+              undone.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
             <DialogClose render={<Button variant="outline" />}>Cancel</DialogClose>
             <Button
               variant="destructive"
-              disabled={isDeleting}
+              disabled={isArchiving}
               onClick={() => {
-                if (deleteId) deleteAgent({ id: deleteId });
+                if (archiveId) archiveAgent({ id: archiveId });
               }}
             >
-              Delete
+              Archive
             </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
 
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>ID</TableHead>
-            <TableHead>Name</TableHead>
-            <TableHead>Status</TableHead>
-            <TableHead>Created</TableHead>
-            <TableHead />
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {agents?.length === 0 ? (
-            <TableRow>
-              <TableCell colSpan={5} className="text-center text-muted-foreground">
-                No agents yet.
-              </TableCell>
-            </TableRow>
-          ) : (
-            agents?.map((agent) => (
-              <TableRow
-                key={agent.id}
-                className="cursor-pointer"
-                onClick={() => navigate({ to: "/agents/$id", params: { id: agent.id } })}
-              >
-                <TableCell className="max-w-32 font-mono text-xs">
-                  <div className="group flex items-center gap-1 min-w-0">
-                    <span className="truncate">{agent.id}</span>
-                    <CopyButton text={agent.id} className="opacity-0 group-hover:opacity-100" />
-                  </div>
-                </TableCell>
-                <TableCell className="font-medium">{agent.name ?? "-"}</TableCell>
-                <TableCell>
-                  <PhaseBadge phase={agent.phase} />
-                </TableCell>
-                <TableCell className="text-sm text-muted-foreground">
-                  {agent.createdAt
-                    ? formatDistanceToNow(agent.createdAt, { addSuffix: true })
-                    : "—"}
-                </TableCell>
-                <TableCell className="w-10" onClick={(e) => e.stopPropagation()}>
-                  <DropdownMenu>
-                    <DropdownMenuTrigger
-                      render={<Button variant="ghost" size="icon" aria-label="Open actions menu" />}
-                    >
-                      <MoreHorizontal className="size-4" />
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                      {agent.suspended ? (
-                        <DropdownMenuItem onClick={() => resumeAgent({ id: agent.id })}>
-                          Resume
-                        </DropdownMenuItem>
-                      ) : (
-                        <DropdownMenuItem onClick={() => suspendAgent({ id: agent.id })}>
-                          Pause
-                        </DropdownMenuItem>
-                      )}
-                      <DropdownMenuSeparator />
-                      <DropdownMenuItem
-                        variant="destructive"
-                        onClick={() => setDeleteId(agent.id)}
-                      >
-                        Delete
-                      </DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </TableCell>
+      <Tabs value={tab} onValueChange={(v) => setTab(v as "all" | "active")}>
+        <TabsList>
+          <TabsTrigger value="all">All</TabsTrigger>
+          <TabsTrigger value="active">Active</TabsTrigger>
+        </TabsList>
+        <TabsContent value={tab}>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>ID</TableHead>
+                <TableHead>Name</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Created</TableHead>
+                <TableHead />
               </TableRow>
-            ))
-          )}
-        </TableBody>
-      </Table>
+            </TableHeader>
+            <TableBody>
+              {agents?.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={5} className="text-center text-muted-foreground">
+                    No agents yet.
+                  </TableCell>
+                </TableRow>
+              ) : (
+                agents?.map((agent) => (
+                  <TableRow
+                    key={agent.id}
+                    className="cursor-pointer"
+                    onClick={() => navigate({ to: "/agents/$id", params: { id: agent.id } })}
+                  >
+                    <TableCell className="max-w-32 font-mono text-xs">
+                      <div className="group flex items-center gap-1 min-w-0">
+                        <span className="truncate">{agent.id}</span>
+                        <CopyButton text={agent.id} className="opacity-0 group-hover:opacity-100" />
+                      </div>
+                    </TableCell>
+                    <TableCell className="font-medium">{agent.name ?? "-"}</TableCell>
+                    <TableCell>
+                      {agent.archived ? (
+                        <Badge variant="secondary">Archived</Badge>
+                      ) : (
+                        <PhaseBadge phase={agent.phase} />
+                      )}
+                    </TableCell>
+                    <TableCell className="text-sm text-muted-foreground">
+                      {agent.createdAt
+                        ? formatDistanceToNow(agent.createdAt, { addSuffix: true })
+                        : "—"}
+                    </TableCell>
+                    <TableCell className="w-10" onClick={(e) => e.stopPropagation()}>
+                      {!agent.archived && (
+                        <DropdownMenu>
+                          <DropdownMenuTrigger
+                            render={
+                              <Button variant="ghost" size="icon" aria-label="Open actions menu" />
+                            }
+                          >
+                            <MoreHorizontal className="size-4" />
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="end">
+                            {agent.suspended ? (
+                              <DropdownMenuItem onClick={() => resumeAgent({ id: agent.id })}>
+                                Resume
+                              </DropdownMenuItem>
+                            ) : (
+                              <DropdownMenuItem onClick={() => suspendAgent({ id: agent.id })}>
+                                Pause
+                              </DropdownMenuItem>
+                            )}
+                            <DropdownMenuSeparator />
+                            <DropdownMenuItem
+                              variant="destructive"
+                              onClick={() => setArchiveId(agent.id)}
+                            >
+                              Archive
+                            </DropdownMenuItem>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </TabsContent>
+      </Tabs>
     </div>
   );
 }

--- a/apps/dashboard/src/entities/agent.ts
+++ b/apps/dashboard/src/entities/agent.ts
@@ -78,6 +78,7 @@ export const AgentSchema = AgentInputSchema.extend({
   id: z.string().min(1),
   userId: z.string().min(1),
   suspended: z.boolean().optional(),
+  archived: z.boolean().optional(),
   phase: AgentPhaseSchema.optional(),
   createdAt: z.date().optional(),
 }).readonly();

--- a/apps/dashboard/src/server/infras/kubernetes/client.ts
+++ b/apps/dashboard/src/server/infras/kubernetes/client.ts
@@ -5,16 +5,13 @@ import { config } from "@/server/libs/config";
 import {
   CreateAgentInput,
   CreateSecretInput,
+  ListAgentsFilter,
   ListSecretsFilter,
   PatchAgentInput,
   Runtime,
   SecretPatch,
 } from "../../usecases/adaptors/runtime";
-import {
-  HermesAgent,
-  HermesAgentList,
-  HermesAgentSpec,
-} from "./types/hermes-agent";
+import { HermesAgent, HermesAgentList, HermesAgentSpec } from "./types/hermes-agent";
 
 const enum HermesGroup {
   Default = "agents.hermeum.app",
@@ -45,6 +42,7 @@ export function agentToHermesAgent(agent: Agent): HermesAgent {
   const labels: Record<string, string> = {
     [HermeumLabel.ManagedBy]: HermeumLabelValue.ManagedBy,
     [HermeumLabel.UserId]: agent.userId,
+    [HermeumLabel.Archived]: String(agent.archived ?? false),
   };
 
   const annotations: Record<string, string> = {};
@@ -109,6 +107,7 @@ export function mapHermesAgent(raw: HermesAgent): Agent {
     skills: raw.spec.hermes?.skills?.map((s) => s.identifier),
     plugins: raw.spec.hermes?.plugins?.map((p) => p.identifier),
     suspended: raw.spec.suspend,
+    archived: raw.metadata?.labels?.[HermeumLabel.Archived] === "true",
     phase: raw.status?.phase as AgentPhase | undefined,
     createdAt: raw.metadata?.creationTimestamp,
   };
@@ -174,13 +173,17 @@ export class KubernetesClient implements Runtime {
     this.coreV1Api = this.kc.makeApiClient(k8s.CoreV1Api);
   }
 
-  async listHermesAgents(): Promise<Agent[]> {
+  async listHermesAgents(params?: ListAgentsFilter): Promise<Agent[]> {
+    const selector = [`${HermeumLabel.ManagedBy}=${HermeumLabelValue.ManagedBy}`];
+    if (params?.archived !== undefined) {
+      selector.push(`${HermeumLabel.Archived}=${String(params.archived)}`);
+    }
     const body = await this.customObjectsApi.listNamespacedCustomObject({
       namespace: config.kubernetesNamespace,
       group: HermesGroup.Default,
       version: HermesVersion.V1Alpha1,
       plural: HermesPlural.Agents,
-      labelSelector: `${HermeumLabel.ManagedBy}=${HermeumLabelValue.ManagedBy}`,
+      labelSelector: selector.join(","),
     });
     return (body as HermesAgentList).items.map(mapHermesAgent);
   }
@@ -246,14 +249,8 @@ export class KubernetesClient implements Runtime {
     return mapHermesAgent(resource as HermesAgent);
   }
 
-  async deleteHermesAgent(id: string): Promise<void> {
-    await this.customObjectsApi.deleteNamespacedCustomObject({
-      namespace: config.kubernetesNamespace,
-      group: HermesGroup.Default,
-      version: HermesVersion.V1Alpha1,
-      plural: HermesPlural.Agents,
-      name: id,
-    });
+  async archiveHermesAgent(id: string): Promise<Agent> {
+    return this.patchHermesAgent({ id, patch: { suspended: true, archived: true } });
   }
 
   async listSecrets(params?: ListSecretsFilter): Promise<Secret[]> {

--- a/apps/dashboard/src/server/routers/trpc/agent.ts
+++ b/apps/dashboard/src/server/routers/trpc/agent.ts
@@ -1,15 +1,17 @@
 import { z } from "zod";
 
 import { Agent, AgentInputSchema, SkillSchema } from "@/entities";
-import { AgentUseCase } from "@/server/usecases/agent";
+import { AgentUseCase, ListAgentsFilterSchema } from "@/server/usecases/agent";
 import { protectedProcedure, t } from "./shared.js";
 
 const usecase = new AgentUseCase();
 
 export const agentRouter = t.router({
-  list: protectedProcedure.query(async ({ ctx }): Promise<Agent[]> => {
-    return await usecase.listHermesAgents(ctx);
-  }),
+  list: protectedProcedure
+    .input(ListAgentsFilterSchema.optional())
+    .query(async ({ ctx, input }): Promise<Agent[]> => {
+      return await usecase.listHermesAgents(ctx, input);
+    }),
 
   get: protectedProcedure
     .input(z.object({ id: z.string().min(1) }))
@@ -17,9 +19,11 @@ export const agentRouter = t.router({
       return await usecase.getHermesAgent(ctx, input.id);
     }),
 
-  create: protectedProcedure.input(AgentInputSchema).mutation(async ({ ctx, input }): Promise<Agent> => {
-    return await usecase.createHermesAgent(ctx, input);
-  }),
+  create: protectedProcedure
+    .input(AgentInputSchema)
+    .mutation(async ({ ctx, input }): Promise<Agent> => {
+      return await usecase.createHermesAgent(ctx, input);
+    }),
 
   update: protectedProcedure
     .input(AgentInputSchema.extend({ id: z.string().min(1) }))
@@ -28,10 +32,10 @@ export const agentRouter = t.router({
       return await usecase.updateHermesAgent(ctx, id, agentInput);
     }),
 
-  delete: protectedProcedure
+  archive: protectedProcedure
     .input(z.object({ id: z.string().min(1) }))
-    .mutation(async ({ ctx, input }): Promise<void> => {
-      return await usecase.deleteHermesAgent(ctx, input.id);
+    .mutation(async ({ ctx, input }): Promise<Agent> => {
+      return await usecase.archiveHermesAgent(ctx, input.id);
     }),
 
   installSkill: protectedProcedure

--- a/apps/dashboard/src/server/usecases/adaptors/runtime.ts
+++ b/apps/dashboard/src/server/usecases/adaptors/runtime.ts
@@ -6,16 +6,18 @@ export type PatchAgentInput = {
   patch: Partial<Omit<Agent, "id" | "userId" | "phase" | "createdAt">>;
 };
 
+export type ListAgentsFilter = { archived?: boolean | undefined };
+
 export type CreateSecretInput = Pick<Secret, "userId" | "name" | "description">;
 export type SecretPatch = Partial<Pick<Secret, "name" | "description" | "archived">>;
 export type ListSecretsFilter = { archived?: boolean | undefined };
 
 export interface Runtime {
-  listHermesAgents: () => Promise<Agent[]>;
+  listHermesAgents: (params?: ListAgentsFilter) => Promise<Agent[]>;
   getHermesAgent: (id: string) => Promise<Agent | null>;
   createHermesAgent: (input: CreateAgentInput) => Promise<Agent>;
   patchHermesAgent: (input: PatchAgentInput) => Promise<Agent>;
-  deleteHermesAgent: (id: string) => Promise<void>;
+  archiveHermesAgent: (id: string) => Promise<Agent>;
 
   getGatewayToken: (agentId: string) => Promise<string | null>;
 

--- a/apps/dashboard/src/server/usecases/agent.test.ts
+++ b/apps/dashboard/src/server/usecases/agent.test.ts
@@ -24,7 +24,7 @@ function makeRuntime(): Runtime {
     getHermesAgent: vi.fn(),
     createHermesAgent: vi.fn(),
     patchHermesAgent: vi.fn(),
-    deleteHermesAgent: vi.fn(),
+    archiveHermesAgent: vi.fn(),
     listSecrets: vi.fn(),
     getSecret: vi.fn(),
     createSecret: vi.fn(),
@@ -48,7 +48,7 @@ describe("AgentUseCase.getmutatingWebhookJsonPatch", () => {
   it("returns null when agent.type is undefined", () => {
     const useCase = new AgentUseCase(
       makeRuntime(),
-      makeConfig({ "some-type": { mutatingWebhookJsonPatch: [] } }),
+      makeConfig({ "some-type": { mutatingWebhookJsonPatch: [] } })
     );
     const result = useCase.getmutatingWebhookJsonPatch(makeAgent({ type: undefined }));
     expect(result).toBeNull();
@@ -112,10 +112,10 @@ describe("AgentUseCase.getmutatingWebhookJsonPatch", () => {
     ];
     const useCase = new AgentUseCase(
       makeRuntime(),
-      makeConfig({ t: { mutatingWebhookJsonPatch: patch } }),
+      makeConfig({ t: { mutatingWebhookJsonPatch: patch } })
     );
     const result = useCase.getmutatingWebhookJsonPatch(
-      makeAgent({ type: "t", name: undefined, description: undefined }),
+      makeAgent({ type: "t", name: undefined, description: undefined })
     );
     expect(result![0]!.value).toBe("name=;desc=");
   });
@@ -124,7 +124,7 @@ describe("AgentUseCase.getmutatingWebhookJsonPatch", () => {
     const patch: JsonPatchOp[] = [{ op: "remove", path: "/metadata/labels/old" }];
     const useCase = new AgentUseCase(
       makeRuntime(),
-      makeConfig({ t: { mutatingWebhookJsonPatch: patch } }),
+      makeConfig({ t: { mutatingWebhookJsonPatch: patch } })
     );
     const result = useCase.getmutatingWebhookJsonPatch(makeAgent({ type: "t" }));
     expect(result).toEqual(patch);
@@ -144,10 +144,10 @@ describe("AgentUseCase.getmutatingWebhookJsonPatch", () => {
     ];
     const useCase = new AgentUseCase(
       makeRuntime(),
-      makeConfig({ t: { mutatingWebhookJsonPatch: patch } }),
+      makeConfig({ t: { mutatingWebhookJsonPatch: patch } })
     );
     const result = useCase.getmutatingWebhookJsonPatch(
-      makeAgent({ type: "t", id: "a1", userId: "u2" }),
+      makeAgent({ type: "t", id: "a1", userId: "u2" })
     );
     expect(result![0]!.value).toEqual([
       { name: "AGENT_ID", value: "a1" },

--- a/apps/dashboard/src/server/usecases/agent.ts
+++ b/apps/dashboard/src/server/usecases/agent.ts
@@ -1,4 +1,5 @@
 import Handlebars from "handlebars";
+import { z } from "zod";
 
 import {
   Agent,
@@ -15,6 +16,11 @@ import { KubernetesClient } from "../infras/kubernetes/client";
 import { LocalConfig } from "../infras/local-agent-config";
 import { Runtime } from "./adaptors/runtime";
 import { ConfigAdaptor } from "./adaptors/config";
+
+export const ListAgentsFilterSchema = z.object({
+  archived: z.boolean().optional(),
+});
+export type ListAgentsFilter = z.infer<typeof ListAgentsFilterSchema>;
 
 export class AgentUseCase {
   constructor(
@@ -51,8 +57,8 @@ export class AgentUseCase {
     }));
   }
 
-  async listHermesAgents(ctx: Context): Promise<Agent[]> {
-    return this.runtime.listHermesAgents();
+  async listHermesAgents(ctx: Context, input?: ListAgentsFilter): Promise<Agent[]> {
+    return this.runtime.listHermesAgents(input);
   }
 
   async getHermesAgent(ctx: Context, id: string): Promise<Agent | null> {
@@ -85,13 +91,13 @@ export class AgentUseCase {
     return this.runtime.patchHermesAgent({ id, patch });
   }
 
-  async deleteHermesAgent(ctx: Context, id: string): Promise<void> {
+  async archiveHermesAgent(ctx: Context, id: string): Promise<Agent> {
     const agent = await this.runtime.getHermesAgent(id);
     if (!agent) {
       throw new Error(`HermesAgent ${id} not found`);
     }
     this.verifyOwnership(ctx, agent);
-    return this.runtime.deleteHermesAgent(id);
+    return this.runtime.archiveHermesAgent(id);
   }
 
   async installSkill(ctx: Context, agentId: string, skill: Skill): Promise<Agent> {


### PR DESCRIPTION
## Summary
- Deleting an agent used to hard-delete the `HermesAgent` custom resource via `deleteNamespacedCustomObject`. Archiving now permanently suspends it (`spec.suspend = true`) and marks it with the `hermeum.app/archived` label instead, mirroring the existing secret-archive pattern — the CR is never deleted.
- Agents list gets an All/Active tab toggle (like secrets) backed by a server-side label selector, so archived agents are hidden by default.
- Archiving is one-way: archived agents show an "Archived" badge and no further Pause/Resume/Archive actions on either the list or detail page.

## Test plan
- [x] `pnpm lint` / `pnpm format:check` / `tsc --noEmit` on touched files
- [x] `vitest run` for `agent.test.ts`
- [x] Verified live against a real cluster: archived an agent via the UI, confirmed the `HermesAgent` CR still exists (`suspended: true`, `archived: true`, not deleted), confirmed the "Archived" badge and hidden actions on both pages, and confirmed the Active tab filters it out server-side