### PR TITLE
Add AI revise input to edit-agent dialog

### DIFF
--- a/apps/dashboard/src/client/ui/components/agent-yaml.ts
+++ b/apps/dashboard/src/client/ui/components/agent-yaml.ts
@@ -1,0 +1,15 @@
+import { Document, Scalar } from "yaml";
+
+import type { AgentInput } from "@/entities";
+
+// Renders `soul` as a literal block (`|`) instead of yaml's default folded
+// style (`>-`), which collapses newlines into blank-line-separated runs and
+// hard-wraps lines — unreadable for multi-paragraph markdown.
+export function stringifyAgentInput(input: AgentInput): string {
+  const doc = new Document(input);
+  const soul = doc.get("soul", true);
+  if (soul instanceof Scalar && typeof soul.value === "string") {
+    soul.type = Scalar.BLOCK_LITERAL;
+  }
+  return doc.toString().trim();
+}

--- a/apps/dashboard/src/client/ui/components/create-agent-dialog.tsx
+++ b/apps/dashboard/src/client/ui/components/create-agent-dialog.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { Document, parse, Scalar } from "yaml";
+import { parse } from "yaml";
 
 import { LoaderCircle } from "lucide-react";
 
@@ -25,21 +25,10 @@ import {
 } from "@hermeum/components/ui/dialog";
 import { toast } from "sonner";
 import { useTRPC } from "@/router";
-import type { Template, AgentInput } from "@/entities";
+import type { Template } from "@/entities";
 import { AgentInputSchema } from "@/entities";
 import { CodeEditor } from "@/client/ui/components/code-editor";
-
-// Renders `soul` as a literal block (`|`) instead of yaml's default folded
-// style (`>-`), which collapses newlines into blank-line-separated runs and
-// hard-wraps lines — unreadable for multi-paragraph markdown.
-function stringifyAgentInput(input: AgentInput): string {
-  const doc = new Document(input);
-  const soul = doc.get("soul", true);
-  if (soul instanceof Scalar && typeof soul.value === "string") {
-    soul.type = Scalar.BLOCK_LITERAL;
-  }
-  return doc.toString().trim();
-}
+import { stringifyAgentInput } from "@/client/ui/components/agent-yaml";
 
 const DEFAULT_YAML = stringifyAgentInput({
   name: "Untitled agent",

--- a/apps/dashboard/src/client/ui/components/edit-agent-dialog.tsx
+++ b/apps/dashboard/src/client/ui/components/edit-agent-dialog.tsx
@@ -133,7 +133,7 @@ export function EditInstanceDialog({ instance, open, onOpenChange }: EditInstanc
           </DialogDescription>
         </DialogHeader>
 
-        <div className="min-h-0 min-w-0 flex-1 overflow-y-auto space-y-2">
+        <div className="min-h-0 min-w-0 flex-1 overflow-y-auto space-y-2 p-px">
           <CodeEditor
             value={editorValue}
             onChange={setEditorValue}
@@ -142,36 +142,36 @@ export function EditInstanceDialog({ instance, open, onOpenChange }: EditInstanc
             maxHeight="360px"
           />
           {validationError && <p className="text-sm text-destructive">{validationError}</p>}
+        </div>
 
-          <div className="rounded-[0.25rem] border p-3">
-            <Textarea
-              value={prompt}
-              onChange={(e) => setPrompt(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
-                  e.preventDefault();
-                  handleRevise();
-                }
-              }}
-              placeholder="Ask AI to change something…"
-              className="min-h-9 border-transparent px-0 py-0 focus-visible:border-transparent"
-            />
-            <div className="flex justify-end gap-2">
-              {previousValue !== null && (
-                <Button variant="ghost" size="xs" onClick={handleUndoRevision}>
-                  Undo revision
-                </Button>
-              )}
-              <Button
-                variant="outline"
-                size="xs"
-                onClick={handleRevise}
-                disabled={prompt.trim().length === 0 || isRevising}
-              >
-                {isRevising && <LoaderCircle className="animate-spin" />}
-                {isRevising ? "Revising…" : "Revise"}
+        <div className="shrink-0 rounded-[0.25rem] border p-3">
+          <Textarea
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
+                e.preventDefault();
+                handleRevise();
+              }
+            }}
+            placeholder="Ask AI to change something…"
+            className="min-h-9 border-transparent px-0 py-0 focus-visible:border-transparent"
+          />
+          <div className="flex justify-end gap-2">
+            {previousValue !== null && (
+              <Button variant="ghost" size="xs" onClick={handleUndoRevision}>
+                Undo revision
               </Button>
-            </div>
+            )}
+            <Button
+              variant="outline"
+              size="xs"
+              onClick={handleRevise}
+              disabled={prompt.trim().length === 0 || isRevising}
+            >
+              {isRevising && <LoaderCircle className="animate-spin" />}
+              {isRevising ? "Revising…" : "Revise"}
+            </Button>
           </div>
         </div>
 

--- a/apps/dashboard/src/client/ui/components/edit-agent-dialog.tsx
+++ b/apps/dashboard/src/client/ui/components/edit-agent-dialog.tsx
@@ -1,12 +1,15 @@
 import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { stringify, parse } from "yaml";
+import { parse } from "yaml";
 import { toast } from "sonner";
+import { LoaderCircle } from "lucide-react";
 import { useTRPC } from "@/router";
-import type { Agent } from "@/entities";
+import type { Agent, AgentInput } from "@/entities";
 import { AgentInputObjectSchema, AgentInputSchema } from "@/entities";
 import { CodeEditor } from "@/client/ui/components/code-editor";
+import { stringifyAgentInput } from "@/client/ui/components/agent-yaml";
 import { Button } from "@hermeum/components/ui/button";
+import { Textarea } from "@hermeum/components/ui/textarea";
 import {
   Dialog,
   DialogClose,
@@ -24,7 +27,7 @@ interface EditInstanceDialogProps {
 }
 
 function agentToYaml(agent: Agent): string {
-  return stringify(AgentInputObjectSchema.parse(agent)).trim();
+  return stringifyAgentInput(AgentInputObjectSchema.parse(agent));
 }
 
 export function EditInstanceDialog({ instance, open, onOpenChange }: EditInstanceDialogProps) {
@@ -32,6 +35,8 @@ export function EditInstanceDialog({ instance, open, onOpenChange }: EditInstanc
   const queryClient = useQueryClient();
   const [editorValue, setEditorValue] = useState(() => agentToYaml(instance));
   const [validationError, setValidationError] = useState<string | null>(null);
+  const [prompt, setPrompt] = useState("");
+  const [previousValue, setPreviousValue] = useState<string | null>(null);
 
   const { mutate: updateAgent, isPending: isUpdating } = useMutation(
     trpc.agent.update.mutationOptions({
@@ -47,33 +52,74 @@ export function EditInstanceDialog({ instance, open, onOpenChange }: EditInstanc
     })
   );
 
+  const { mutate: reviseAgent, isPending: isRevising } = useMutation(
+    trpc.agentConfig.update.mutationOptions({
+      onSuccess: (revised) => {
+        setPreviousValue(editorValue);
+        setEditorValue(stringifyAgentInput(revised));
+        setPrompt("");
+        setValidationError(null);
+      },
+      onError: (error) => {
+        toast.error(error.message);
+      },
+    })
+  );
+
   function handleOpenChange(nextOpen: boolean) {
     if (!nextOpen) {
       setEditorValue(agentToYaml(instance));
       setValidationError(null);
+      setPrompt("");
+      setPreviousValue(null);
     }
     onOpenChange(nextOpen);
   }
 
-  function handleSave() {
-    let parsed: Record<string, unknown>;
+  // Parses the editor content, surfacing errors via `validationError`.
+  // `schema` differs by caller: revise accepts drafts (object schema only),
+  // save requires the full refined schema.
+  function parseEditor(
+    schema: typeof AgentInputObjectSchema | typeof AgentInputSchema
+  ): AgentInput | null {
+    let parsed: unknown;
     try {
-      parsed = (parse(editorValue) ?? {}) as Record<string, unknown>;
+      parsed = parse(editorValue) ?? {};
     } catch (e) {
       setValidationError(e instanceof Error ? e.message : "Invalid YAML");
-      return;
+      return null;
     }
 
-    const result = AgentInputSchema.safeParse(parsed);
+    const result = schema.safeParse(parsed);
     if (!result.success) {
       const issue = result.error.issues[0]!;
       const path = issue.path.length > 0 ? `/${issue.path.join("/")}` : "";
       setValidationError(`${issue.message} (path: ${path})`);
-      return;
+      return null;
     }
 
     setValidationError(null);
-    updateAgent({ id: instance.id, ...parsed });
+    return result.data;
+  }
+
+  function handleRevise() {
+    if (prompt.trim().length === 0 || isRevising) return;
+    const config = parseEditor(AgentInputObjectSchema);
+    if (!config) return;
+    reviseAgent({ prompt: prompt.trim(), config });
+  }
+
+  function handleUndoRevision() {
+    if (previousValue === null) return;
+    setEditorValue(previousValue);
+    setPreviousValue(null);
+    setValidationError(null);
+  }
+
+  function handleSave() {
+    const config = parseEditor(AgentInputSchema);
+    if (!config) return;
+    updateAgent({ id: instance.id, ...config });
   }
 
   return (
@@ -91,15 +137,47 @@ export function EditInstanceDialog({ instance, open, onOpenChange }: EditInstanc
           <CodeEditor
             value={editorValue}
             onChange={setEditorValue}
+            readOnly={isRevising}
             invalid={!!validationError}
-            maxHeight="420px"
+            maxHeight="360px"
           />
           {validationError && <p className="text-sm text-destructive">{validationError}</p>}
+
+          <div className="rounded-[0.25rem] border p-3">
+            <Textarea
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
+                  e.preventDefault();
+                  handleRevise();
+                }
+              }}
+              placeholder="Ask AI to change something…"
+              className="min-h-9 border-transparent px-0 py-0 focus-visible:border-transparent"
+            />
+            <div className="flex justify-end gap-2">
+              {previousValue !== null && (
+                <Button variant="ghost" size="xs" onClick={handleUndoRevision}>
+                  Undo revision
+                </Button>
+              )}
+              <Button
+                variant="outline"
+                size="xs"
+                onClick={handleRevise}
+                disabled={prompt.trim().length === 0 || isRevising}
+              >
+                {isRevising && <LoaderCircle className="animate-spin" />}
+                {isRevising ? "Revising…" : "Revise"}
+              </Button>
+            </div>
+          </div>
         </div>
 
         <DialogFooter>
           <DialogClose render={<Button variant="outline" />}>Cancel</DialogClose>
-          <Button onClick={handleSave} disabled={isUpdating}>
+          <Button onClick={handleSave} disabled={isUpdating || isRevising}>
             {isUpdating ? "Saving…" : "Save changes"}
           </Button>
         </DialogFooter>


### PR DESCRIPTION
## Summary
- Add a minimal prompt box below the YAML editor in the edit-agent dialog that revises the current editor content via the existing `agentConfig.update` endpoint, with a one-shot "Undo revision" to recover the pre-revision text.
- Editor and Save are disabled while a revision is in flight; the prompt text survives request failures instead of being cleared.
- Extract `stringifyAgentInput` (block-literal `soul` rendering) into a shared `agent-yaml.ts` module used by both the create and edit dialogs — fixes a pre-existing bug where the edit dialog rendered multi-paragraph `soul` as folded/hard-wrapped YAML instead of a literal block.
- Layout fix: move the revise box outside the scrollable editor container so it stays visible when the config is long, and add 1px padding to the scroll container so the editor's border isn't clipped top/bottom.

## Test plan
- [x] `eslint` clean on all changed files
- [x] `tsc --noEmit` clean (pre-existing unrelated failures on `main` left untouched)
- [x] Manual: open Edit agent, type an instruction, confirm the YAML updates and `soul` stays block-literal
- [x] Manual: confirm hand edits made before revising are included in the request (revise operates on editor content, not the saved agent)
- [x] Manual: "Undo revision" restores the pre-revision text
- [x] Manual: breaking the YAML before Revise shows a validation error and sends no request
- [ ] Manual: revise box stays visible (not scrolled out) with a long config, and the editor border renders fully