### PR TITLE
feat: enforce and propagate webhook config for Hermes agents

### DIFF
--- a/apps/dashboard/src/entities/agent.test.ts
+++ b/apps/dashboard/src/entities/agent.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+
+import { AgentInputSchema } from "./agent";
+
+function makeInput(overrides: Record<string, unknown> = {}) {
+  return {
+    config: { platforms: { webhook: { enabled: true } } },
+    ...overrides,
+  };
+}
+
+describe("AgentInputSchema webhook secret validation", () => {
+  it("fails when webhook is enabled and env is missing", () => {
+    const result = AgentInputSchema.safeParse(makeInput());
+    expect(result.success).toBe(false);
+  });
+
+  it("fails when webhook is enabled and env lacks a sensitive WEBHOOK_SECRET", () => {
+    const result = AgentInputSchema.safeParse(
+      makeInput({ env: [{ name: "WEBHOOK_SECRET", value: "shh" }] })
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it("succeeds when webhook is enabled and env has a sensitive WEBHOOK_SECRET", () => {
+    const result = AgentInputSchema.safeParse(
+      makeInput({ env: [{ name: "WEBHOOK_SECRET", value: "shh", sensitive: true }] })
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("succeeds when webhook is disabled regardless of env", () => {
+    const result = AgentInputSchema.safeParse({
+      config: { platforms: { webhook: { enabled: false } } },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("succeeds when webhook config is omitted entirely", () => {
+    const result = AgentInputSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+});

--- a/apps/dashboard/src/entities/agent.ts
+++ b/apps/dashboard/src/entities/agent.ts
@@ -68,7 +68,7 @@ export const SelfConfigureSchema = z
 
 export type SelfConfigure = z.infer<typeof SelfConfigureSchema>;
 
-export const AgentInputSchema = z.object({
+const AgentInputObjectSchema = z.object({
   name: z.string().optional(),
   description: z.string().optional(),
   type: z.string().optional(),
@@ -78,6 +78,19 @@ export const AgentInputSchema = z.object({
   plugins: PluginsSchema,
   sharedEnvSets: z.array(z.string()).optional(),
   env: EnvSchema,
+});
+
+export const AgentInputSchema = AgentInputObjectSchema.superRefine((data, ctx) => {
+  if (data.config?.platforms?.webhook?.enabled !== true) return;
+  const hasSecret = data.env?.some((v) => v.name === "WEBHOOK_SECRET" && v.sensitive === true);
+  if (!hasSecret) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message:
+        'Env var "WEBHOOK_SECRET" (sensitive) is required when config.platforms.webhook.enabled is true.',
+      path: ["env"],
+    });
+  }
 });
 
 export type AgentInput = z.infer<typeof AgentInputSchema>;
@@ -92,7 +105,7 @@ export const AgentPhaseSchema = z.enum([
 ]);
 export type AgentPhase = z.infer<typeof AgentPhaseSchema>;
 
-export const AgentSchema = AgentInputSchema.extend({
+export const AgentSchema = AgentInputObjectSchema.extend({
   id: z.string().min(1),
   userId: z.string().min(1),
   suspended: z.boolean().optional(),

--- a/apps/dashboard/src/entities/hermes-config.ts
+++ b/apps/dashboard/src/entities/hermes-config.ts
@@ -96,10 +96,7 @@ export const WebhookSchema = z
     enabled: z
       .boolean()
       .optional()
-      .describe(
-        "Whether the webhook server is enabled. The WEBHOOK_ENABLED=true environment " +
-          "variable is already injected into the agent, so omit this unless disabling."
-      ),
+      .describe("Whether the webhook server is enabled."),
     extra: z
       .looseObject({
         port: z
@@ -107,15 +104,7 @@ export const WebhookSchema = z
           .int()
           .optional()
           .describe(
-            "Port the webhook server listens on. The WEBHOOK_PORT environment variable is " +
-              "already injected, so omit this unless a different port is needed."
-          ),
-        secret: z
-          .string()
-          .optional()
-          .describe(
-            "Global fallback HMAC secret for routes without their own. Omit this: an " +
-              "auto-generated WEBHOOK_SECRET environment variable is already injected into the agent."
+            "Port the webhook server listens on. Defaults to 8644; omit this unless a different port is needed."
           ),
         rate_limit: z
           .number()
@@ -133,7 +122,10 @@ export const WebhookSchema = z
       .optional()
       .describe("Webhook server settings."),
   })
-  .describe("Webhook messaging platform configuration.");
+  .describe(
+    "Webhook messaging platform configuration. Requires the WEBHOOK_SECRET environment " +
+      "variable to be set when enabled=true."
+  );
 
 export type Webhook = z.infer<typeof WebhookSchema>;
 

--- a/apps/dashboard/src/entities/hermes-config.ts
+++ b/apps/dashboard/src/entities/hermes-config.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 // Config schema for LLM structured output: descriptions guide generation accuracy.
 // Fields not defined here are still allowed (loose objects) so users can configure
-// whatever the Hermes agent supports. 
+// whatever the Hermes agent supports.
 export const ModelProviderSchema = z
   .union([z.enum(["novita", "openai", "anthropic", "openrouter"]), z.string()])
   .describe(
@@ -34,10 +34,7 @@ export const ModelSchema = z
 export type Model = z.infer<typeof ModelSchema>;
 
 export const WebhookDeliverSchema = z
-  .union([
-    z.enum(["log", "github_comment", "telegram", "discord", "slack", "email"]),
-    z.string(),
-  ])
+  .union([z.enum(["log", "github_comment", "telegram", "discord", "slack", "email"]), z.string()])
   .describe(
     "Destination for the response. Common targets are enumerated; other platform names " +
       '(e.g. "signal", "matrix", "whatsapp") are also accepted. Defaults to "log".'
@@ -93,10 +90,7 @@ export type WebhookRoute = z.infer<typeof WebhookRouteSchema>;
 
 export const WebhookSchema = z
   .looseObject({
-    enabled: z
-      .boolean()
-      .optional()
-      .describe("Whether the webhook server is enabled."),
+    enabled: z.boolean().optional().describe("Whether the webhook server is enabled."),
     extra: z
       .looseObject({
         port: z
@@ -106,10 +100,7 @@ export const WebhookSchema = z
           .describe(
             "Port the webhook server listens on. Defaults to 8644; omit this unless a different port is needed."
           ),
-        rate_limit: z
-          .number()
-          .optional()
-          .describe("Maximum requests per minute. Defaults to 30."),
+        rate_limit: z.number().optional().describe("Maximum requests per minute. Defaults to 30."),
         max_body_bytes: z
           .number()
           .optional()
@@ -139,9 +130,7 @@ export type Platforms = z.infer<typeof PlatformsSchema>;
 
 export const ConfigSchema = z
   .looseObject({
-    model: ModelSchema.optional().describe(
-      "Model configuration to use."
-    ),
+    model: ModelSchema.optional().describe("Model configuration to use."),
     platforms: PlatformsSchema.optional(),
   })
   .optional()

--- a/apps/dashboard/src/server/infras/kubernetes/client.test.ts
+++ b/apps/dashboard/src/server/infras/kubernetes/client.test.ts
@@ -107,6 +107,32 @@ describe("agentToHermesAgent workspace.dotEnv wiring", () => {
   });
 });
 
+describe("agentToHermesAgent config.webhook wiring", () => {
+  it("maps enabled and extra.port, and derives secretRef when enabled", () => {
+    const hermesAgent = agentToHermesAgent(
+      makeAgent({ config: { platforms: { webhook: { enabled: true, extra: { port: 8644 } } } } })
+    );
+    expect(hermesAgent.spec.hermes?.config?.webhook).toEqual({
+      enabled: true,
+      port: 8644,
+      secretRef: { name: "agent-1-dot-env", key: "WEBHOOK_SECRET" },
+    });
+  });
+
+  it("omits secretRef when webhook is disabled", () => {
+    const hermesAgent = agentToHermesAgent(
+      makeAgent({ config: { platforms: { webhook: { enabled: false } } } })
+    );
+    expect(hermesAgent.spec.hermes?.config?.webhook).toEqual({ enabled: false });
+  });
+
+  it("leaves config.webhook undefined when there's no platforms.webhook", () => {
+    const hermesAgent = agentToHermesAgent(makeAgent({ config: { platforms: {} } }));
+    expect(hermesAgent.spec.hermes?.config?.webhook).toBeUndefined();
+    expect(hermesAgent.spec.hermes?.config?.raw).toEqual({ platforms: {} });
+  });
+});
+
 describe("agentToHermesAgent podAnnotations wiring", () => {
   it("stamps an env-hash annotation derived from agent.env", () => {
     const env = [{ name: "REGION", value: "us-east-1" }];

--- a/apps/dashboard/src/server/infras/kubernetes/client.ts
+++ b/apps/dashboard/src/server/infras/kubernetes/client.ts
@@ -152,6 +152,16 @@ export function agentToHermesAgent(agent: Agent): HermesAgent {
   const hermes: Partial<HermesAgentSpec["hermes"]> = {};
   if (agent.config !== undefined) {
     hermes.config = { raw: agent.config };
+    const webhook = agent.config.platforms?.webhook;
+    if (webhook !== undefined) {
+      hermes.config.webhook = {
+        ...(webhook.enabled !== undefined && { enabled: webhook.enabled }),
+        ...(webhook.extra?.port !== undefined && { port: webhook.extra.port }),
+        ...(webhook.enabled === true && {
+          secretRef: { name: agentEnvResourceName(agent.id), key: "WEBHOOK_SECRET" },
+        }),
+      };
+    }
   }
   if (agent.sharedEnvSets !== undefined) {
     hermes.envFrom = agent.sharedEnvSets.map((name) => ({ secretRef: { name } }));


### PR DESCRIPTION
## Summary
- Simplify `WebhookSchema` descriptions in `hermes-config.ts`: drop the redundant `secret`/`extra.secret` fields, remove internal env var names (`WEBHOOK_ENABLED`, `WEBHOOK_PORT`) from field descriptions, and document that `WEBHOOK_SECRET` is required when `webhook.enabled=true`.
- Add a Zod `superRefine` on `AgentInputSchema` that enforces a sensitive `WEBHOOK_SECRET` env var exists whenever `config.platforms.webhook.enabled=true`, so misconfigured agents fail validation at create/update time instead of deploying with a broken webhook.
- Map `agent.config.platforms.webhook` into the HermesAgent CR's structured `spec.hermes.config.webhook` field (`enabled`, `port`, `secretRef`) in `client.ts`, so the operator actually receives these fields in structured form (previously only the opaque `config.raw` blob carried them). `secretRef` points at the agent's own per-agent env Secret + `WEBHOOK_SECRET` key.

## Test plan
- [x] `vitest run` in `apps/dashboard` — all new and existing tests pass (40/40; one unrelated pre-existing suite failure locally due to a missing `HERMEUM_DATABASE_URL` env var, not caused by this change)
- [x] `pnpm --filter dashboard typecheck` — clean
- [x] `pnpm --filter dashboard lint` — no new issues (one pre-existing unrelated error in `template.ts`)
- [x] `pnpm format:check` — all changed files match Prettier style