### PR TITLE
fix: make Active the default tab for agents and shared env sets

### DIFF
--- a/apps/dashboard/src/client/ui/routes/agents/index.tsx
+++ b/apps/dashboard/src/client/ui/routes/agents/index.tsx
@@ -45,7 +45,7 @@ function DashboardPage() {
   const queryClient = useQueryClient();
   const [dialogOpen, setDialogOpen] = useState(false);
   const [archiveId, setArchiveId] = useState<string | null>(null);
-  const [tab, setTab] = useState<"all" | "active">("all");
+  const [tab, setTab] = useState<"all" | "active">("active");
   const navigate = useNavigate();
 
   const {
@@ -157,8 +157,8 @@ function DashboardPage() {
 
       <Tabs value={tab} onValueChange={(v) => setTab(v as "all" | "active")}>
         <TabsList>
-          <TabsTrigger value="all">All</TabsTrigger>
           <TabsTrigger value="active">Active</TabsTrigger>
+          <TabsTrigger value="all">All</TabsTrigger>
         </TabsList>
         <TabsContent value={tab}>
           <Table>

--- a/apps/dashboard/src/client/ui/routes/shared-env-sets/index.tsx
+++ b/apps/dashboard/src/client/ui/routes/shared-env-sets/index.tsx
@@ -69,7 +69,7 @@ function SharedEnvSetsPage() {
   const queryClient = useQueryClient();
   const [dialogOpen, setDialogOpen] = useState(false);
   const [archiveId, setArchiveId] = useState<string | null>(null);
-  const [tab, setTab] = useState<"all" | "active">("all");
+  const [tab, setTab] = useState<"all" | "active">("active");
   const navigate = useNavigate();
 
   const {
@@ -148,8 +148,8 @@ function SharedEnvSetsPage() {
 
       <Tabs value={tab} onValueChange={(v) => setTab(v as "all" | "active")}>
         <TabsList>
-          <TabsTrigger value="all">All</TabsTrigger>
           <TabsTrigger value="active">Active</TabsTrigger>
+          <TabsTrigger value="all">All</TabsTrigger>
         </TabsList>
         <TabsContent value={tab}>
           <Table>


### PR DESCRIPTION
Switch the default tab value from 'all' to 'active' and reorder the tab triggers so Active appears first on both the agents and shared env sets list pages.