### PR TITLE
Improve create-agent Quick start flow and Describe UX

### DIFF
--- a/apps/dashboard/src/client/ui/components/create-agent-dialog.tsx
+++ b/apps/dashboard/src/client/ui/components/create-agent-dialog.tsx
@@ -2,6 +2,8 @@ import { useState } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { Document, parse, Scalar } from "yaml";
 
+import { LoaderCircle } from "lucide-react";
+
 import { cn } from "@hermeum/components/lib/utils";
 import {
   Collapsible,
@@ -92,7 +94,7 @@ export function CreateAgentDialog({ open, onOpenChange, onSuccess }: CreateAgent
         setEditorValue(stringifyAgentInput(agentInput));
         setSelectedTemplateId(null);
         setValidationError(null);
-        setSelectedName(agentInput.name);
+        setSelectedName(agentInput.name ?? null);
         setQuickStartOpen(false);
       },
       onError: (error) => {
@@ -183,6 +185,12 @@ export function CreateAgentDialog({ open, onOpenChange, onSuccess }: CreateAgent
                     <Textarea
                       value={description}
                       onChange={(e) => setDescription(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
+                          e.preventDefault();
+                          handleGenerate();
+                        }
+                      }}
                       placeholder="Reviews new pull requests and leaves inline comments on risky changes."
                       className="min-h-24 border-transparent px-0 py-0 focus-visible:border-transparent"
                     />
@@ -193,6 +201,7 @@ export function CreateAgentDialog({ open, onOpenChange, onSuccess }: CreateAgent
                         onClick={handleGenerate}
                         disabled={description.trim().length === 0 || isGenerating}
                       >
+                        {isGenerating && <LoaderCircle className="animate-spin" />}
                         {isGenerating ? "Generating…" : "Generate"}
                       </Button>
                     </div>

--- a/apps/dashboard/src/client/ui/components/create-agent-dialog.tsx
+++ b/apps/dashboard/src/client/ui/components/create-agent-dialog.tsx
@@ -69,6 +69,7 @@ export function CreateAgentDialog({ open, onOpenChange, onSuccess }: CreateAgent
   const [quickStartOpen, setQuickStartOpen] = useState(true);
   const [quickStartTab, setQuickStartTab] = useState<"describe" | "template">("describe");
   const [description, setDescription] = useState("");
+  const [selectedName, setSelectedName] = useState<string | null>(null);
 
   const { data: templates } = useQuery(trpc.template.list.queryOptions());
 
@@ -91,6 +92,8 @@ export function CreateAgentDialog({ open, onOpenChange, onSuccess }: CreateAgent
         setEditorValue(stringifyAgentInput(agentInput));
         setSelectedTemplateId(null);
         setValidationError(null);
+        setSelectedName(agentInput.name);
+        setQuickStartOpen(false);
       },
       onError: (error) => {
         toast.error(error.message);
@@ -106,6 +109,7 @@ export function CreateAgentDialog({ open, onOpenChange, onSuccess }: CreateAgent
       setQuickStartOpen(true);
       setQuickStartTab("describe");
       setDescription("");
+      setSelectedName(null);
     }
     onOpenChange(nextOpen);
   }
@@ -113,6 +117,8 @@ export function CreateAgentDialog({ open, onOpenChange, onSuccess }: CreateAgent
   function handleSelectTemplate(template: Template) {
     setSelectedTemplateId(template.id);
     setEditorValue(stringifyAgentInput(template.agentInput));
+    setSelectedName(template.name);
+    setQuickStartOpen(false);
   }
 
   function handleGenerate() {
@@ -153,7 +159,14 @@ export function CreateAgentDialog({ open, onOpenChange, onSuccess }: CreateAgent
           {/* Starting point section */}
           <Collapsible open={quickStartOpen} onOpenChange={setQuickStartOpen}>
             <CollapsibleTrigger>
-              <span>Quick start</span>
+              <span className="flex min-w-0 items-baseline gap-1.5">
+                <span>Quick start</span>
+                {selectedName && (
+                  <span className="truncate font-normal text-muted-foreground">
+                    · {selectedName}
+                  </span>
+                )}
+              </span>
             </CollapsibleTrigger>
             <CollapsibleContent className="pb-2">
               <Tabs


### PR DESCRIPTION
## Summary
- Auto-collapses the "Quick start" section in the Create Agent dialog once a template is selected or an agent config is generated, and shows the chosen name next to the header so the selection stays visible after collapsing.
- Pressing `Enter` in the "Describe your agent" textarea now triggers generation directly; `Shift+Enter` still inserts a newline (IME composition is respected).
- The "Generate" button shows a spinning indicator while a generation request is in flight.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `eslint` passes on the changed file
- [x] Manually verify in the browser: select a template → Quick start collapses and shows the template name; generate via Describe tab → Quick start collapses and shows the generated name; Enter submits the Describe textarea, Shift+Enter inserts a newline; Generate button shows a spinner while pending