### PR TITLE
ci: add GitHub Actions workflow for lint, test, and build on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Test
+        run: pnpm test
+
+      - name: Build
+        run: pnpm build

--- a/apps/dashboard/src/server/usecases/template.ts
+++ b/apps/dashboard/src/server/usecases/template.ts
@@ -4,7 +4,7 @@ import { ConfigAdaptor } from "./adaptors/config";
 export class TemplateUseCase {
   constructor(private readonly config: ConfigAdaptor) {}
 
-  list(ctx: Context): Template[] {
+  list(_ctx: Context): Template[] {
     return this.config.get().templates;
   }
 

--- a/apps/dashboard/vite.config.ts
+++ b/apps/dashboard/vite.config.ts
@@ -72,6 +72,9 @@ export default defineConfig((configEnv) => {
     test: {
       environment: "node",
       include: ["src/**/*.test.ts"],
+      env: {
+        HERMEUM_DATABASE_URL: "file:./test.db",
+      },
     },
   };
 });

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "build": "turbo build",
     "dev": "turbo dev",
     "lint": "turbo lint",
+    "test": "turbo test",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "typecheck": "turbo typecheck",

--- a/packages/components/eslint.config.js
+++ b/packages/components/eslint.config.js
@@ -1,0 +1,3 @@
+import reactConfig from "@hermeum/eslint-config/react";
+
+export default reactConfig;

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -36,6 +36,7 @@
     "@hermeum/typescript-config": "workspace:*",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
+    "eslint": "^9.0.0",
     "shadcn": "^4.2.0",
     "tailwindcss": "^4.2.2",
     "typescript": "^5.8.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,6 +217,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.0.0
         version: 19.2.3(@types/react@19.2.14)
+      eslint:
+        specifier: ^9.0.0
+        version: 9.39.4(jiti@2.6.1)
       shadcn:
         specifier: ^4.2.0
         version: 4.2.0(@types/node@25.5.0)(typescript@5.9.3)

--- a/turbo.json
+++ b/turbo.json
@@ -14,6 +14,9 @@
     "lint": {
       "dependsOn": ["^lint"]
     },
+    "test": {
+      "dependsOn": ["^build"]
+    },
     "typecheck": {
       "dependsOn": ["^build", "^typecheck"]
     },


### PR DESCRIPTION
## What

Adds `.github/workflows/ci.yml` running **lint → test → build** as separate steps on every PR targeting `main` (opened / synchronize / reopened) and on pushes to `main`. Uses `pnpm/action-setup` (version resolved from `packageManager`), Node 22 with pnpm cache, `--frozen-lockfile` installs, and concurrency cancellation for stacked pushes.

## Why

The repo had no CI, so lint/test/build regressions could land unnoticed.

## Notes for review

- **Test pipeline wiring**: there was no root test pipeline — added a `test` task to `turbo.json` and a root `"test": "turbo test"` script. Packages without a test script are skipped by turbo.
- **Pre-existing breaks fixed** (root `pnpm lint` / `pnpm test` failed before this PR and would have failed the first CI run):
  - `@hermeum/components` ran `eslint .` without declaring `eslint` as a devDependency and had no `eslint.config.js`. Added both (config mirrors the dashboard's, extending `@hermeum/eslint-config/react`).
  - Unused `ctx` arg in `apps/dashboard/src/server/usecases/template.ts` renamed to `_ctx`.
  - `src/server/libs/config.ts` requires `HERMEUM_DATABASE_URL` at import time, crashing the kubernetes client test suite without a local `.env`. Set a dummy `file:./test.db` in the vitest `env` so tests are hermetic.
- `format:check` is intentionally not in CI: 42 pre-existing files fail prettier (mostly `packages/components/ui/*`). Can add it after a one-time `pnpm format` in a follow-up.

Verified locally: `pnpm lint`, `pnpm test` (3 suites, 64 tests), and `pnpm build` all pass from the repo root.