### PR TITLE
refactor(dashboard): rename AgentConfig to HermeumConfig

### DIFF
--- a/apps/dashboard/src/entities/hermeum-config.ts
+++ b/apps/dashboard/src/entities/hermeum-config.ts
@@ -17,7 +17,7 @@ export const AgentTypeSchema = z.object({
 
 export type AgentType = z.infer<typeof AgentTypeSchema>;
 
-export const AgentConfigSchema = z
+export const HermeumConfigSchema = z
   .object({
     agentTypes: z.record(z.string(), AgentTypeSchema).optional(),
     templates: z.array(TemplateSchema),
@@ -36,7 +36,7 @@ export const AgentConfigSchema = z
   })
   .readonly();
 
-export type AgentConfig = z.infer<typeof AgentConfigSchema>;
+export type HermeumConfig = z.infer<typeof HermeumConfigSchema>;
 
 export type WebhookVariables = {
   agentId: string;

--- a/apps/dashboard/src/entities/index.ts
+++ b/apps/dashboard/src/entities/index.ts
@@ -1,5 +1,5 @@
 export * from "./auth";
 export * from "./agent";
 export * from "./template";
-export * from "./agent-config";
+export * from "./hermeum-config";
 export * from "./secret";

--- a/apps/dashboard/src/server/infras/local-hermeum-config.ts
+++ b/apps/dashboard/src/server/infras/local-hermeum-config.ts
@@ -1,12 +1,12 @@
 import * as fs from "node:fs";
 import { parse } from "yaml";
 
-import { AgentConfig, AgentConfigSchema } from "@/entities";
+import { HermeumConfig, HermeumConfigSchema } from "@/entities";
 import { config } from "@/server/libs/config";
 import { ConfigAdaptor } from "../usecases/adaptors/config";
 
 export class LocalConfig implements ConfigAdaptor {
-  private cache: AgentConfig;
+  private cache: HermeumConfig;
 
   constructor(private filePath?: string) {
     const resolvedPath = this.filePath ?? config.agentConfigPath;
@@ -14,17 +14,17 @@ export class LocalConfig implements ConfigAdaptor {
     try {
       const content = fs.readFileSync(resolvedPath, "utf-8");
       const raw = parse(content);
-      this.cache = AgentConfigSchema.parse(raw);
+      this.cache = HermeumConfigSchema.parse(raw);
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code === "ENOENT") {
-        this.cache = AgentConfigSchema.parse({ templates: [] });
+        this.cache = HermeumConfigSchema.parse({ templates: [] });
       } else {
         throw err;
       }
     }
   }
 
-  get(): AgentConfig {
+  get(): HermeumConfig {
     return this.cache;
   }
 }

--- a/apps/dashboard/src/server/routers/trpc/template.ts
+++ b/apps/dashboard/src/server/routers/trpc/template.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 import { Template } from "@/entities";
-import { LocalConfig } from "@/server/infras/local-agent-config";
+import { LocalConfig } from "@/server/infras/local-hermeum-config";
 import { TemplateUseCase } from "@/server/usecases/template";
 import { protectedProcedure, t } from "./shared.js";
 

--- a/apps/dashboard/src/server/usecases/adaptors/config.ts
+++ b/apps/dashboard/src/server/usecases/adaptors/config.ts
@@ -1,5 +1,5 @@
-import { AgentConfig } from "@/entities";
+import { HermeumConfig } from "@/entities";
 
 export interface ConfigAdaptor {
-  get(): AgentConfig;
+  get(): HermeumConfig;
 }

--- a/apps/dashboard/src/server/usecases/agent.test.ts
+++ b/apps/dashboard/src/server/usecases/agent.test.ts
@@ -1,20 +1,20 @@
 import { describe, it, expect, vi } from "vitest";
 
 vi.mock("../infras/kubernetes/client", () => ({ KubernetesClient: vi.fn() }));
-vi.mock("../infras/local-agent-config", () => ({ LocalConfig: vi.fn() }));
+vi.mock("../infras/local-hermeum-config", () => ({ LocalConfig: vi.fn() }));
 
 import { AgentUseCase } from "./agent";
 import type { ConfigAdaptor } from "./adaptors/config";
 import type { Runtime } from "./adaptors/runtime";
-import type { AgentConfig, JsonPatchOp } from "@/entities";
+import type { HermeumConfig, JsonPatchOp } from "@/entities";
 import type { Agent, Context, Secret } from "@/entities";
 
-function makeConfig(agentTypes?: AgentConfig["agentTypes"]): ConfigAdaptor {
+function makeConfig(agentTypes?: HermeumConfig["agentTypes"]): ConfigAdaptor {
   return {
     get: vi.fn().mockReturnValue({
       agentTypes,
       templates: [],
-    } satisfies AgentConfig),
+    } satisfies HermeumConfig),
   };
 }
 

--- a/apps/dashboard/src/server/usecases/agent.ts
+++ b/apps/dashboard/src/server/usecases/agent.ts
@@ -13,7 +13,7 @@ import {
 } from "@/entities";
 
 import { KubernetesClient } from "../infras/kubernetes/client";
-import { LocalConfig } from "../infras/local-agent-config";
+import { LocalConfig } from "../infras/local-hermeum-config";
 import { Runtime } from "./adaptors/runtime";
 import { ConfigAdaptor } from "./adaptors/config";
 


### PR DESCRIPTION
## Summary
- Renamed the `AgentConfig` entity type/schema to `HermeumConfig` (and the underlying `agent-config.ts` / `local-agent-config.ts` files to `hermeum-config.ts` / `local-hermeum-config.ts`) since `AgentConfig` was easily confused with the unrelated `Agent` entity.
- Updated all imports and usages across entities, adaptors, use cases, and tests.

## Why
`AgentConfig` isn't config for a single agent — it's the platform-level catalog of agent types and templates loaded from `agent-config.yaml`. The old name collided conceptually with `Agent` (a runtime agent instance). `HermeumConfig` better reflects its role and avoids the confusion.

## Test plan
- [x] `pnpm typecheck` passes in `apps/dashboard`
- [x] `pnpm test` passes (18/18) in `apps/dashboard`
- [x] `pnpm lint` in `apps/dashboard` shows only pre-existing, unrelated errors/warnings