### PR TITLE
feat(dashboard): display agent secrets in accordion on agent detail page

### DIFF
--- a/apps/dashboard/src/client/ui/routes/agents/$id.tsx
+++ b/apps/dashboard/src/client/ui/routes/agents/$id.tsx
@@ -201,7 +201,7 @@ function AgentDetailPage() {
           <div className="flex flex-col divide-y">
             {/* soul */}
             {agent.soul && (
-              <div className="py-6 flex flex-col gap-3">
+              <div className="py-8 flex flex-col gap-3">
                 <p className="text-sm font-medium">Soul</p>
                 <pre className="rounded bg-muted p-3 text-xs overflow-auto max-h-64">
                   {agent.soul}
@@ -211,7 +211,7 @@ function AgentDetailPage() {
 
             {/* config */}
             {agent.config && (
-              <div className="py-6 flex flex-col gap-3">
+              <div className="py-8 flex flex-col gap-3">
                 <p className="text-sm font-medium">Configuration</p>
                 <CodeEditor value={stringifyYaml(agent.config)} readOnly maxHeight="300px" />
               </div>
@@ -219,7 +219,7 @@ function AgentDetailPage() {
 
             {/* skills */}
             {agent.skills && agent.skills.length > 0 && (
-              <div className="py-6 flex flex-col gap-3">
+              <div className="py-8 flex flex-col gap-3">
                 <p className="text-sm font-medium">Skills</p>
                 <ButtonList items={agent.skills} max={10} />
               </div>
@@ -227,14 +227,14 @@ function AgentDetailPage() {
 
             {/* plugins */}
             {agent.plugins && agent.plugins.length > 0 && (
-              <div className="py-6 flex flex-col gap-3">
+              <div className="py-8 flex flex-col gap-3">
                 <p className="text-sm font-medium">Plugins</p>
                 <ButtonList items={agent.plugins} max={10} />
               </div>
             )}
 
             {/* secrets */}
-            <div className="py-6 flex flex-col gap-3">
+            <div className="py-8 flex flex-col gap-3">
               <p className="text-sm font-medium">Secrets</p>
               {agent.secrets && agent.secrets.length > 0 ? (
                 <Accordion multiple className="w-full border rounded-md px-4">
@@ -287,7 +287,7 @@ function AgentDetailPage() {
         <TabsContent value="connect" className="mt-4">
           <div className="flex flex-col divide-y">
             {gatewayToken && (
-              <div className="py-6 flex flex-col gap-3">
+              <div className="py-8 flex flex-col gap-3">
                 <p className="text-sm font-medium">Gateway Token</p>
                 <div className="group flex items-center gap-2">
                   <span className="font-mono text-sm text-muted-foreground">

--- a/apps/dashboard/src/client/ui/routes/agents/$id.tsx
+++ b/apps/dashboard/src/client/ui/routes/agents/$id.tsx
@@ -43,21 +43,22 @@ export const Route = createFileRoute("/agents/$id")({
 
 const BADGE_MAX = 10;
 
-function BadgeList({ items, max = BADGE_MAX }: { items: string[]; max?: number }) {
+function ButtonList({ items, max = BADGE_MAX }: { items: string[]; max?: number }) {
   const visible = items.slice(0, max);
   const overflow = items.length - visible.length;
   return (
     <div className="flex flex-wrap gap-2">
       {visible.map((item) => (
-        <Badge key={item} variant="secondary" className="font-mono text-xs">
+        <Button
+          key={item}
+          variant="outline"
+          size="sm"
+          className="h-auto px-2 py-1 font-mono text-xs"
+        >
           {item}
-        </Badge>
+        </Button>
       ))}
-      {overflow > 0 && (
-        <Badge variant="outline" className="text-xs text-muted-foreground">
-          +{overflow} more
-        </Badge>
-      )}
+      {overflow > 0 && <span className="text-xs text-muted-foreground">+{overflow} more</span>}
     </div>
   );
 }
@@ -220,7 +221,7 @@ function AgentDetailPage() {
             {agent.skills && agent.skills.length > 0 && (
               <div className="py-6 flex flex-col gap-3">
                 <p className="text-sm font-medium">Skills</p>
-                <BadgeList items={agent.skills} max={10} />
+                <ButtonList items={agent.skills} max={10} />
               </div>
             )}
 
@@ -228,60 +229,58 @@ function AgentDetailPage() {
             {agent.plugins && agent.plugins.length > 0 && (
               <div className="py-6 flex flex-col gap-3">
                 <p className="text-sm font-medium">Plugins</p>
-                <BadgeList items={agent.plugins} max={10} />
+                <ButtonList items={agent.plugins} max={10} />
               </div>
             )}
 
             {/* secrets */}
-            {
-              <div className="py-6 flex flex-col gap-3">
-                <p className="text-sm font-medium">Secrets</p>
-                {agent.secrets && agent.secrets.length > 0 ? (
-                  <Accordion multiple className="w-full border rounded-md px-4">
-                    {secrets?.map((secret) => (
-                      <AccordionItem key={secret.id} value={secret.id}>
-                        <AccordionTrigger className="items-center hover:no-underline">
-                          <div className="flex items-center gap-2">
-                            <span className="font-medium hover:underline">{secret.name}</span>
-                            <div className="group flex items-center gap-1">
-                              <span className="font-mono text-xs text-muted-foreground">
-                                {secret.id}
-                              </span>
-                              <CopyButton
-                                text={secret.id}
-                                className="opacity-0 group-hover:opacity-100"
-                              />
-                            </div>
+            <div className="py-6 flex flex-col gap-3">
+              <p className="text-sm font-medium">Secrets</p>
+              {agent.secrets && agent.secrets.length > 0 ? (
+                <Accordion multiple className="w-full border rounded-md px-4">
+                  {secrets?.map((secret) => (
+                    <AccordionItem key={secret.id} value={secret.id}>
+                      <AccordionTrigger className="items-center hover:no-underline">
+                        <div className="flex items-center gap-2">
+                          <span className="font-medium hover:underline">{secret.name}</span>
+                          <div className="group flex items-center gap-1">
+                            <span className="font-mono text-xs text-muted-foreground">
+                              {secret.id}
+                            </span>
+                            <CopyButton
+                              text={secret.id}
+                              className="opacity-0 group-hover:opacity-100"
+                            />
                           </div>
-                        </AccordionTrigger>
-                        <AccordionContent>
-                          {secret.envVars.length > 0 ? (
-                            <div className="flex flex-wrap gap-2 pb-2">
-                              {secret.envVars.map((v) => (
-                                <Button
-                                  key={v.name}
-                                  variant="outline"
-                                  size="sm"
-                                  className="h-auto px-2 py-1 font-mono text-xs"
-                                >
-                                  {v.name}
-                                </Button>
-                              ))}
-                            </div>
-                          ) : (
-                            <p className="text-sm text-muted-foreground pb-2">
-                              No environment variables.
-                            </p>
-                          )}
-                        </AccordionContent>
-                      </AccordionItem>
-                    ))}
-                  </Accordion>
-                ) : (
-                  <p className="text-sm text-muted-foreground">No secrets attached.</p>
-                )}
-              </div>
-            }
+                        </div>
+                      </AccordionTrigger>
+                      <AccordionContent>
+                        {secret.envVars.length > 0 ? (
+                          <div className="flex flex-wrap gap-2 pb-2">
+                            {secret.envVars.map((v) => (
+                              <Button
+                                key={v.name}
+                                variant="outline"
+                                size="sm"
+                                className="h-auto px-2 py-1 font-mono text-xs"
+                              >
+                                {v.name}
+                              </Button>
+                            ))}
+                          </div>
+                        ) : (
+                          <p className="text-sm text-muted-foreground pb-2">
+                            No environment variables.
+                          </p>
+                        )}
+                      </AccordionContent>
+                    </AccordionItem>
+                  ))}
+                </Accordion>
+              ) : (
+                <p className="text-sm text-muted-foreground">No secrets attached.</p>
+              )}
+            </div>
           </div>
         </TabsContent>
 

--- a/apps/dashboard/src/client/ui/routes/agents/$id.tsx
+++ b/apps/dashboard/src/client/ui/routes/agents/$id.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { Eye, EyeOff, MoreHorizontal, RefreshCw } from "lucide-react";
 import { stringify as stringifyYaml } from "yaml";
@@ -14,6 +14,12 @@ import { Button } from "@hermeum/components/ui/button";
 import { EditInstanceDialog } from "@/client/ui/components/edit-agent-dialog";
 import { CodeEditor } from "@/client/ui/components/code-editor";
 import { CopyButton } from "@/client/ui/components/copy-button";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@hermeum/components/ui/accordion";
 import {
   Dialog,
   DialogClose,
@@ -72,6 +78,16 @@ function AgentDetailPage() {
     ...trpc.agent.getGatewayToken.queryOptions({ id }),
     enabled: isOwner,
   });
+  const secretIds = agent?.secrets ?? [];
+  const secretQueries = useQueries({
+    queries: secretIds.map((secretId) => ({
+      ...trpc.secret.get.queryOptions({ id: secretId }),
+      enabled: secretIds.length > 0,
+    })),
+  });
+  const secrets = secretQueries
+    .map((q) => q.data)
+    .filter((s): s is NonNullable<typeof s> => s != null);
   const [editOpen, setEditOpen] = useState(false);
   const [archiveOpen, setArchiveOpen] = useState(false);
   const [tokenVisible, setTokenVisible] = useState(false);
@@ -215,6 +231,57 @@ function AgentDetailPage() {
                 <BadgeList items={agent.plugins} max={10} />
               </div>
             )}
+
+            {/* secrets */}
+            {
+              <div className="py-6 flex flex-col gap-3">
+                <p className="text-sm font-medium">Secrets</p>
+                {agent.secrets && agent.secrets.length > 0 ? (
+                  <Accordion multiple className="w-full border rounded-md px-4">
+                    {secrets?.map((secret) => (
+                      <AccordionItem key={secret.id} value={secret.id}>
+                        <AccordionTrigger className="items-center hover:no-underline">
+                          <div className="flex items-center gap-2">
+                            <span className="font-medium hover:underline">{secret.name}</span>
+                            <div className="group flex items-center gap-1">
+                              <span className="font-mono text-xs text-muted-foreground">
+                                {secret.id}
+                              </span>
+                              <CopyButton
+                                text={secret.id}
+                                className="opacity-0 group-hover:opacity-100"
+                              />
+                            </div>
+                          </div>
+                        </AccordionTrigger>
+                        <AccordionContent>
+                          {secret.envVars.length > 0 ? (
+                            <div className="flex flex-wrap gap-2 pb-2">
+                              {secret.envVars.map((v) => (
+                                <Button
+                                  key={v.name}
+                                  variant="outline"
+                                  size="sm"
+                                  className="h-auto px-2 py-1 font-mono text-xs"
+                                >
+                                  {v.name}
+                                </Button>
+                              ))}
+                            </div>
+                          ) : (
+                            <p className="text-sm text-muted-foreground pb-2">
+                              No environment variables.
+                            </p>
+                          )}
+                        </AccordionContent>
+                      </AccordionItem>
+                    ))}
+                  </Accordion>
+                ) : (
+                  <p className="text-sm text-muted-foreground">No secrets attached.</p>
+                )}
+              </div>
+            }
           </div>
         </TabsContent>
 


### PR DESCRIPTION
Show secrets attached to an agent in an accordion on the agent detail page. Each secret is fetched individually and rendered with its env vars. Skills and plugins are now also displayed as outline buttons to match the secret env var styling.