### PR TITLE
refactor: document credential env vars and sync provider list in `ModelSchema`

### DIFF
--- a/apps/dashboard/src/entities/hermes-config.ts
+++ b/apps/dashboard/src/entities/hermes-config.ts
@@ -4,7 +4,10 @@ import { z } from "zod";
 // Fields not defined here are still allowed (loose objects) so users can configure
 // whatever the Hermes agent supports. 
 export const ModelProviderSchema = z
-  .union([z.enum(["novita", "openai-api", "anthropic", "openrouter"]), z.string()])
+  .union([
+    z.enum(["anthropic", "openrouter", "zai", "kimi-coding", "openai-api", "ollama-cloud"]),
+    z.string(),
+  ])
   .describe(
     "LLM provider that serves the model. Prefer one of the known providers; " +
       "any other provider name is also accepted."

--- a/apps/dashboard/src/entities/hermes-config.ts
+++ b/apps/dashboard/src/entities/hermes-config.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 // Fields not defined here are still allowed (loose objects) so users can configure
 // whatever the Hermes agent supports. 
 export const ModelProviderSchema = z
-  .union([z.enum(["novita", "openai", "anthropic", "openrouter"]), z.string()])
+  .union([z.enum(["novita", "openai-api", "anthropic", "openrouter"]), z.string()])
   .describe(
     "LLM provider that serves the model. Prefer one of the known providers; " +
       "any other provider name is also accepted."
@@ -29,7 +29,11 @@ export const ModelSchema = z
           'e.g. "https://api.novita.ai/openai/v1". Omit to use the provider default.'
       ),
   })
-  .describe("LLM model configuration for the agent.");
+  .describe(
+    "LLM model configuration for the agent. Credentials must be set as an " +
+      "environment variable depending on provider, e.g. OPENAI_API_KEY is " +
+      'required when provider is "openai-api".'
+  );
 
 export type Model = z.infer<typeof ModelSchema>;
 


### PR DESCRIPTION
## Summary
- Documents that LLM credentials must be set via a provider-specific environment variable (e.g. `OPENAI_API_KEY` for `openai-api`) in `ModelSchema`'s description, so LLM-driven config generation surfaces this requirement.
- Syncs `ModelProviderSchema`'s enum with the providers documented at hermes-agent.nousresearch.com/docs/integrations/providers: renames `openai` to `openai-api`, adds `zai`, `kimi-coding`, and `ollama-cloud`, drops `novita`, and orders all values by their position in the doc's provider table.

## Test plan
- [x] `pnpm format:check` — confirmed no new formatting issues introduced by these changes (pre-existing repo-wide formatting drift in unrelated lines/files is untouched)
- [ ] `pnpm lint` — could not run in this environment (partial `node_modules` install missing the `eslint` binary); should be run in CI or a fully installed environment