### PR TITLE
feat: add typed schema for Hermes agent config

### DIFF
--- a/apps/dashboard/src/entities/agent.ts
+++ b/apps/dashboard/src/entities/agent.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { ConfigSchema } from "./hermes-config";
+
 export const WorkspaceFilesSchema = z.record(z.string(), z.string()).optional();
 
 export type WorkspaceFiles = z.infer<typeof WorkspaceFilesSchema>;
@@ -33,10 +35,6 @@ export const StorageSchema = z
   .optional();
 
 export type Storage = z.infer<typeof StorageSchema>;
-
-export const ConfigSchema = z.record(z.string(), z.unknown()).optional();
-
-export type Config = z.infer<typeof ConfigSchema>;
 
 export const SelfConfigActionSchema = z.enum(["skills", "config", "soul"]);
 

--- a/apps/dashboard/src/entities/hermes-config.ts
+++ b/apps/dashboard/src/entities/hermes-config.ts
@@ -33,11 +33,124 @@ export const ModelSchema = z
 
 export type Model = z.infer<typeof ModelSchema>;
 
+export const WebhookDeliverSchema = z
+  .union([
+    z.enum(["log", "github_comment", "telegram", "discord", "slack", "email"]),
+    z.string(),
+  ])
+  .describe(
+    "Destination for the response. Common targets are enumerated; other platform names " +
+      '(e.g. "signal", "matrix", "whatsapp") are also accepted. Defaults to "log".'
+  );
+
+export type WebhookDeliver = z.infer<typeof WebhookDeliverSchema>;
+
+export const WebhookRouteSchema = z
+  .looseObject({
+    events: z
+      .array(z.string())
+      .optional()
+      .describe(
+        'Event types this route accepts, e.g. ["pull_request"]. Omit or leave empty to accept all events.'
+      ),
+    secret: z
+      .string()
+      .optional()
+      .describe(
+        "HMAC secret to validate webhook senders. Omit to fall back to the auto-generated " +
+          "WEBHOOK_SECRET environment variable, which is already injected into the agent."
+      ),
+    prompt: z
+      .string()
+      .optional()
+      .describe(
+        "Prompt template for the agent. Supports {dot.notation} access to payload fields " +
+          'and {__raw__} for the whole payload as JSON, e.g. "PR #{number}: {pull_request.title}".'
+      ),
+    skills: z
+      .array(z.string())
+      .optional()
+      .describe("Skill names to load for agent runs triggered by this route."),
+    deliver: WebhookDeliverSchema.optional(),
+    deliver_extra: z
+      .record(z.string(), z.unknown())
+      .optional()
+      .describe(
+        "Platform-specific delivery options; values support {dot.notation} templates, " +
+          'e.g. { repo: "{repository.full_name}", pr_number: "{number}" }.'
+      ),
+    deliver_only: z
+      .boolean()
+      .optional()
+      .describe(
+        "If true, skip the agent and deliver the rendered prompt as a literal message. " +
+          "Requires a real deliver target."
+      ),
+  })
+  .describe("A named webhook route that maps incoming events to an agent run or delivery.");
+
+export type WebhookRoute = z.infer<typeof WebhookRouteSchema>;
+
+export const WebhookSchema = z
+  .looseObject({
+    enabled: z
+      .boolean()
+      .optional()
+      .describe(
+        "Whether the webhook server is enabled. The WEBHOOK_ENABLED=true environment " +
+          "variable is already injected into the agent, so omit this unless disabling."
+      ),
+    extra: z
+      .looseObject({
+        port: z
+          .number()
+          .int()
+          .optional()
+          .describe(
+            "Port the webhook server listens on. The WEBHOOK_PORT environment variable is " +
+              "already injected, so omit this unless a different port is needed."
+          ),
+        secret: z
+          .string()
+          .optional()
+          .describe(
+            "Global fallback HMAC secret for routes without their own. Omit this: an " +
+              "auto-generated WEBHOOK_SECRET environment variable is already injected into the agent."
+          ),
+        rate_limit: z
+          .number()
+          .optional()
+          .describe("Maximum requests per minute. Defaults to 30."),
+        max_body_bytes: z
+          .number()
+          .optional()
+          .describe("Maximum request body size in bytes. Defaults to 1048576 (1 MB)."),
+        routes: z
+          .record(z.string(), WebhookRouteSchema)
+          .optional()
+          .describe("Named webhook routes, keyed by route name (used in the webhook URL path)."),
+      })
+      .optional()
+      .describe("Webhook server settings."),
+  })
+  .describe("Webhook messaging platform configuration.");
+
+export type Webhook = z.infer<typeof WebhookSchema>;
+
+export const PlatformsSchema = z
+  .looseObject({
+    webhook: WebhookSchema.optional(),
+  })
+  .describe("Messaging platform integrations.");
+
+export type Platforms = z.infer<typeof PlatformsSchema>;
+
 export const ConfigSchema = z
   .looseObject({
     model: ModelSchema.optional().describe(
       "Model configuration to use."
     ),
+    platforms: PlatformsSchema.optional(),
   })
   .optional()
   .describe(

--- a/apps/dashboard/src/entities/hermes-config.ts
+++ b/apps/dashboard/src/entities/hermes-config.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+
+export const ModelProviderSchema = z
+  .union([z.enum(["novita", "openai", "anthropic", "openrouter"]), z.string()])
+  .describe(
+    "LLM provider that serves the model. Prefer one of the known providers; " +
+      "any other provider name is also accepted."
+  );
+
+export type ModelProvider = z.infer<typeof ModelProviderSchema>;
+
+export const ModelSchema = z
+  .looseObject({
+    provider: ModelProviderSchema,
+    default: z
+      .string()
+      .min(1)
+      .describe(
+        'Default model identifier used for requests, e.g. "moonshotai/kimi-k2.5" or "gpt-5".'
+      ),
+    base_url: z
+      .url()
+      .optional()
+      .describe(
+        "Base URL of the provider's API endpoint, " +
+          'e.g. "https://api.novita.ai/openai/v1". Omit to use the provider default.'
+      ),
+  })
+  .describe("LLM model configuration for the agent.");
+
+export type Model = z.infer<typeof ModelSchema>;
+
+export const ConfigSchema = z
+  .looseObject({
+    model: ModelSchema.optional().describe(
+      "Model configuration to use."
+    ),
+  })
+  .optional()
+  .describe(
+    "Hermes agent configuration. Only well-known fields are validated here; " +
+      "any additional fields are passed through unchanged."
+  );
+
+export type Config = z.infer<typeof ConfigSchema>;

--- a/apps/dashboard/src/entities/hermes-config.ts
+++ b/apps/dashboard/src/entities/hermes-config.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
 
+// Config schema for LLM structured output: descriptions guide generation accuracy.
+// Fields not defined here are still allowed (loose objects) so users can configure
+// whatever the Hermes agent supports. 
 export const ModelProviderSchema = z
   .union([z.enum(["novita", "openai", "anthropic", "openrouter"]), z.string()])
   .describe(

--- a/apps/dashboard/src/entities/index.ts
+++ b/apps/dashboard/src/entities/index.ts
@@ -1,5 +1,6 @@
 export * from "./auth";
 export * from "./agent";
+export * from "./hermes-config";
 export * from "./template";
 export * from "./agent-config";
 export * from "./secret";


### PR DESCRIPTION
## What

Extracts the Hermes agent config schema into its own module (`apps/dashboard/src/entities/hermes-config.ts`) and replaces the opaque `z.record(z.string(), z.unknown())` with typed, described schemas:

- **`model`** — `provider` (enum of novita/openai/anthropic/openrouter with any other string accepted), required `default` model id, optional `base_url`.
- **`platforms.webhook`** — server settings (`enabled`, `port`, `secret`, `rate_limit`, `max_body_bytes`) and named `routes` (`events`, `secret`, `prompt`, `skills`, `deliver`, `deliver_extra`, `deliver_only`), per the [Hermes webhook docs](https://hermes-agent.nousresearch.com/docs/user-guide/messaging/webhooks).

## Why

The schema is used to generate structured output from an LLM, so every field carries a `.describe()` to guide generation accuracy. Validating well-known fields also catches malformed configs at the dialog/tRPC boundary instead of at the agent.

## Notes for review

- All objects are `z.looseObject`, so unknown fields still pass through unchanged — users can configure anything the Hermes agent supports, and existing configs (e.g. `agents.defaults.model`, provider `ollama-cloud`) remain valid.
- Webhook `secret` is optional at both route and server level because the platform already injects an auto-generated `WEBHOOK_SECRET` env var into the pod (along with `WEBHOOK_ENABLED` and `WEBHOOK_PORT`); the field descriptions say so, to keep the LLM from inventing secrets.
- Fields with defaults (`port`, `rate_limit`, `max_body_bytes`) document the default in the description rather than using `.default()`, so validation never mutates a user's config on the way to the CRD.