### PR TITLE
feat: reject unfilled env <fill-me> placeholder on agent create/update

### DIFF
--- a/apps/dashboard/src/client/ui/components/edit-agent-dialog.tsx
+++ b/apps/dashboard/src/client/ui/components/edit-agent-dialog.tsx
@@ -4,7 +4,7 @@ import { stringify, parse } from "yaml";
 import { toast } from "sonner";
 import { useTRPC } from "@/router";
 import type { Agent } from "@/entities";
-import { AgentInputSchema } from "@/entities";
+import { AgentInputObjectSchema, AgentInputSchema } from "@/entities";
 import { CodeEditor } from "@/client/ui/components/code-editor";
 import { Button } from "@hermeum/components/ui/button";
 import {
@@ -24,7 +24,7 @@ interface EditInstanceDialogProps {
 }
 
 function agentToYaml(agent: Agent): string {
-  return stringify(AgentInputSchema.parse(agent)).trim();
+  return stringify(AgentInputObjectSchema.parse(agent)).trim();
 }
 
 export function EditInstanceDialog({ instance, open, onOpenChange }: EditInstanceDialogProps) {

--- a/apps/dashboard/src/entities/agent.test.ts
+++ b/apps/dashboard/src/entities/agent.test.ts
@@ -76,6 +76,22 @@ describe("AgentInputSchema api server key validation", () => {
   });
 });
 
+describe("AgentInputSchema env placeholder validation", () => {
+  it("fails when an env var still has the fill-me placeholder value", () => {
+    const result = AgentInputSchema.safeParse({
+      env: [{ name: "API_KEY", value: "<fill-me>", sensitive: true }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("succeeds when env values are real, non-placeholder strings", () => {
+    const result = AgentInputSchema.safeParse({
+      env: [{ name: "API_KEY", value: "sk-real-value", sensitive: true }],
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
 describe("AgentInputObjectSchema as LLM structured-output schema", () => {
   it("accepts a representative generated payload", () => {
     const result = AgentInputObjectSchema.safeParse({

--- a/apps/dashboard/src/entities/agent.ts
+++ b/apps/dashboard/src/entities/agent.ts
@@ -131,6 +131,18 @@ export const AgentInputSchema = AgentInputObjectSchema.superRefine((data, ctx) =
   if (data.config?.api_server?.enabled === true) {
     requireSensitiveEnv("API_SERVER_KEY", "config.api_server.enabled");
   }
+
+  data.env?.forEach((v, i) => {
+    if (v.value === ENV_PLACEHOLDER_SENTINEL) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          `Env var "${v.name}" still has the placeholder value ` +
+          `"${ENV_PLACEHOLDER_SENTINEL}" — replace it with a real value.`,
+        path: ["env", i, "value"],
+      });
+    }
+  });
 });
 
 export type AgentInput = z.infer<typeof AgentInputSchema>;

--- a/apps/dashboard/src/server/usecases/agent.test.ts
+++ b/apps/dashboard/src/server/usecases/agent.test.ts
@@ -460,7 +460,9 @@ describe("AgentUseCase generated env scrubbing", () => {
     const result = await useCase.generateAgentInput(makeCtx(), "prompt");
 
     expect(result.env).toEqual([{ name: "WEBHOOK_SECRET", value: "<fill-me>", sensitive: true }]);
-    expect(AgentInputSchema.safeParse(result).success).toBe(true);
+    // The prefill still needs a real secret before it can be created — AgentInputSchema
+    // rejects the unfilled placeholder.
+    expect(AgentInputSchema.safeParse(result).success).toBe(false);
   });
 
   it("appends a sensitive API_SERVER_KEY when the api server is enabled but missing", async () => {
@@ -472,7 +474,9 @@ describe("AgentUseCase generated env scrubbing", () => {
     const result = await useCase.generateAgentInput(makeCtx(), "prompt");
 
     expect(result.env).toEqual([{ name: "API_SERVER_KEY", value: "<fill-me>", sensitive: true }]);
-    expect(AgentInputSchema.safeParse(result).success).toBe(true);
+    // The prefill still needs a real secret before it can be created — AgentInputSchema
+    // rejects the unfilled placeholder.
+    expect(AgentInputSchema.safeParse(result).success).toBe(false);
   });
 
   it("does not duplicate WEBHOOK_SECRET when already present", async () => {


### PR DESCRIPTION
## Summary
- `AgentInputSchema` (`apps/dashboard/src/entities/agent.ts`) now rejects any `env` entry whose value is still the `<fill-me>` placeholder (`ENV_PLACEHOLDER_SENTINEL`), with a message telling the user which var to fill in. Since this schema backs both agent dialogs and the server tRPC/usecase input, the check is enforced everywhere an agent is created or updated.
- `edit-agent-dialog.tsx`'s YAML-loading helper now uses the unrefined `AgentInputObjectSchema` instead of the strict `AgentInputSchema`, so opening the edit dialog for an agent that already has a legacy unfilled placeholder doesn't crash — save-time validation (already using `safeParse`) remains the actual enforcement point.
- Updated two pre-existing usecase tests that asserted generated placeholder output passed full schema validation; that assertion is now correctly `false`.

## Why
AI-generated agent configs prefill sensitive env vars (e.g. `WEBHOOK_SECRET`, `API_SERVER_KEY`) with the `<fill-me>` sentinel instead of inventing secrets. Nothing previously stopped a user from clicking "Create agent" or "Save changes" right after generation without noticing the placeholder was never replaced, silently persisting an agent with a fake secret value.

## Test plan
- [x] `npx vitest run` in `apps/dashboard` — 66 tests pass, including new placeholder-validation cases in `entities/agent.test.ts`
- [x] `pnpm format:check` — clean on touched files
- [ ] `pnpm lint` — could not run; `eslint` binary missing from `node_modules/.bin` in this environment (pre-existing, unrelated to this change)
- [ ] Manual UI verification blocked by email-based sign-in in the local preview environment