### PR TITLE
refactor: restrict secret references to owner, with opt-in sharing

### DIFF
--- a/apps/dashboard/src/client/ui/components/create-secret-dialog.tsx
+++ b/apps/dashboard/src/client/ui/components/create-secret-dialog.tsx
@@ -14,12 +14,14 @@ import {
 } from "@hermeum/components/ui/dialog";
 import {
   Field,
+  FieldContent,
   FieldDescription,
   FieldError,
   FieldGroup,
   FieldLabel,
 } from "@hermeum/components/ui/field";
 import { Input } from "@hermeum/components/ui/input";
+import { Switch } from "@hermeum/components/ui/switch";
 import { Textarea } from "@hermeum/components/ui/textarea";
 import { toast } from "sonner";
 import { useTRPC } from "@/router";
@@ -27,6 +29,7 @@ import { useTRPC } from "@/router";
 const schema = z.object({
   name: z.string().min(1, "Name is required"),
   description: z.string(),
+  shared: z.boolean(),
 });
 
 interface CreateSecretDialogProps {
@@ -39,12 +42,13 @@ export function CreateSecretDialog({ open, onOpenChange }: CreateSecretDialogPro
   const queryClient = useQueryClient();
 
   const form = useForm({
-    defaultValues: { name: "", description: "" },
+    defaultValues: { name: "", description: "", shared: false },
     validators: { onSubmit: schema },
     onSubmit: async ({ value }) => {
       createSecret({
         name: value.name.trim(),
         description: value.description.trim() || undefined,
+        shared: value.shared,
       });
     },
   });
@@ -121,6 +125,26 @@ export function CreateSecretDialog({ open, onOpenChange }: CreateSecretDialogPro
                     onChange={(e) => field.handleChange(e.target.value)}
                     onBlur={field.handleBlur}
                     rows={3}
+                  />
+                </Field>
+              )}
+            </form.Field>
+
+            <form.Field name="shared">
+              {(field) => (
+                <Field orientation="horizontal">
+                  <FieldContent>
+                    <FieldLabel htmlFor={field.name}>Share with all agents</FieldLabel>
+                    <FieldDescription>
+                      Any agent, including agents owned by other users, will be able to use this
+                      secret.
+                    </FieldDescription>
+                  </FieldContent>
+                  <Switch
+                    id={field.name}
+                    name={field.name}
+                    checked={field.state.value}
+                    onCheckedChange={(checked) => field.handleChange(checked)}
                   />
                 </Field>
               )}

--- a/apps/dashboard/src/client/ui/components/edit-secret-dialog.tsx
+++ b/apps/dashboard/src/client/ui/components/edit-secret-dialog.tsx
@@ -15,12 +15,14 @@ import {
 } from "@hermeum/components/ui/dialog";
 import {
   Field,
+  FieldContent,
   FieldDescription,
   FieldError,
   FieldGroup,
   FieldLabel,
 } from "@hermeum/components/ui/field";
 import { Input } from "@hermeum/components/ui/input";
+import { Switch } from "@hermeum/components/ui/switch";
 import { Textarea } from "@hermeum/components/ui/textarea";
 import { toast } from "sonner";
 import { useTRPC } from "@/router";
@@ -28,13 +30,14 @@ import { useTRPC } from "@/router";
 const schema = z.object({
   name: z.string().min(1, "Name is required"),
   description: z.string(),
+  shared: z.boolean(),
 });
 
 interface EditSecretDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   secretId: string;
-  initial: { name: string; description?: string };
+  initial: { name: string; description?: string; shared?: boolean };
 }
 
 export function EditSecretDialog({
@@ -47,13 +50,18 @@ export function EditSecretDialog({
   const queryClient = useQueryClient();
 
   const form = useForm({
-    defaultValues: { name: initial.name, description: initial.description ?? "" },
+    defaultValues: {
+      name: initial.name,
+      description: initial.description ?? "",
+      shared: initial.shared ?? false,
+    },
     validators: { onSubmit: schema },
     onSubmit: async ({ value }) => {
       updateSecret({
         id: secretId,
         name: value.name.trim(),
         description: value.description.trim() || undefined,
+        shared: value.shared,
       });
     },
   });
@@ -76,9 +84,13 @@ export function EditSecretDialog({
 
   useEffect(() => {
     if (open) {
-      form.reset({ name: initial.name, description: initial.description ?? "" });
+      form.reset({
+        name: initial.name,
+        description: initial.description ?? "",
+        shared: initial.shared ?? false,
+      });
     }
-  }, [open, initial.name, initial.description]);
+  }, [open, initial.name, initial.description, initial.shared]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -132,6 +144,26 @@ export function EditSecretDialog({
                     rows={3}
                   />
                   <FieldDescription>Optional. Describe what this secret is used for.</FieldDescription>
+                </Field>
+              )}
+            </form.Field>
+
+            <form.Field name="shared">
+              {(field) => (
+                <Field orientation="horizontal">
+                  <FieldContent>
+                    <FieldLabel htmlFor={field.name}>Share with all agents</FieldLabel>
+                    <FieldDescription>
+                      Any agent, including agents owned by other users, will be able to use this
+                      secret.
+                    </FieldDescription>
+                  </FieldContent>
+                  <Switch
+                    id={field.name}
+                    name={field.name}
+                    checked={field.state.value}
+                    onCheckedChange={(checked) => field.handleChange(checked)}
+                  />
                 </Field>
               )}
             </form.Field>

--- a/apps/dashboard/src/client/ui/routes/secrets/$id.tsx
+++ b/apps/dashboard/src/client/ui/routes/secrets/$id.tsx
@@ -98,6 +98,7 @@ function SecretDetailPage() {
           <div className="flex items-center gap-3">
             <h1 className="text-2xl font-bold">{secret.name}</h1>
             <Badge variant="secondary">{secret.archived ? "Archived" : "Active"}</Badge>
+            {secret.shared && <Badge variant="outline">Shared</Badge>}
           </div>
           <div className="group flex items-center gap-1">
             <p className="font-mono text-sm text-muted-foreground">{secret.id}</p>
@@ -196,6 +197,7 @@ function SecretDetailPage() {
         initial={{
           name: secret.name,
           ...(secret.description && { description: secret.description }),
+          ...(secret.shared !== undefined && { shared: secret.shared }),
         }}
       />
 

--- a/apps/dashboard/src/client/ui/routes/secrets/index.tsx
+++ b/apps/dashboard/src/client/ui/routes/secrets/index.tsx
@@ -181,7 +181,10 @@ function SecretsPage() {
                 </TableCell>
                 <TableCell className="font-medium">{secret.name}</TableCell>
                 <TableCell>
-                  <Badge variant="secondary">{secret.archived ? "Archived" : "Active"}</Badge>
+                  <div className="flex items-center gap-1.5">
+                    <Badge variant="secondary">{secret.archived ? "Archived" : "Active"}</Badge>
+                    {secret.shared && <Badge variant="outline">Shared</Badge>}
+                  </div>
                 </TableCell>
                 <TableCell className="text-sm text-muted-foreground">
                   <EnvVarList envVars={secret.envVars} />

--- a/apps/dashboard/src/entities/secret.ts
+++ b/apps/dashboard/src/entities/secret.ts
@@ -31,6 +31,7 @@ export const SecretSchema = z.object({
   description: z.string().optional(),
   envVars: z.array(SecretEnvVarSchema),
   archived: z.boolean().optional(),
+  shared: z.boolean().optional(),
   createdAt: z.date().optional().readonly(),
 });
 export type Secret = z.infer<typeof SecretSchema>;

--- a/apps/dashboard/src/server/infras/kubernetes/client.ts
+++ b/apps/dashboard/src/server/infras/kubernetes/client.ts
@@ -31,6 +31,7 @@ const enum HermeumLabel {
   ManagedBy = "app.kubernetes.io/managed-by",
   UserId = "hermeum.app/user-id",
   Archived = "hermeum.app/archived",
+  Shared = "hermeum.app/shared",
 }
 const enum HermeumLabelValue {
   ManagedBy = "hermeum",
@@ -129,6 +130,7 @@ export function secretToKubernetesSecret(
         [HermeumLabel.ManagedBy]: HermeumLabelValue.ManagedBy,
         [HermeumLabel.UserId]: secret.userId,
         [HermeumLabel.Archived]: String(secret.archived ?? false),
+        [HermeumLabel.Shared]: String(secret.shared ?? false),
       },
       annotations: {
         [HermeumAnnotation.Name]: secret.name,
@@ -158,6 +160,7 @@ function mapKubernetesSecret(raw: k8s.V1Secret): Secret {
     description: raw.metadata?.annotations?.[HermeumAnnotation.Description],
     envVars,
     archived: raw.metadata?.labels?.[HermeumLabel.Archived] === "true",
+    shared: raw.metadata?.labels?.[HermeumLabel.Shared] === "true",
     createdAt: raw.metadata?.creationTimestamp,
   };
 }

--- a/apps/dashboard/src/server/usecases/adaptors/runtime.ts
+++ b/apps/dashboard/src/server/usecases/adaptors/runtime.ts
@@ -6,8 +6,8 @@ export type PatchAgentInput = {
   patch: Partial<Omit<Agent, "id" | "userId" | "phase" | "createdAt">>;
 };
 
-export type CreateSecretInput = Pick<Secret, "userId" | "name" | "description">;
-export type SecretPatch = Partial<Pick<Secret, "name" | "description" | "archived">>;
+export type CreateSecretInput = Pick<Secret, "userId" | "name" | "description" | "shared">;
+export type SecretPatch = Partial<Pick<Secret, "name" | "description" | "archived" | "shared">>;
 export type ListSecretsFilter = { archived?: boolean | undefined };
 
 export interface Runtime {

--- a/apps/dashboard/src/server/usecases/agent.test.ts
+++ b/apps/dashboard/src/server/usecases/agent.test.ts
@@ -270,4 +270,49 @@ describe("AgentUseCase secret ownership validation", () => {
       useCase.updateHermesAgent(makeCtx("user-1"), "agent-1", { secrets: ["secret-1"] })
     ).resolves.toBeDefined();
   });
+
+  it("createHermesAgent succeeds when a referenced secret belongs to another user but is shared", async () => {
+    const runtime = makeRuntime();
+    (runtime.getSecret as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeSecret({ id: "secret-1", userId: "other-user", shared: true })
+    );
+    (runtime.createHermesAgent as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeAgent({ secrets: ["secret-1"] })
+    );
+    const useCase = new AgentUseCase(runtime, makeConfig());
+
+    await expect(
+      useCase.createHermesAgent(makeCtx("user-1"), { secrets: ["secret-1"] })
+    ).resolves.toBeDefined();
+  });
+
+  it("createHermesAgent throws when a referenced shared secret is archived", async () => {
+    const runtime = makeRuntime();
+    (runtime.getSecret as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeSecret({ id: "secret-1", userId: "other-user", shared: true, archived: true })
+    );
+    const useCase = new AgentUseCase(runtime, makeConfig());
+
+    await expect(
+      useCase.createHermesAgent(makeCtx("user-1"), { secrets: ["secret-1"] })
+    ).rejects.toThrow('Secret "secret-1" is archived');
+  });
+
+  it("updateHermesAgent succeeds when a referenced secret belongs to another user but is shared", async () => {
+    const runtime = makeRuntime();
+    (runtime.getHermesAgent as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeAgent({ userId: "user-1" })
+    );
+    (runtime.getSecret as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeSecret({ id: "secret-1", userId: "other-user", shared: true })
+    );
+    (runtime.patchHermesAgent as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeAgent({ secrets: ["secret-1"] })
+    );
+    const useCase = new AgentUseCase(runtime, makeConfig());
+
+    await expect(
+      useCase.updateHermesAgent(makeCtx("user-1"), "agent-1", { secrets: ["secret-1"] })
+    ).resolves.toBeDefined();
+  });
 });

--- a/apps/dashboard/src/server/usecases/agent.test.ts
+++ b/apps/dashboard/src/server/usecases/agent.test.ts
@@ -7,7 +7,7 @@ import { AgentUseCase } from "./agent";
 import type { ConfigAdaptor } from "./adaptors/config";
 import type { Runtime } from "./adaptors/runtime";
 import type { AgentConfig, JsonPatchOp } from "@/entities";
-import type { Agent } from "@/entities";
+import type { Agent, Context, Secret } from "@/entities";
 
 function makeConfig(agentTypes?: AgentConfig["agentTypes"]): ConfigAdaptor {
   return {
@@ -42,6 +42,23 @@ function makeAgent(overrides: Partial<Agent> = {}): Agent {
     userId: "user-1",
     ...overrides,
   } as Agent;
+}
+
+function makeCtx(userId = "user-1"): Context {
+  return {
+    session: { id: "session-1", userId, expiresAt: new Date() },
+    user: { id: userId, email: "user@example.com", name: "User", createdAt: new Date() },
+  };
+}
+
+function makeSecret(overrides: Partial<Secret> = {}): Secret {
+  return {
+    id: "secret-1",
+    userId: "user-1",
+    name: "My Secret",
+    envVars: [],
+    ...overrides,
+  };
 }
 
 describe("AgentUseCase.getmutatingWebhookJsonPatch", () => {
@@ -168,5 +185,89 @@ describe("AgentUseCase.getmutatingWebhookJsonPatch", () => {
     expect(result).toHaveLength(2);
     expect(result![0]).not.toHaveProperty("value");
     expect(result![1]!.value).toBe("zz9");
+  });
+});
+
+describe("AgentUseCase secret ownership validation", () => {
+  it("createHermesAgent throws when a referenced secret belongs to another user", async () => {
+    const runtime = makeRuntime();
+    (runtime.getSecret as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeSecret({ id: "secret-1", userId: "other-user" })
+    );
+    const useCase = new AgentUseCase(runtime, makeConfig());
+
+    await expect(
+      useCase.createHermesAgent(makeCtx("user-1"), { secrets: ["secret-1"] })
+    ).rejects.toThrow('Secret "secret-1" not found');
+  });
+
+  it("createHermesAgent succeeds when a referenced secret belongs to the same user", async () => {
+    const runtime = makeRuntime();
+    (runtime.getSecret as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeSecret({ id: "secret-1", userId: "user-1" })
+    );
+    (runtime.createHermesAgent as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeAgent({ secrets: ["secret-1"] })
+    );
+    const useCase = new AgentUseCase(runtime, makeConfig());
+
+    await expect(
+      useCase.createHermesAgent(makeCtx("user-1"), { secrets: ["secret-1"] })
+    ).resolves.toBeDefined();
+  });
+
+  it("createHermesAgent throws when a referenced secret is archived", async () => {
+    const runtime = makeRuntime();
+    (runtime.getSecret as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeSecret({ id: "secret-1", userId: "user-1", archived: true })
+    );
+    const useCase = new AgentUseCase(runtime, makeConfig());
+
+    await expect(
+      useCase.createHermesAgent(makeCtx("user-1"), { secrets: ["secret-1"] })
+    ).rejects.toThrow('Secret "secret-1" is archived');
+  });
+
+  it("createHermesAgent throws when a referenced secret does not exist", async () => {
+    const runtime = makeRuntime();
+    (runtime.getSecret as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const useCase = new AgentUseCase(runtime, makeConfig());
+
+    await expect(
+      useCase.createHermesAgent(makeCtx("user-1"), { secrets: ["secret-1"] })
+    ).rejects.toThrow('Secret "secret-1" not found');
+  });
+
+  it("updateHermesAgent throws when a referenced secret belongs to another user", async () => {
+    const runtime = makeRuntime();
+    (runtime.getHermesAgent as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeAgent({ userId: "user-1" })
+    );
+    (runtime.getSecret as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeSecret({ id: "secret-1", userId: "other-user" })
+    );
+    const useCase = new AgentUseCase(runtime, makeConfig());
+
+    await expect(
+      useCase.updateHermesAgent(makeCtx("user-1"), "agent-1", { secrets: ["secret-1"] })
+    ).rejects.toThrow('Secret "secret-1" not found');
+  });
+
+  it("updateHermesAgent succeeds when a referenced secret belongs to the same user", async () => {
+    const runtime = makeRuntime();
+    (runtime.getHermesAgent as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeAgent({ userId: "user-1" })
+    );
+    (runtime.getSecret as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeSecret({ id: "secret-1", userId: "user-1" })
+    );
+    (runtime.patchHermesAgent as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeAgent({ secrets: ["secret-1"] })
+    );
+    const useCase = new AgentUseCase(runtime, makeConfig());
+
+    await expect(
+      useCase.updateHermesAgent(makeCtx("user-1"), "agent-1", { secrets: ["secret-1"] })
+    ).resolves.toBeDefined();
   });
 });

--- a/apps/dashboard/src/server/usecases/agent.ts
+++ b/apps/dashboard/src/server/usecases/agent.ts
@@ -65,7 +65,7 @@ export class AgentUseCase {
     if (agentInput.type !== undefined) {
       this.checkAgentTypeAllowed(agentInput.type);
     }
-    await this.checkSecretsExist(agentInput.secrets);
+    await this.checkSecretsAccessible(ctx, agentInput.secrets);
     return this.runtime.createHermesAgent({ ...agentInput, userId: ctx.user!.id });
   }
 
@@ -81,7 +81,7 @@ export class AgentUseCase {
     if (patch.type !== undefined) {
       this.checkAgentTypeAllowed(patch.type);
     }
-    await this.checkSecretsExist(patch.secrets);
+    await this.checkSecretsAccessible(ctx, patch.secrets);
     return this.runtime.patchHermesAgent({ id, patch });
   }
 
@@ -131,10 +131,10 @@ export class AgentUseCase {
     });
   }
 
-  private async checkSecretsExist(secrets: string[] | undefined): Promise<void> {
+  private async checkSecretsAccessible(ctx: Context, secrets: string[] | undefined): Promise<void> {
     for (const name of secrets ?? []) {
       const secret = await this.runtime.getSecret(name);
-      if (!secret) {
+      if (!secret || secret.userId !== ctx.user!.id) {
         throw new Error(`Secret "${name}" not found`);
       }
       if (secret.archived) {

--- a/apps/dashboard/src/server/usecases/agent.ts
+++ b/apps/dashboard/src/server/usecases/agent.ts
@@ -134,7 +134,7 @@ export class AgentUseCase {
   private async checkSecretsAccessible(ctx: Context, secrets: string[] | undefined): Promise<void> {
     for (const name of secrets ?? []) {
       const secret = await this.runtime.getSecret(name);
-      if (!secret || secret.userId !== ctx.user!.id) {
+      if (!secret || (secret.userId !== ctx.user!.id && !secret.shared)) {
         throw new Error(`Secret "${name}" not found`);
       }
       if (secret.archived) {

--- a/apps/dashboard/src/server/usecases/secret.ts
+++ b/apps/dashboard/src/server/usecases/secret.ts
@@ -7,6 +7,7 @@ import { Runtime } from "./adaptors/runtime";
 export const CreateSecretInputSchema = z.object({
   name: z.string().min(1),
   description: z.string().optional(),
+  shared: z.boolean().optional(),
 });
 export type CreateSecretInput = z.infer<typeof CreateSecretInputSchema>;
 
@@ -18,6 +19,7 @@ export type ListSecretsInput = z.infer<typeof ListSecretsFilterSchema>;
 export const UpdateSecretInputSchema = z.object({
   name: z.string().min(1).optional(),
   description: z.string().optional(),
+  shared: z.boolean().optional(),
 });
 export type UpdateSecretInput = z.infer<typeof UpdateSecretInputSchema>;
 
@@ -45,6 +47,7 @@ export class SecretUseCase {
     return this.runtime.patchSecret(id, {
       ...(input.name !== undefined && { name: input.name }),
       ...(input.description !== undefined && { description: input.description }),
+      ...(input.shared !== undefined && { shared: input.shared }),
     });
   }
 

--- a/packages/components/ui/switch.tsx
+++ b/packages/components/ui/switch.tsx
@@ -1,0 +1,30 @@
+import { Switch as SwitchPrimitive } from "@base-ui/react/switch"
+
+import { cn } from "@hermeum/components/lib/utils"
+
+function Switch({
+  className,
+  size = "default",
+  ...props
+}: SwitchPrimitive.Root.Props & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      data-size={size}
+      className={cn(
+        "peer group/switch relative inline-flex shrink-0 items-center rounded-none border transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/30 aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/20 data-[size=default]:h-4.5 data-[size=default]:w-8.25 data-[size=sm]:h-3.5 data-[size=sm]:w-6.25 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-unchecked:border-input/50 data-unchecked:bg-input data-disabled:cursor-not-allowed data-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className="pointer-events-none block bg-background ring-0 transition-transform group-data-[size=default]/switch:size-3.5 group-data-[size=sm]/switch:size-2.5 data-checked:translate-x-[calc(100%+2px)] dark:data-checked:bg-primary-foreground data-unchecked:translate-x-0.25 dark:data-unchecked:bg-foreground"
+      />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }


### PR DESCRIPTION
## Summary
- Agents can now only reference secrets owned by the same user (previously any user's secret could be attached to any agent by ID).
- Adds an opt-in `shared` boolean on `Secret`: when enabled, any agent — regardless of owner — can reference it. Wired through the entity, use cases, Kubernetes label storage, and a new toggle in the create/edit secret dialogs.

## Test plan
- [x] `pnpm lint` (dashboard) — no new issues vs. base branch
- [x] `pnpm typecheck` (dashboard) — passes
- [x] `vitest run` (dashboard) — 18/18 tests pass, including new ownership/sharing coverage in `agent.test.ts`
- [ ] Manual check in the browser: create a secret, toggle "Share with all agents," confirm badge shows on list/detail pages and the toggle persists through edit/reload