### PR TITLE
refactor: remove Handlebars variable substitution from mutating webhook JSON patch

### DIFF
--- a/apps/dashboard/src/entities/hermeum-config.ts
+++ b/apps/dashboard/src/entities/hermeum-config.ts
@@ -37,11 +37,3 @@ export const HermeumConfigSchema = z
   .readonly();
 
 export type HermeumConfig = z.infer<typeof HermeumConfigSchema>;
-
-export type WebhookVariables = {
-  agentId: string;
-  userId: string;
-  agentName: string;
-  agentDescription: string;
-  agentType: string;
-};

--- a/apps/dashboard/src/server/usecases/agent.test.ts
+++ b/apps/dashboard/src/server/usecases/agent.test.ts
@@ -93,17 +93,7 @@ describe("AgentUseCase.getmutatingWebhookJsonPatch", () => {
     expect(result).toBeNull();
   });
 
-  it("returns the patch unchanged when no Handlebars variables are present", () => {
-    const patch: JsonPatchOp[] = [{ op: "add", path: "/metadata/labels/env", value: "production" }];
-    const useCase = new AgentUseCase(
-      makeRuntime(),
-      makeConfig({ "my-type": { mutatingWebhookJsonPatch: patch } })
-    );
-    const result = useCase.getmutatingWebhookJsonPatch(makeAgent({ type: "my-type" }));
-    expect(result).toEqual(patch);
-  });
-
-  it("substitutes all five variables in a string value", () => {
+  it("returns the patch verbatim, including Handlebars-style placeholders", () => {
     const patch: JsonPatchOp[] = [
       {
         op: "replace",
@@ -125,23 +115,10 @@ describe("AgentUseCase.getmutatingWebhookJsonPatch", () => {
         description: "Does things",
       })
     );
+    expect(result).toEqual(patch);
     expect(result![0]!.value).toBe(
-      "id=abc123 user=usr456 name=My Agent desc=Does things type=my-type"
+      "id={{agentId}} user={{userId}} name={{agentName}} desc={{agentDescription}} type={{agentType}}"
     );
-  });
-
-  it("defaults agentName and agentDescription to empty string when undefined on agent", () => {
-    const patch: JsonPatchOp[] = [
-      { op: "add", path: "/x", value: "name={{agentName}};desc={{agentDescription}}" },
-    ];
-    const useCase = new AgentUseCase(
-      makeRuntime(),
-      makeConfig({ t: { mutatingWebhookJsonPatch: patch } })
-    );
-    const result = useCase.getmutatingWebhookJsonPatch(
-      makeAgent({ type: "t", name: undefined, description: undefined })
-    );
-    expect(result![0]!.value).toBe("name=;desc=");
   });
 
   it("passes through ops without a value property unchanged", () => {
@@ -155,7 +132,7 @@ describe("AgentUseCase.getmutatingWebhookJsonPatch", () => {
     expect(result![0]).not.toHaveProperty("value");
   });
 
-  it("substitutes variables inside a nested object/array value", () => {
+  it("passes through nested object/array values without substitution", () => {
     const patch: JsonPatchOp[] = [
       {
         op: "add",
@@ -173,10 +150,7 @@ describe("AgentUseCase.getmutatingWebhookJsonPatch", () => {
     const result = useCase.getmutatingWebhookJsonPatch(
       makeAgent({ type: "t", id: "a1", userId: "u2" })
     );
-    expect(result![0]!.value).toEqual([
-      { name: "AGENT_ID", value: "a1" },
-      { name: "USER_ID", value: "u2" },
-    ]);
+    expect(result).toEqual(patch);
   });
 
   it("handles a mixed patch array with and without value in a single call", () => {
@@ -191,7 +165,7 @@ describe("AgentUseCase.getmutatingWebhookJsonPatch", () => {
     const result = useCase.getmutatingWebhookJsonPatch(makeAgent({ type: "t", id: "zz9" }));
     expect(result).toHaveLength(2);
     expect(result![0]).not.toHaveProperty("value");
-    expect(result![1]!.value).toBe("zz9");
+    expect(result![1]!.value).toBe("{{agentId}}");
   });
 });
 

--- a/apps/dashboard/src/server/usecases/agent.ts
+++ b/apps/dashboard/src/server/usecases/agent.ts
@@ -1,4 +1,3 @@
-import Handlebars from "handlebars";
 import { z } from "zod";
 
 import {
@@ -14,7 +13,6 @@ import {
   JsonPatchOp,
   Skill,
   SkillSchema,
-  WebhookVariables,
 } from "@/entities";
 
 import { AiSdkGenerator } from "../infras/ai-sdk";
@@ -68,28 +66,7 @@ export class AgentUseCase {
     const { agentTypes } = this.config.get();
     const agentType = agentTypes?.[agent.type];
     if (!agentType) return null;
-    return this.substituteVariables(agentType.mutatingWebhookJsonPatch, agent);
-  }
-
-  private substituteVariables(patch: JsonPatchOp[], agent: Agent): JsonPatchOp[] {
-    const vars: WebhookVariables = {
-      agentId: agent.id,
-      userId: agent.userId,
-      agentName: agent.name ?? "",
-      agentDescription: agent.description ?? "",
-      agentType: agent.type ?? "",
-    };
-
-    const substituteValue = (v: unknown): unknown => {
-      const json = JSON.stringify(v);
-      const substituted = Handlebars.compile(json, { noEscape: true })(vars);
-      return JSON.parse(substituted);
-    };
-
-    return patch.map((op) => ({
-      ...op,
-      ...(op.value !== undefined && { value: substituteValue(op.value) }),
-    }));
+    return agentType.mutatingWebhookJsonPatch;
   }
 
   async listHermesAgents(ctx: Context, input?: ListAgentsFilter): Promise<Agent[]> {


### PR DESCRIPTION
## Summary
- Remove the `substituteVariables` method that compiled each JSONPatch op value as a Handlebars template against agent fields (`agentId`, `userId`, `agentName`, `agentDescription`, `agentType`).
- `getmutatingWebhookJsonPatch` now returns the configured `mutatingWebhookJsonPatch` verbatim. Null-return behavior is unchanged (no agent type, no config, unknown type).
- Drop the now-unused `WebhookVariables` type export and the `handlebars` import.
- Tests updated to assert verbatim passthrough of `{{...}}` placeholders and nested values.

## Test Plan
- [x] `pnpm vitest run src/server/usecases/agent.test.ts` — 28/28 pass
- [x] `eslint` clean on all three changed files
- [x] `tsc --noEmit` introduces no new errors (the one pre-existing error in `kubernetes/client.test.ts:201` is unrelated and present on the clean tree)