### PR TITLE
Improve create-agent UX: soul guidance, editor overflow fix, wider dialogs

### DIFF
--- a/apps/dashboard/src/client/ui/components/code-editor.tsx
+++ b/apps/dashboard/src/client/ui/components/code-editor.tsx
@@ -1,4 +1,4 @@
-import CodeMirror from "@uiw/react-codemirror";
+import CodeMirror, { EditorView } from "@uiw/react-codemirror";
 import { yaml as yamlLang } from "@codemirror/lang-yaml";
 import { cn } from "@hermeum/components/lib/utils";
 
@@ -18,25 +18,32 @@ export function CodeEditor({
   maxHeight,
 }: CodeEditorProps) {
   return (
-    <CodeMirror
-      value={value}
-      extensions={[yamlLang()]}
-      {...(onChange !== undefined && { onChange })}
-      editable={!readOnly}
-      {...(maxHeight !== undefined && { maxHeight })}
-      style={{ wordSpacing: "2.5px" }}
-      basicSetup={{
-        lineNumbers: false,
-        foldGutter: false,
-        searchKeymap: false,
-        autocompletion: false,
-        lintKeymap: false,
-        highlightActiveLine: !readOnly,
-      }}
+    <div
       className={cn(
-        "overflow-hidden rounded-[0.25rem] border text-sm [&_.cm-content]:outline-none [&_.cm-editor.cm-focused]:outline-none [&_.cm-scroller]:font-sans! [&_.cm-line]:py-[0.15rem]!",
+        "min-w-0 overflow-hidden rounded-[0.25rem] border text-sm",
         invalid && "border-destructive"
       )}
-    />
+    >
+      <CodeMirror
+        value={value}
+        extensions={[yamlLang(), EditorView.lineWrapping]}
+        {...(onChange !== undefined && { onChange })}
+        editable={!readOnly}
+        {...(maxHeight !== undefined && { maxHeight })}
+        style={{ wordSpacing: "2.5px" }}
+        basicSetup={{
+          lineNumbers: true,
+          foldGutter: false,
+          searchKeymap: false,
+          autocompletion: false,
+          lintKeymap: false,
+          highlightActiveLine: !readOnly,
+          highlightActiveLineGutter: !readOnly,
+        }}
+        className={cn(
+          "[&_.cm-content]:outline-none [&_.cm-editor.cm-focused]:outline-none [&_.cm-scroller]:font-sans! [&_.cm-line]:py-[0.15rem]! [&_.cm-gutters]:border-r-0! [&_.cm-gutters]:bg-transparent! [&_.cm-gutterElement]:pl-3! [&_.cm-gutterElement]:pr-2! [&_.cm-gutterElement]:text-muted-foreground/60"
+        )}
+      />
+    </div>
   );
 }

--- a/apps/dashboard/src/client/ui/components/create-agent-dialog.tsx
+++ b/apps/dashboard/src/client/ui/components/create-agent-dialog.tsx
@@ -157,7 +157,7 @@ export function CreateAgentDialog({ open, onOpenChange, onSuccess }: CreateAgent
           <DialogDescription>Start from a template or describe what you need.</DialogDescription>
         </DialogHeader>
 
-        <div className="min-h-0 flex-1 overflow-y-auto space-y-4">
+        <div className="min-h-0 min-w-0 flex-1 overflow-y-auto space-y-4">
           {/* Starting point section */}
           <Collapsible open={quickStartOpen} onOpenChange={setQuickStartOpen}>
             <CollapsibleTrigger>

--- a/apps/dashboard/src/client/ui/components/create-agent-dialog.tsx
+++ b/apps/dashboard/src/client/ui/components/create-agent-dialog.tsx
@@ -151,7 +151,7 @@ export function CreateAgentDialog({ open, onOpenChange, onSuccess }: CreateAgent
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="flex flex-col sm:max-w-xl max-h-[min(700px,calc(100dvh-4rem))]">
+      <DialogContent className="flex flex-col sm:max-w-2xl max-h-[min(700px,calc(100dvh-4rem))]">
         <DialogHeader>
           <DialogTitle>Create agent</DialogTitle>
           <DialogDescription>Start from a template or describe what you need.</DialogDescription>

--- a/apps/dashboard/src/client/ui/components/edit-agent-dialog.tsx
+++ b/apps/dashboard/src/client/ui/components/edit-agent-dialog.tsx
@@ -87,7 +87,7 @@ export function EditInstanceDialog({ instance, open, onOpenChange }: EditInstanc
           </DialogDescription>
         </DialogHeader>
 
-        <div className="min-h-0 flex-1 overflow-y-auto space-y-2">
+        <div className="min-h-0 min-w-0 flex-1 overflow-y-auto space-y-2">
           <CodeEditor
             value={editorValue}
             onChange={setEditorValue}

--- a/apps/dashboard/src/client/ui/components/edit-agent-dialog.tsx
+++ b/apps/dashboard/src/client/ui/components/edit-agent-dialog.tsx
@@ -78,7 +78,7 @@ export function EditInstanceDialog({ instance, open, onOpenChange }: EditInstanc
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="flex flex-col sm:max-w-xl max-h-[min(600px,calc(100dvh-4rem))]">
+      <DialogContent className="flex flex-col sm:max-w-2xl max-h-[min(600px,calc(100dvh-4rem))]">
         <DialogHeader>
           <DialogTitle>Edit agent</DialogTitle>
           <DialogDescription>

--- a/apps/dashboard/src/server/usecases/agent-prompt.ts
+++ b/apps/dashboard/src/server/usecases/agent-prompt.ts
@@ -15,7 +15,29 @@ explicitly.
 # Hermes agent configuration
 
 The \`config\` field holds the Hermes agent's configuration (model,
-webhooks, and so on). 
+webhooks, and so on).
+
+## Soul (soul)
+- A good soul is stable across contexts, broad enough to apply in many
+  conversations, specific enough to materially shape the voice, and focused
+  on communication and identity — not task-specific instructions.
+
+Example — "review GitHub pull requests":
+soul: |
+  # Personality
+  You are a pragmatic senior code reviewer with strong taste.
+  You optimize for correctness and clarity over politeness theater.
+
+  ## Style
+  - Be direct without being cold
+  - Push back when a change is risky
+  - Admit uncertainty plainly
+  - Keep feedback compact unless depth is useful
+
+  ## What to avoid
+  - Sycophancy and hype language
+  - Repeating the user's framing if it's wrong
+  - Overexplaining obvious things
 
 ## Model (config.model)
 - Only set config.model when the request names a specific provider or model;


### PR DESCRIPTION
## Summary
- Add a Soul section to the agent-generation system prompt so generated agents get a durable, well-structured personality (matching the Hermes personality docs' good-SOUL.md guidance) instead of generic filler.
- Fix the create/edit agent dialogs overflowing horizontally: CodeMirror now wraps long lines and shows line numbers instead of letting content push past the dialog edge, and the scroll containers guard against flex/grid width blowout.
- Widen the create/edit agent dialogs (`sm:max-w-2xl`) to give the YAML editor more room.

## Test plan
- [x] `pnpm lint` passes (only a pre-existing, unrelated error remains in `template.ts`)
- [x] Verified in browser: create-agent dialog no longer overflows horizontally, long `soul` lines wrap with line numbers shown
- [x] Verified generation end-to-end: prompting for a Kubernetes on-call agent produces a soul following the `# Personality` / `## Style` / `## What to avoid` structure