### PR TITLE
fix: hide action buttons for archived resources

### DIFF
--- a/apps/dashboard/src/client/ui/routes/agents/$id.tsx
+++ b/apps/dashboard/src/client/ui/routes/agents/$id.tsx
@@ -156,9 +156,11 @@ function AgentDetailPage() {
           )}
         </div>
         <div className="flex gap-2">
-          <Button variant="outline" onClick={() => setEditOpen(true)}>
-            Edit
-          </Button>
+          {!agent.archived && (
+            <Button variant="outline" onClick={() => setEditOpen(true)}>
+              Edit
+            </Button>
+          )}
           {!agent.archived && (
             <DropdownMenu>
               <DropdownMenuTrigger

--- a/apps/dashboard/src/client/ui/routes/shared-env-sets/$id.tsx
+++ b/apps/dashboard/src/client/ui/routes/shared-env-sets/$id.tsx
@@ -108,41 +108,47 @@ function SharedEnvSetDetailPage() {
           )}
         </div>
         <div className="flex items-center gap-2">
-          <Button variant="outline" size="sm" onClick={() => setEditOpen(true)}>
-            <Pencil className="size-3.5" />
-            Edit
-          </Button>
-          <DropdownMenu>
-            <DropdownMenuTrigger
-              render={<Button variant="outline" size="icon" aria-label="More actions" />}
-            >
-              <Button variant="outline" size="icon" aria-label="Open actions menu">
-                <MoreHorizontal className="size-4" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem variant="destructive" onClick={() => setArchiveOpen(true)}>
-                Archive
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+          {!envSet.archived && (
+            <Button variant="outline" size="sm" onClick={() => setEditOpen(true)}>
+              <Pencil className="size-3.5" />
+              Edit
+            </Button>
+          )}
+          {!envSet.archived && (
+            <DropdownMenu>
+              <DropdownMenuTrigger
+                render={<Button variant="outline" size="icon" aria-label="More actions" />}
+              >
+                <Button variant="outline" size="icon" aria-label="Open actions menu">
+                  <MoreHorizontal className="size-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem variant="destructive" onClick={() => setArchiveOpen(true)}>
+                  Archive
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
         </div>
       </div>
 
       <div className="flex flex-col gap-3">
         <div className="flex items-center justify-between">
           <h2 className="font-medium">Environment variables</h2>
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={() => {
-              setAddError(null);
-              setAddOpen(true);
-            }}
-          >
-            <Plus className="size-3.5" />
-            Add env
-          </Button>
+          {!envSet.archived && (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => {
+                setAddError(null);
+                setAddOpen(true);
+              }}
+            >
+              <Plus className="size-3.5" />
+              Add env
+            </Button>
+          )}
         </div>
 
         <Table>
@@ -164,23 +170,25 @@ function SharedEnvSetDetailPage() {
                 <TableRow key={v.name}>
                   <TableCell className="font-mono text-xs">{v.name}</TableCell>
                   <TableCell className="w-10">
-                    <DropdownMenu>
-                      <DropdownMenuTrigger
-                        render={
-                          <Button variant="ghost" size="icon" aria-label="Open actions menu" />
-                        }
-                      >
-                        <MoreHorizontal className="size-4" />
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent align="end">
-                        <DropdownMenuItem
-                          variant="destructive"
-                          onClick={() => setDeleteEnvVarName(v.name)}
+                    {!envSet.archived && (
+                      <DropdownMenu>
+                        <DropdownMenuTrigger
+                          render={
+                            <Button variant="ghost" size="icon" aria-label="Open actions menu" />
+                          }
                         >
-                          Delete
-                        </DropdownMenuItem>
-                      </DropdownMenuContent>
-                    </DropdownMenu>
+                          <MoreHorizontal className="size-4" />
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          <DropdownMenuItem
+                            variant="destructive"
+                            onClick={() => setDeleteEnvVarName(v.name)}
+                          >
+                            Delete
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    )}
                   </TableCell>
                 </TableRow>
               ))

--- a/apps/dashboard/src/client/ui/routes/shared-env-sets/index.tsx
+++ b/apps/dashboard/src/client/ui/routes/shared-env-sets/index.tsx
@@ -203,23 +203,25 @@ function SharedEnvSetsPage() {
                         : "—"}
                     </TableCell>
                     <TableCell className="w-10" onClick={(e) => e.stopPropagation()}>
-                      <DropdownMenu>
-                        <DropdownMenuTrigger
-                          render={
-                            <Button variant="ghost" size="icon" aria-label="Open actions menu" />
-                          }
-                        >
-                          <MoreHorizontal className="size-4" />
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent align="end">
-                          <DropdownMenuItem
-                            variant="destructive"
-                            onClick={() => setArchiveId(envSet.id)}
+                      {!envSet.archived && (
+                        <DropdownMenu>
+                          <DropdownMenuTrigger
+                            render={
+                              <Button variant="ghost" size="icon" aria-label="Open actions menu" />
+                            }
                           >
-                            Archive
-                          </DropdownMenuItem>
-                        </DropdownMenuContent>
-                      </DropdownMenu>
+                            <MoreHorizontal className="size-4" />
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="end">
+                            <DropdownMenuItem
+                              variant="destructive"
+                              onClick={() => setArchiveId(envSet.id)}
+                            >
+                              Archive
+                            </DropdownMenuItem>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      )}
                     </TableCell>
                   </TableRow>
                 ))


### PR DESCRIPTION
## Summary
Archived agents and shared env sets cannot be updated or modified, but the UI was still displaying action buttons (Edit, Archive, Add env, per-env-var Delete) for them. This hides all mutating action buttons when a resource is archived.

## Changes
- **agents/$id.tsx**: Hide Edit button when agent is archived (dropdown was already guarded)
- **shared-env-sets/index.tsx**: Hide per-row Archive dropdown for archived env sets
- **shared-env-sets/$id.tsx**: Hide Edit button, Archive dropdown, Add env button, and per-env-var Delete dropdown when env set is archived

The Refresh button on the agent detail page is intentionally left visible since it is read-only.