### PR TITLE
Rename dashboard browser tab title to Hermeum

### DIFF
--- a/apps/dashboard/index.html
+++ b/apps/dashboard/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>ClawAgent</title>
+    <title>Hermeum</title>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- Updated the dashboard's `<title>` from "ClawAgent" to "Hermeum" — a leftover from before the project was renamed.

## Test plan
- [x] Verified `apps/dashboard/index.html` renders "Hermeum" in the browser tab