### PR TITLE
Add env vars to Agent config

### DIFF
--- a/apps/dashboard/src/client/ui/components/create-agent-dialog.tsx
+++ b/apps/dashboard/src/client/ui/components/create-agent-dialog.tsx
@@ -40,6 +40,7 @@ const DEFAULT_YAML = stringify({
   skills: [],
   plugins: [],
   sharedEnvSets: [],
+  env: [],
 } as AgentInput).trim();
 
 interface CreateAgentDialogProps {

--- a/apps/dashboard/src/client/ui/routes/agents/$id.tsx
+++ b/apps/dashboard/src/client/ui/routes/agents/$id.tsx
@@ -233,6 +233,25 @@ function AgentDetailPage() {
               </div>
             )}
 
+            {/* env */}
+            {agent.env && agent.env.length > 0 && (
+              <div className="py-8 flex flex-col gap-3">
+                <p className="text-sm font-medium">Environment Variables</p>
+                <div className="flex flex-wrap gap-2">
+                  {agent.env.map((v) => (
+                    <Button
+                      key={v.name}
+                      variant="outline"
+                      size="sm"
+                      className="h-auto px-2 py-1 font-mono text-xs"
+                    >
+                      {v.name}={v.value}
+                    </Button>
+                  ))}
+                </div>
+              </div>
+            )}
+
             {/* shared env sets */}
             <div className="py-8 flex flex-col gap-3">
               <p className="text-sm font-medium">Shared Env Sets</p>

--- a/apps/dashboard/src/server/infras/kubernetes/client.test.ts
+++ b/apps/dashboard/src/server/infras/kubernetes/client.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  agentEnvResourceName,
+  agentToHermesAgent,
+  hashAgentEnv,
+  maskSensitiveEnv,
+  splitAgentEnv,
+} from "./client";
+import type { Agent } from "@/entities";
+
+function makeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: "agent-1",
+    userId: "user-1",
+    ...overrides,
+  } as Agent;
+}
+
+describe("agentEnvResourceName", () => {
+  it("derives the ConfigMap/Secret name from the agent id", () => {
+    expect(agentEnvResourceName("agent-1")).toBe("agent-1-dot-env");
+  });
+});
+
+describe("splitAgentEnv", () => {
+  it("partitions env vars into ConfigMap and Secret data by sensitivity", () => {
+    const { configMapData, secretData } = splitAgentEnv([
+      { name: "REGION", value: "us-east-1" },
+      { name: "API_KEY", value: "shh", sensitive: true },
+    ]);
+    expect(configMapData).toEqual({ REGION: "us-east-1" });
+    expect(secretData).toEqual({ API_KEY: "shh" });
+  });
+
+  it("returns empty objects for undefined env", () => {
+    expect(splitAgentEnv(undefined)).toEqual({ configMapData: {}, secretData: {} });
+  });
+});
+
+describe("maskSensitiveEnv", () => {
+  it("replaces sensitive values with the secret sentinel and leaves others untouched", () => {
+    const masked = maskSensitiveEnv([
+      { name: "REGION", value: "us-east-1" },
+      { name: "API_KEY", value: "shh", sensitive: true },
+    ]);
+    expect(masked).toEqual([
+      { name: "REGION", value: "us-east-1" },
+      { name: "API_KEY", value: "<secret>", sensitive: true },
+    ]);
+  });
+
+  it("passes through undefined", () => {
+    expect(maskSensitiveEnv(undefined)).toBeUndefined();
+  });
+});
+
+describe("hashAgentEnv", () => {
+  it("is stable for equivalent env content regardless of order", () => {
+    const a = hashAgentEnv([
+      { name: "REGION", value: "us-east-1" },
+      { name: "API_KEY", value: "shh", sensitive: true },
+    ]);
+    const b = hashAgentEnv([
+      { name: "API_KEY", value: "shh", sensitive: true },
+      { name: "REGION", value: "us-east-1" },
+    ]);
+    expect(a).toBe(b);
+  });
+
+  it("changes when a value changes", () => {
+    const a = hashAgentEnv([{ name: "REGION", value: "us-east-1" }]);
+    const b = hashAgentEnv([{ name: "REGION", value: "us-west-2" }]);
+    expect(a).not.toBe(b);
+  });
+
+  it("changes when a var is added or removed", () => {
+    const a = hashAgentEnv([{ name: "REGION", value: "us-east-1" }]);
+    const b = hashAgentEnv([
+      { name: "REGION", value: "us-east-1" },
+      { name: "API_KEY", value: "shh", sensitive: true },
+    ]);
+    expect(a).not.toBe(b);
+  });
+
+  it("is stable across undefined and empty array", () => {
+    expect(hashAgentEnv(undefined)).toBe(hashAgentEnv([]));
+  });
+});
+
+describe("agentToHermesAgent workspace.dotEnv wiring", () => {
+  it("always sets both configMapRef and secretRef to the same agent-derived name", () => {
+    const hermesAgent = agentToHermesAgent(makeAgent());
+    expect(hermesAgent.spec.hermes?.workspace?.dotEnv).toEqual({
+      configMapRef: { name: "agent-1-dot-env" },
+      secretRef: { name: "agent-1-dot-env" },
+    });
+  });
+
+  it("includes the SOUL.md file alongside dotEnv when soul is set", () => {
+    const hermesAgent = agentToHermesAgent(makeAgent({ soul: "You are helpful." }));
+    expect(hermesAgent.spec.hermes?.workspace?.files).toEqual({ "SOUL.md": "You are helpful." });
+    expect(hermesAgent.spec.hermes?.workspace?.dotEnv).toEqual({
+      configMapRef: { name: "agent-1-dot-env" },
+      secretRef: { name: "agent-1-dot-env" },
+    });
+  });
+});
+
+describe("agentToHermesAgent podAnnotations wiring", () => {
+  it("stamps an env-hash annotation derived from agent.env", () => {
+    const env = [{ name: "REGION", value: "us-east-1" }];
+    const hermesAgent = agentToHermesAgent(makeAgent({ env }));
+    expect(hermesAgent.spec.podAnnotations).toEqual({ "hermeum.app/env-hash": hashAgentEnv(env) });
+  });
+
+  it("changes the annotation when env content changes", () => {
+    const a = agentToHermesAgent(makeAgent({ env: [{ name: "REGION", value: "us-east-1" }] }));
+    const b = agentToHermesAgent(makeAgent({ env: [{ name: "REGION", value: "us-west-2" }] }));
+    expect(a.spec.podAnnotations).not.toEqual(b.spec.podAnnotations);
+  });
+});

--- a/apps/dashboard/src/server/infras/kubernetes/client.ts
+++ b/apps/dashboard/src/server/infras/kubernetes/client.ts
@@ -1,6 +1,14 @@
 import * as k8s from "@kubernetes/client-node";
 
-import { Agent, AgentPhase, EnvVar, SharedEnvSet, SharedEnvSetEnvVar } from "@/entities";
+import {
+  Agent,
+  AgentPhase,
+  ENV_SECRET_SENTINEL,
+  Env,
+  EnvVar,
+  SharedEnvSet,
+  SharedEnvSetEnvVar,
+} from "@/entities";
 import { config } from "@/server/libs/config";
 import {
   CreateAgentInput,
@@ -33,11 +41,79 @@ const enum HermeumLabel {
 const enum HermeumLabelValue {
   ManagedBy = "hermeum",
   SharedEnvSet = "shared-env-set",
+  AgentEnv = "agent-env",
 }
 const enum HermeumAnnotation {
   Name = "hermeum.app/name",
   Description = "hermeum.app/description",
   Type = "hermeum.app/type",
+}
+
+export function agentEnvResourceName(agentId: string): string {
+  return `${agentId}-dot-env`;
+}
+
+export function splitAgentEnv(env: Env): {
+  configMapData: Record<string, string>;
+  secretData: Record<string, string>;
+} {
+  const configMapData: Record<string, string> = {};
+  const secretData: Record<string, string> = {};
+  for (const v of env ?? []) {
+    if (v.sensitive) {
+      secretData[v.name] = v.value;
+    } else {
+      configMapData[v.name] = v.value;
+    }
+  }
+  return { configMapData, secretData };
+}
+
+export function maskSensitiveEnv(env: Env): Env {
+  return env?.map((v) => (v.sensitive ? { ...v, value: ENV_SECRET_SENTINEL } : v));
+}
+
+export function agentEnvToConfigMap(
+  agent: Pick<Agent, "id" | "userId" | "archived">,
+  data: Record<string, string>
+): k8s.V1ConfigMap {
+  return {
+    apiVersion: "v1",
+    kind: "ConfigMap",
+    metadata: {
+      name: agentEnvResourceName(agent.id),
+      namespace: config.kubernetesNamespace,
+      labels: {
+        [HermeumLabel.ManagedBy]: HermeumLabelValue.ManagedBy,
+        [HermeumLabel.Resource]: HermeumLabelValue.AgentEnv,
+        [HermeumLabel.UserId]: agent.userId,
+        [HermeumLabel.Archived]: String(agent.archived ?? false),
+      },
+    },
+    data,
+  };
+}
+
+export function agentEnvToSecret(
+  agent: Pick<Agent, "id" | "userId" | "archived">,
+  stringData: Record<string, string>
+): k8s.V1Secret {
+  return {
+    apiVersion: "v1",
+    kind: "Secret",
+    type: "Opaque",
+    metadata: {
+      name: agentEnvResourceName(agent.id),
+      namespace: config.kubernetesNamespace,
+      labels: {
+        [HermeumLabel.ManagedBy]: HermeumLabelValue.ManagedBy,
+        [HermeumLabel.Resource]: HermeumLabelValue.AgentEnv,
+        [HermeumLabel.UserId]: agent.userId,
+        [HermeumLabel.Archived]: String(agent.archived ?? false),
+      },
+    },
+    stringData,
+  };
 }
 
 export function agentToHermesAgent(agent: Agent): HermesAgent {
@@ -65,9 +141,14 @@ export function agentToHermesAgent(agent: Agent): HermesAgent {
   if (agent.sharedEnvSets !== undefined) {
     hermes.envFrom = agent.sharedEnvSets.map((name) => ({ secretRef: { name } }));
   }
-  if (agent.soul !== undefined) {
-    hermes.workspace = { files: { "SOUL.md": agent.soul } };
-  }
+  const envResourceName = agentEnvResourceName(agent.id);
+  hermes.workspace = {
+    ...(agent.soul !== undefined && { files: { "SOUL.md": agent.soul } }),
+    dotEnv: {
+      configMapRef: { name: envResourceName },
+      secretRef: { name: envResourceName },
+    },
+  };
   if (agent.skills !== undefined) {
     hermes.skills = agent.skills.map((identifier) => ({ identifier }));
   }
@@ -199,6 +280,86 @@ export class KubernetesClient implements Runtime {
     return (body as HermesAgentList).items.map(mapHermesAgent);
   }
 
+  private async getHermesAgentEnv(agentId: string): Promise<Env> {
+    const name = agentEnvResourceName(agentId);
+    const [configMap, secret] = await Promise.all([
+      this.coreV1Api
+        .readNamespacedConfigMap({ name, namespace: config.kubernetesNamespace })
+        .catch(() => null),
+      this.coreV1Api
+        .readNamespacedSecret({ name, namespace: config.kubernetesNamespace })
+        .catch(() => null),
+    ]);
+    const nonSensitive = Object.entries(configMap?.data ?? {}).map(([name, value]) => ({
+      name,
+      value,
+    }));
+    const sensitive = Object.keys(secret?.data ?? {}).map((name) => ({
+      name,
+      value: ENV_SECRET_SENTINEL,
+      sensitive: true,
+    }));
+    return [...nonSensitive, ...sensitive];
+  }
+
+  private async createHermesAgentEnv(
+    agent: Pick<Agent, "id" | "userId" | "archived">,
+    env: Env
+  ): Promise<Env> {
+    const { configMapData, secretData } = splitAgentEnv(env);
+    await this.coreV1Api.createNamespacedConfigMap({
+      namespace: config.kubernetesNamespace,
+      body: agentEnvToConfigMap(agent, configMapData),
+    });
+    await this.coreV1Api.createNamespacedSecret({
+      namespace: config.kubernetesNamespace,
+      body: agentEnvToSecret(agent, secretData),
+    });
+    return maskSensitiveEnv(env);
+  }
+
+  private async patchHermesAgentEnv(agentId: string, env: Env): Promise<Env> {
+    const name = agentEnvResourceName(agentId);
+    const currentConfigMap = await this.coreV1Api.readNamespacedConfigMap({
+      name,
+      namespace: config.kubernetesNamespace,
+    });
+    const currentSecret = await this.coreV1Api.readNamespacedSecret({
+      name,
+      namespace: config.kubernetesNamespace,
+    });
+    const existingSecretData = decodeSecretData(currentSecret.data ?? {});
+
+    const resolvedEnv = env?.map((v) => {
+      if (v.sensitive && v.value === ENV_SECRET_SENTINEL) {
+        const existingValue = existingSecretData[v.name];
+        if (existingValue === undefined) {
+          throw new Error(
+            `Cannot preserve value for sensitive env var "${v.name}": no existing secret value found`
+          );
+        }
+        return { ...v, value: existingValue };
+      }
+      return v;
+    });
+    const { configMapData, secretData } = splitAgentEnv(resolvedEnv);
+
+    await this.coreV1Api.replaceNamespacedConfigMap({
+      name,
+      namespace: config.kubernetesNamespace,
+      body: { ...currentConfigMap, data: configMapData },
+    });
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { data: _data, ...restSecret } = currentSecret;
+    await this.coreV1Api.replaceNamespacedSecret({
+      name,
+      namespace: config.kubernetesNamespace,
+      body: { ...restSecret, stringData: secretData },
+    });
+
+    return maskSensitiveEnv(resolvedEnv);
+  }
+
   async getHermesAgent(id: string): Promise<Agent | null> {
     try {
       const body = await this.customObjectsApi.getNamespacedCustomObject({
@@ -208,7 +369,7 @@ export class KubernetesClient implements Runtime {
         plural: HermesPlural.Agents,
         name: id,
       });
-      return mapHermesAgent(body as HermesAgent);
+      return { ...mapHermesAgent(body as HermesAgent), env: await this.getHermesAgentEnv(id) };
     } catch {
       return null;
     }
@@ -216,10 +377,9 @@ export class KubernetesClient implements Runtime {
 
   async createHermesAgent(agentInput: CreateAgentInput): Promise<Agent> {
     const id = `agent-${Math.random().toString(36).slice(2, 8)}`;
-    const body = agentToHermesAgent({
-      id,
-      ...agentInput,
-    });
+    const agent = { id, ...agentInput };
+    const env = await this.createHermesAgentEnv(agent, agent.env);
+    const body = agentToHermesAgent(agent);
     const resource = await this.customObjectsApi.createNamespacedCustomObject({
       namespace: config.kubernetesNamespace,
       group: HermesGroup.Default,
@@ -227,7 +387,7 @@ export class KubernetesClient implements Runtime {
       plural: HermesPlural.Agents,
       body,
     });
-    return mapHermesAgent(resource as HermesAgent);
+    return { ...mapHermesAgent(resource as HermesAgent), env };
   }
 
   async patchHermesAgent({ id, patch }: PatchAgentInput): Promise<Agent> {
@@ -242,10 +402,11 @@ export class KubernetesClient implements Runtime {
       throw new Error(`Agent with id ${id} not found`);
     }
 
-    const body = agentToHermesAgent({
+    const merged = {
       ...mapHermesAgent(raw),
       ...patch,
-    });
+    };
+    const body = agentToHermesAgent(merged);
     if (body.metadata && raw.metadata?.resourceVersion) {
       body.metadata.resourceVersion = raw.metadata.resourceVersion;
     }
@@ -257,7 +418,13 @@ export class KubernetesClient implements Runtime {
       name: id,
       body,
     });
-    return mapHermesAgent(resource as HermesAgent);
+
+    const env =
+      patch.env !== undefined
+        ? await this.patchHermesAgentEnv(id, patch.env)
+        : await this.getHermesAgentEnv(id);
+
+    return { ...mapHermesAgent(resource as HermesAgent), env };
   }
 
   async archiveHermesAgent(id: string): Promise<Agent> {

--- a/apps/dashboard/src/server/infras/kubernetes/client.ts
+++ b/apps/dashboard/src/server/infras/kubernetes/client.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import * as k8s from "@kubernetes/client-node";
 
 import {
@@ -48,6 +50,9 @@ const enum HermeumAnnotation {
   Description = "hermeum.app/description",
   Type = "hermeum.app/type",
 }
+const enum HermeumPodAnnotation {
+  EnvHash = "hermeum.app/env-hash",
+}
 
 export function agentEnvResourceName(agentId: string): string {
   return `${agentId}-dot-env`;
@@ -71,6 +76,16 @@ export function splitAgentEnv(env: Env): {
 
 export function maskSensitiveEnv(env: Env): Env {
   return env?.map((v) => (v.sensitive ? { ...v, value: ENV_SECRET_SENTINEL } : v));
+}
+
+// Deterministic fingerprint of env content, stamped onto the pod template via
+// podAnnotations so the StatefulSet rolls its pods whenever env changes.
+export function hashAgentEnv(env: Env): string {
+  const canonical = [...(env ?? [])]
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map((v) => `${v.name}=${v.value}|${v.sensitive ?? false}`)
+    .join("\n");
+  return createHash("sha256").update(canonical).digest("hex");
 }
 
 export function agentEnvToConfigMap(
@@ -160,6 +175,7 @@ export function agentToHermesAgent(agent: Agent): HermesAgent {
   const spec: HermesAgentSpec = {
     ...(agent.suspended !== undefined && { suspend: agent.suspended }),
     ...(Object.keys(hermes).length > 0 && { hermes: hermes as HermesAgentSpec["hermes"] }),
+    podAnnotations: { [HermeumPodAnnotation.EnvHash]: hashAgentEnv(agent.env) },
   };
 
   return {
@@ -280,6 +296,8 @@ export class KubernetesClient implements Runtime {
     return (body as HermesAgentList).items.map(mapHermesAgent);
   }
 
+  // Real (unmasked) env — callers are responsible for masking before this
+  // reaches an API response.
   private async getHermesAgentEnv(agentId: string): Promise<Env> {
     const name = agentEnvResourceName(agentId);
     const [configMap, secret] = await Promise.all([
@@ -294,9 +312,9 @@ export class KubernetesClient implements Runtime {
       name,
       value,
     }));
-    const sensitive = Object.keys(secret?.data ?? {}).map((name) => ({
+    const sensitive = Object.entries(decodeSecretData(secret?.data ?? {})).map(([name, value]) => ({
       name,
-      value: ENV_SECRET_SENTINEL,
+      value,
       sensitive: true,
     }));
     return [...nonSensitive, ...sensitive];
@@ -305,7 +323,7 @@ export class KubernetesClient implements Runtime {
   private async createHermesAgentEnv(
     agent: Pick<Agent, "id" | "userId" | "archived">,
     env: Env
-  ): Promise<Env> {
+  ): Promise<void> {
     const { configMapData, secretData } = splitAgentEnv(env);
     await this.coreV1Api.createNamespacedConfigMap({
       namespace: config.kubernetesNamespace,
@@ -315,7 +333,32 @@ export class KubernetesClient implements Runtime {
       namespace: config.kubernetesNamespace,
       body: agentEnvToSecret(agent, secretData),
     });
-    return maskSensitiveEnv(env);
+  }
+
+  // Sensitive values round-trip through the client as the ENV_SECRET_SENTINEL
+  // placeholder (never the real value), so an unchanged sensitive var arrives
+  // here still holding the sentinel — swap it back for the value already in
+  // the Secret instead of overwriting it with the literal placeholder string.
+  private async resolveMaskedEnv(agentId: string, env: Env): Promise<Env> {
+    const name = agentEnvResourceName(agentId);
+    const currentSecret = await this.coreV1Api.readNamespacedSecret({
+      name,
+      namespace: config.kubernetesNamespace,
+    });
+    const existingSecretData = decodeSecretData(currentSecret.data ?? {});
+
+    return env?.map((v) => {
+      if (v.sensitive && v.value === ENV_SECRET_SENTINEL) {
+        const existingValue = existingSecretData[v.name];
+        if (existingValue === undefined) {
+          throw new Error(
+            `Cannot preserve value for sensitive env var "${v.name}": no existing secret value found`
+          );
+        }
+        return { ...v, value: existingValue };
+      }
+      return v;
+    });
   }
 
   private async patchHermesAgentEnv(agentId: string, env: Env): Promise<Env> {
@@ -328,21 +371,7 @@ export class KubernetesClient implements Runtime {
       name,
       namespace: config.kubernetesNamespace,
     });
-    const existingSecretData = decodeSecretData(currentSecret.data ?? {});
-
-    const resolvedEnv = env?.map((v) => {
-      if (v.sensitive && v.value === ENV_SECRET_SENTINEL) {
-        const existingValue = existingSecretData[v.name];
-        if (existingValue === undefined) {
-          throw new Error(
-            `Cannot preserve value for sensitive env var "${v.name}": no existing secret value found`
-          );
-        }
-        return { ...v, value: existingValue };
-      }
-      return v;
-    });
-    const { configMapData, secretData } = splitAgentEnv(resolvedEnv);
+    const { configMapData, secretData } = splitAgentEnv(env);
 
     await this.coreV1Api.replaceNamespacedConfigMap({
       name,
@@ -357,7 +386,7 @@ export class KubernetesClient implements Runtime {
       body: { ...restSecret, stringData: secretData },
     });
 
-    return maskSensitiveEnv(resolvedEnv);
+    return env;
   }
 
   async getHermesAgent(id: string): Promise<Agent | null> {
@@ -369,7 +398,8 @@ export class KubernetesClient implements Runtime {
         plural: HermesPlural.Agents,
         name: id,
       });
-      return { ...mapHermesAgent(body as HermesAgent), env: await this.getHermesAgentEnv(id) };
+      const env = await this.getHermesAgentEnv(id);
+      return { ...mapHermesAgent(body as HermesAgent), env: maskSensitiveEnv(env) };
     } catch {
       return null;
     }
@@ -378,7 +408,7 @@ export class KubernetesClient implements Runtime {
   async createHermesAgent(agentInput: CreateAgentInput): Promise<Agent> {
     const id = `agent-${Math.random().toString(36).slice(2, 8)}`;
     const agent = { id, ...agentInput };
-    const env = await this.createHermesAgentEnv(agent, agent.env);
+    await this.createHermesAgentEnv(agent, agent.env);
     const body = agentToHermesAgent(agent);
     const resource = await this.customObjectsApi.createNamespacedCustomObject({
       namespace: config.kubernetesNamespace,
@@ -387,7 +417,7 @@ export class KubernetesClient implements Runtime {
       plural: HermesPlural.Agents,
       body,
     });
-    return { ...mapHermesAgent(resource as HermesAgent), env };
+    return { ...mapHermesAgent(resource as HermesAgent), env: maskSensitiveEnv(agent.env) };
   }
 
   async patchHermesAgent({ id, patch }: PatchAgentInput): Promise<Agent> {
@@ -402,9 +432,18 @@ export class KubernetesClient implements Runtime {
       throw new Error(`Agent with id ${id} not found`);
     }
 
+    // Resolve the real (unmasked) env before building the CR body, so the
+    // hash agentToHermesAgent stamps into podAnnotations reflects the actual
+    // stored content — and stays stable across patches that don't touch env.
+    const env =
+      patch.env !== undefined
+        ? await this.patchHermesAgentEnv(id, await this.resolveMaskedEnv(id, patch.env))
+        : await this.getHermesAgentEnv(id);
+
     const merged = {
       ...mapHermesAgent(raw),
       ...patch,
+      env,
     };
     const body = agentToHermesAgent(merged);
     if (body.metadata && raw.metadata?.resourceVersion) {
@@ -419,12 +458,7 @@ export class KubernetesClient implements Runtime {
       body,
     });
 
-    const env =
-      patch.env !== undefined
-        ? await this.patchHermesAgentEnv(id, patch.env)
-        : await this.getHermesAgentEnv(id);
-
-    return { ...mapHermesAgent(resource as HermesAgent), env };
+    return { ...mapHermesAgent(resource as HermesAgent), env: maskSensitiveEnv(env) };
   }
 
   async archiveHermesAgent(id: string): Promise<Agent> {

--- a/apps/dashboard/src/server/infras/kubernetes/types/hermes-agent.ts
+++ b/apps/dashboard/src/server/infras/kubernetes/types/hermes-agent.ts
@@ -293,6 +293,7 @@ export interface HermesAgentSpec {
   sidecars?: k8s.V1Container[] | undefined;
   extraVolumes?: k8s.V1Volume[] | undefined;
   extraVolumeMounts?: k8s.V1VolumeMount[] | undefined;
+  podAnnotations?: Record<string, string> | undefined;
   searxng?: SearXNG | undefined;
   camofox?: Camofox | undefined;
 }

--- a/apps/dashboard/src/server/infras/kubernetes/types/hermes-agent.ts
+++ b/apps/dashboard/src/server/infras/kubernetes/types/hermes-agent.ts
@@ -31,7 +31,8 @@ export interface HermesStorage {
 // ─── Workspace ────────────────────────────────────────────────────────────────
 
 export interface HermesDotEnv {
-  secretRef: { name: string };
+  secretRef?: { name: string } | undefined;
+  configMapRef?: { name: string } | undefined;
 }
 
 export interface HermesWorkspace {

--- a/apps/dashboard/src/server/usecases/agent.test.ts
+++ b/apps/dashboard/src/server/usecases/agent.test.ts
@@ -274,3 +274,76 @@ describe("AgentUseCase shared env set validation", () => {
     ).rejects.toThrow('Shared env set "envset-1" is archived');
   });
 });
+
+describe("AgentUseCase env sensitivity validation", () => {
+  it("updateHermesAgent throws when flipping a sensitive env var to non-sensitive", async () => {
+    const runtime = makeRuntime();
+    (runtime.getHermesAgent as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeAgent({
+        userId: "user-1",
+        env: [{ name: "API_KEY", value: "<secret>", sensitive: true }],
+      })
+    );
+    const useCase = new AgentUseCase(runtime, makeConfig());
+
+    await expect(
+      useCase.updateHermesAgent(makeCtx("user-1"), "agent-1", {
+        env: [{ name: "API_KEY", value: "plain", sensitive: false }],
+      })
+    ).rejects.toThrow('Env var "API_KEY" is sensitive and cannot be marked as non-sensitive');
+  });
+
+  it("updateHermesAgent throws when omitting sensitive on a previously sensitive env var", async () => {
+    const runtime = makeRuntime();
+    (runtime.getHermesAgent as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeAgent({
+        userId: "user-1",
+        env: [{ name: "API_KEY", value: "<secret>", sensitive: true }],
+      })
+    );
+    const useCase = new AgentUseCase(runtime, makeConfig());
+
+    await expect(
+      useCase.updateHermesAgent(makeCtx("user-1"), "agent-1", {
+        env: [{ name: "API_KEY", value: "<secret>" }],
+      })
+    ).rejects.toThrow('Env var "API_KEY" is sensitive and cannot be marked as non-sensitive');
+  });
+
+  it("updateHermesAgent allows flipping a non-sensitive env var to sensitive", async () => {
+    const runtime = makeRuntime();
+    (runtime.getHermesAgent as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeAgent({ userId: "user-1", env: [{ name: "REGION", value: "us-east-1" }] })
+    );
+    (runtime.patchHermesAgent as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeAgent({ env: [{ name: "REGION", value: "<secret>", sensitive: true }] })
+    );
+    const useCase = new AgentUseCase(runtime, makeConfig());
+
+    await expect(
+      useCase.updateHermesAgent(makeCtx("user-1"), "agent-1", {
+        env: [{ name: "REGION", value: "us-east-1", sensitive: true }],
+      })
+    ).resolves.toBeDefined();
+  });
+
+  it("updateHermesAgent allows adding new env vars and removing existing ones", async () => {
+    const runtime = makeRuntime();
+    (runtime.getHermesAgent as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeAgent({
+        userId: "user-1",
+        env: [{ name: "API_KEY", value: "<secret>", sensitive: true }],
+      })
+    );
+    (runtime.patchHermesAgent as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeAgent({ env: [{ name: "NEW_VAR", value: "hello" }] })
+    );
+    const useCase = new AgentUseCase(runtime, makeConfig());
+
+    await expect(
+      useCase.updateHermesAgent(makeCtx("user-1"), "agent-1", {
+        env: [{ name: "NEW_VAR", value: "hello" }],
+      })
+    ).resolves.toBeDefined();
+  });
+});

--- a/apps/dashboard/src/server/usecases/agent.ts
+++ b/apps/dashboard/src/server/usecases/agent.ts
@@ -6,6 +6,7 @@ import {
   AgentInput,
   AgentInputSchema,
   Context,
+  Env,
   JsonPatchOp,
   Skill,
   SkillSchema,
@@ -88,7 +89,20 @@ export class AgentUseCase {
       this.checkAgentTypeAllowed(patch.type);
     }
     await this.checkSharedEnvSetsAccessible(patch.sharedEnvSets);
+    if (patch.env !== undefined) {
+      this.checkEnvSensitivityNotDowngraded(agent.env, patch.env);
+    }
     return this.runtime.patchHermesAgent({ id, patch });
+  }
+
+  private checkEnvSensitivityNotDowngraded(existingEnv: Env, patchEnv: Env): void {
+    const existingByName = new Map((existingEnv ?? []).map((v) => [v.name, v]));
+    for (const v of patchEnv ?? []) {
+      const prev = existingByName.get(v.name);
+      if (prev?.sensitive && !v.sensitive) {
+        throw new Error(`Env var "${v.name}" is sensitive and cannot be marked as non-sensitive`);
+      }
+    }
   }
 
   async archiveHermesAgent(ctx: Context, id: string): Promise<Agent> {


### PR DESCRIPTION
## Summary

- Adds an `env` field to `Agent`/`AgentInput`, letting users inject environment variables into a `HermesAgent`. Non-sensitive vars are stored in a ConfigMap and sensitive vars in a Secret, both named `<agent-id>-dot-env`, wired into `hermes.workspace.dotEnv` (mirrors the operator's `.env` file generation).
- Sensitive values are masked as `<secret>` on any read, and once a var is marked sensitive it can't be flipped back to non-sensitive on update.
- Stamps a content hash of the env into `spec.podAnnotations` on create/patch so the operator rolls the StatefulSet's pods whenever env vars actually change, while staying stable across unrelated patches (e.g. suspend/resume) so those don't trigger a spurious rollout.
- Adds an "Environment Variables" section to the agent detail page and an `env: []` default in the create-agent dialog's starter YAML.

## Why

`HermesAgent` had no way to inject agent-specific env vars. This wires the dashboard-managed ConfigMap/Secret pattern (already used for shared env sets) into the operator's newer `workspace.dotEnv` support, with a validation rule to prevent silently downgrading a credential to plaintext.

## Notes for reviewers

- `KubernetesClient` keeps mask/unmask concerns at the `getHermesAgent`/`createHermesAgent`/`patchHermesAgent` level: those three methods explicitly mask sensitive values on the way out and resolve the `<secret>` placeholder (via `resolveMaskedEnv`) on the way in, rather than mixing that into the lower-level ConfigMap/Secret read-write methods.
- The `podAnnotations` field itself was verified against the operator's updated `HermesAgentSpec` (pasted into this session) but the test cluster used for manual verification runs an older CRD schema that doesn't yet include `podAnnotations`, so Kubernetes silently prunes it there — confirmed via a standalone script that `agentToHermesAgent`/`hashAgentEnv` produce the correct payload before it ever reaches the cluster. The CRD will need redeploying with the operator's new schema for the annotation to take effect end-to-end.
- Everything else (ConfigMap/Secret creation, masking, sensitivity-downgrade rejection) was verified live against the test cluster: create/read/patch round-trips, and UI checks on the agent detail page.