### PR TITLE
feat: map api_server config to HermesAgent config.apiServer

### DIFF
--- a/apps/dashboard/src/entities/agent.test.ts
+++ b/apps/dashboard/src/entities/agent.test.ts
@@ -41,3 +41,36 @@ describe("AgentInputSchema webhook secret validation", () => {
     expect(result.success).toBe(true);
   });
 });
+
+describe("AgentInputSchema api server key validation", () => {
+  function makeApiServerInput(overrides: Record<string, unknown> = {}) {
+    return {
+      config: { api_server: { enabled: true } },
+      ...overrides,
+    };
+  }
+
+  it("fails when the api server is enabled and env is missing", () => {
+    const result = AgentInputSchema.safeParse(makeApiServerInput());
+    expect(result.success).toBe(false);
+  });
+
+  it("fails when the api server is enabled and env lacks a sensitive API_SERVER_KEY", () => {
+    const result = AgentInputSchema.safeParse(
+      makeApiServerInput({ env: [{ name: "API_SERVER_KEY", value: "shh" }] })
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it("succeeds when the api server is enabled and env has a sensitive API_SERVER_KEY", () => {
+    const result = AgentInputSchema.safeParse(
+      makeApiServerInput({ env: [{ name: "API_SERVER_KEY", value: "shh", sensitive: true }] })
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("succeeds when the api server is disabled regardless of env", () => {
+    const result = AgentInputSchema.safeParse({ config: { api_server: { enabled: false } } });
+    expect(result.success).toBe(true);
+  });
+});

--- a/apps/dashboard/src/entities/agent.ts
+++ b/apps/dashboard/src/entities/agent.ts
@@ -81,15 +81,21 @@ const AgentInputObjectSchema = z.object({
 });
 
 export const AgentInputSchema = AgentInputObjectSchema.superRefine((data, ctx) => {
-  if (data.config?.platforms?.webhook?.enabled !== true) return;
-  const hasSecret = data.env?.some((v) => v.name === "WEBHOOK_SECRET" && v.sensitive === true);
-  if (!hasSecret) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message:
-        'Env var "WEBHOOK_SECRET" (sensitive) is required when config.platforms.webhook.enabled is true.',
-      path: ["env"],
-    });
+  const requireSensitiveEnv = (name: string, enabledPath: string) => {
+    const hasVar = data.env?.some((v) => v.name === name && v.sensitive === true);
+    if (!hasVar) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Env var "${name}" (sensitive) is required when ${enabledPath} is true.`,
+        path: ["env"],
+      });
+    }
+  };
+  if (data.config?.platforms?.webhook?.enabled === true) {
+    requireSensitiveEnv("WEBHOOK_SECRET", "config.platforms.webhook.enabled");
+  }
+  if (data.config?.api_server?.enabled === true) {
+    requireSensitiveEnv("API_SERVER_KEY", "config.api_server.enabled");
   }
 });
 

--- a/apps/dashboard/src/entities/hermes-config.ts
+++ b/apps/dashboard/src/entities/hermes-config.ts
@@ -135,9 +135,10 @@ export const PlatformsSchema = z
 
 export type Platforms = z.infer<typeof PlatformsSchema>;
 
-// config.yaml support for the API server isn't officially released upstream yet (only
-// env vars are documented), but it's added here so Hermeum can generate declarative
-// agent config ahead of that release.
+// The Hermes agent has no api_server section in config.yaml (the API server is
+// configured via env vars upstream), so this field is never written to the raw
+// agent config. It maps to the HermesAgent CR's config.apiServer field, which the
+// operator turns into API_SERVER_* environment variables.
 export const ApiServerSchema = z
   .looseObject({
     enabled: z
@@ -155,13 +156,6 @@ export const ApiServerSchema = z
         "HTTP server port. Corresponds to the API_SERVER_PORT environment variable. " +
           "Defaults to 8642."
       ),
-    host: z
-      .string()
-      .optional()
-      .describe(
-        "Bind address. Corresponds to the API_SERVER_HOST environment variable. " +
-          "Defaults to 127.0.0.1 (localhost only)."
-      ),
     cors_origins: z
       .array(z.string())
       .optional()
@@ -171,8 +165,8 @@ export const ApiServerSchema = z
       ),
   })
   .describe(
-    "API server configuration. The bearer auth token (API_SERVER_KEY) is a credential " +
-      "and must be set via the agent's env vars (marked sensitive), not here."
+    "API server configuration. Requires the API_SERVER_KEY environment variable " +
+      "(the bearer auth token, marked sensitive) to be set when enabled=true."
   );
 
 export type ApiServer = z.infer<typeof ApiServerSchema>;

--- a/apps/dashboard/src/server/infras/kubernetes/client.test.ts
+++ b/apps/dashboard/src/server/infras/kubernetes/client.test.ts
@@ -4,6 +4,7 @@ import {
   agentEnvResourceName,
   agentToHermesAgent,
   hashAgentEnv,
+  mapHermesConfig,
   maskSensitiveEnv,
   splitAgentEnv,
 } from "./client";
@@ -130,6 +131,75 @@ describe("agentToHermesAgent config.webhook wiring", () => {
     const hermesAgent = agentToHermesAgent(makeAgent({ config: { platforms: {} } }));
     expect(hermesAgent.spec.hermes?.config?.webhook).toBeUndefined();
     expect(hermesAgent.spec.hermes?.config?.raw).toEqual({ platforms: {} });
+  });
+});
+
+describe("agentToHermesAgent config.apiServer wiring", () => {
+  it("maps api_server fields, derives existingSecret when enabled, and strips it from raw", () => {
+    const hermesAgent = agentToHermesAgent(
+      makeAgent({
+        config: {
+          model: { provider: "anthropic", default: "claude-sonnet-5" },
+          api_server: { enabled: true, port: 8642, cors_origins: ["https://app.example.com"] },
+        },
+      })
+    );
+    expect(hermesAgent.spec.hermes?.config?.apiServer).toEqual({
+      enabled: true,
+      port: 8642,
+      corsOrigins: ["https://app.example.com"],
+      existingSecret: { name: "agent-1-dot-env", key: "API_SERVER_KEY" },
+    });
+    expect(hermesAgent.spec.hermes?.config?.raw).toEqual({
+      model: { provider: "anthropic", default: "claude-sonnet-5" },
+    });
+  });
+
+  it("omits existingSecret when the api server is disabled", () => {
+    const hermesAgent = agentToHermesAgent(
+      makeAgent({ config: { api_server: { enabled: false } } })
+    );
+    expect(hermesAgent.spec.hermes?.config?.apiServer).toEqual({ enabled: false });
+    expect(hermesAgent.spec.hermes?.config?.raw).toEqual({});
+  });
+
+  it("leaves config.apiServer undefined when there's no api_server", () => {
+    const hermesAgent = agentToHermesAgent(makeAgent({ config: { platforms: {} } }));
+    expect(hermesAgent.spec.hermes?.config?.apiServer).toBeUndefined();
+    expect(hermesAgent.spec.hermes?.config?.raw).toEqual({ platforms: {} });
+  });
+});
+
+describe("mapHermesConfig", () => {
+  it("folds apiServer back into config as snake_case api_server without existingSecret", () => {
+    expect(
+      mapHermesConfig({
+        raw: { platforms: {} },
+        apiServer: {
+          enabled: true,
+          port: 8642,
+          corsOrigins: ["https://app.example.com"],
+          existingSecret: { name: "agent-1-dot-env", key: "API_SERVER_KEY" },
+        },
+      })
+    ).toEqual({
+      platforms: {},
+      api_server: { enabled: true, port: 8642, cors_origins: ["https://app.example.com"] },
+    });
+  });
+
+  it("returns raw unchanged when apiServer is absent", () => {
+    expect(mapHermesConfig({ raw: { platforms: {} } })).toEqual({ platforms: {} });
+    expect(mapHermesConfig(undefined)).toBeUndefined();
+  });
+
+  it("round-trips an agent config through the CR", () => {
+    const config = {
+      model: { provider: "anthropic", default: "claude-sonnet-5" },
+      api_server: { enabled: true, port: 8642 },
+    };
+    const hermesAgent = agentToHermesAgent(makeAgent({ config }));
+    expect(mapHermesConfig(hermesAgent.spec.hermes?.config)).toEqual(config);
   });
 });
 

--- a/apps/dashboard/src/server/infras/kubernetes/client.ts
+++ b/apps/dashboard/src/server/infras/kubernetes/client.ts
@@ -21,7 +21,7 @@ import {
   Runtime,
   SharedEnvSetPatch,
 } from "../../usecases/adaptors/runtime";
-import { HermesAgent, HermesAgentList, HermesAgentSpec } from "./types/hermes-agent";
+import { HermesAgent, HermesAgentList, HermesAgentSpec, HermesConfig } from "./types/hermes-agent";
 
 const enum HermesGroup {
   Default = "agents.hermeum.app",
@@ -151,7 +151,20 @@ export function agentToHermesAgent(agent: Agent): HermesAgent {
 
   const hermes: Partial<HermesAgentSpec["hermes"]> = {};
   if (agent.config !== undefined) {
-    hermes.config = { raw: agent.config };
+    // The Hermes agent has no api_server section in config.yaml — it belongs to
+    // the CR's dedicated config.apiServer field, so keep it out of raw.
+    const { api_server: apiServer, ...rawConfig } = agent.config;
+    hermes.config = { raw: rawConfig };
+    if (apiServer !== undefined) {
+      hermes.config.apiServer = {
+        ...(apiServer.enabled !== undefined && { enabled: apiServer.enabled }),
+        ...(apiServer.port !== undefined && { port: apiServer.port }),
+        ...(apiServer.cors_origins !== undefined && { corsOrigins: apiServer.cors_origins }),
+        ...(apiServer.enabled === true && {
+          existingSecret: { name: agentEnvResourceName(agent.id), key: "API_SERVER_KEY" },
+        }),
+      };
+    }
     const webhook = agent.config.platforms?.webhook;
     if (webhook !== undefined) {
       hermes.config.webhook = {
@@ -201,6 +214,24 @@ export function agentToHermesAgent(agent: Agent): HermesAgent {
   };
 }
 
+// Rebuild the agent config from the CR: api_server lives in the dedicated
+// config.apiServer field (not raw), so fold it back in for round-tripping.
+// existingSecret is derived from the agent id at build time and is not mapped back.
+export function mapHermesConfig(config: HermesConfig | undefined): Agent["config"] {
+  const apiServer = config?.apiServer;
+  if (apiServer === undefined) {
+    return config?.raw;
+  }
+  return {
+    ...config?.raw,
+    api_server: {
+      ...(apiServer.enabled !== undefined && { enabled: apiServer.enabled }),
+      ...(apiServer.port !== undefined && { port: apiServer.port }),
+      ...(apiServer.corsOrigins !== undefined && { cors_origins: apiServer.corsOrigins }),
+    },
+  };
+}
+
 export function mapHermesAgent(raw: HermesAgent): Agent {
   return {
     id: raw.metadata?.name ?? "",
@@ -208,7 +239,7 @@ export function mapHermesAgent(raw: HermesAgent): Agent {
     name: raw.metadata?.annotations?.[HermeumAnnotation.Name],
     description: raw.metadata?.annotations?.[HermeumAnnotation.Description],
     type: raw.metadata?.annotations?.[HermeumAnnotation.Type],
-    config: raw.spec.hermes?.config?.raw,
+    config: mapHermesConfig(raw.spec.hermes?.config),
     sharedEnvSets: raw.spec.hermes?.envFrom?.flatMap((e) =>
       e.secretRef?.name ? [e.secretRef.name] : []
     ),


### PR DESCRIPTION
## What

Maps the dashboard's `api_server` agent config (added in #21) to the HermesAgent CR's dedicated `spec.hermes.config.apiServer` field, and removes it from `config.raw`.

## Why

`config.raw` is written verbatim as the Hermes agent's config.yaml, but the agent has no `api_server` section there — the API server is configured purely via `API_SERVER_*` env vars, which the operator derives from `config.apiServer`. Leaving `api_server` in `raw` would inject a key the agent doesn't understand while never actually configuring the API server.

## Changes

- **`client.ts`**: `agentToHermesAgent()` strips `api_server` out of `raw` and maps `enabled`/`port`/`cors_origins` → `apiServer.{enabled,port,corsOrigins}`. When `enabled === true`, it derives `existingSecret: { name: <agentId>-dot-env, key: API_SERVER_KEY }`, mirroring the webhook `secretRef` wiring from #22.
- **`client.ts`**: new `mapHermesConfig()` folds `apiServer` back into snake_case `api_server` on read (without the derived `existingSecret`), so config round-trips — otherwise `patchHermesAgent`'s merge would silently drop the API server config on unrelated patches.
- **`agent.ts`**: `AgentInputSchema` now requires a sensitive `API_SERVER_KEY` env var when `api_server.enabled` is true, same enforcement pattern as `WEBHOOK_SECRET`.
- **`hermes-config.ts`**: dropped the `host` field — the operator hardcodes `API_SERVER_HOST=0.0.0.0` (required for Service routing) and the CR has no host field. Updated the stale comment and the schema description accordingly.

## Notes for reviewers

- Webhook config intentionally stays in `raw` (it is valid config.yaml); only `api_server` is stripped.
- Verified: 31/31 vitest tests pass, `tsc --noEmit` clean. The root `pnpm lint` failure (`@hermeum/components` missing eslint) and the `template.ts` unused-var error are pre-existing on `main`.