### PR TITLE
refactor: remove unused installSkill/uninstallSkill usecase functions

### DIFF
--- a/apps/dashboard/src/server/routers/trpc/agent.ts
+++ b/apps/dashboard/src/server/routers/trpc/agent.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import { Agent, AgentInputSchema, SkillSchema } from "@/entities";
+import { Agent, AgentInputSchema } from "@/entities";
 import { AgentUseCase, ListAgentsFilterSchema } from "@/server/usecases/agent";
 import { protectedProcedure, t } from "./shared.js";
 
@@ -36,18 +36,6 @@ export const agentRouter = t.router({
     .input(z.object({ id: z.string().min(1) }))
     .mutation(async ({ ctx, input }): Promise<Agent> => {
       return await usecase.archiveHermesAgent(ctx, input.id);
-    }),
-
-  installSkill: protectedProcedure
-    .input(z.object({ agentId: z.string().min(1), skill: SkillSchema }))
-    .mutation(async ({ ctx, input }): Promise<Agent> => {
-      return await usecase.installSkill(ctx, input.agentId, input.skill);
-    }),
-
-  uninstallSkill: protectedProcedure
-    .input(z.object({ agentId: z.string().min(1), skill: SkillSchema }))
-    .mutation(async ({ ctx, input }): Promise<Agent> => {
-      return await usecase.uninstallSkill(ctx, input.agentId, input.skill);
     }),
 
   suspend: protectedProcedure

--- a/apps/dashboard/src/server/usecases/agent.ts
+++ b/apps/dashboard/src/server/usecases/agent.ts
@@ -11,8 +11,6 @@ import {
   ENV_SECRET_SENTINEL,
   Env,
   JsonPatchOp,
-  Skill,
-  SkillSchema,
 } from "@/entities";
 
 import { AiSdkGenerator } from "../infras/ai-sdk";
@@ -123,43 +121,6 @@ export class AgentUseCase {
     }
     this.verifyOwnership(ctx, agent);
     return this.runtime.archiveHermesAgent(id);
-  }
-
-  async installSkill(ctx: Context, agentId: string, skill: Skill): Promise<Agent> {
-    SkillSchema.parse(skill);
-
-    const agent = await this.runtime.getHermesAgent(agentId);
-    if (!agent) {
-      throw new Error(`HermesAgent "${agentId}" not found`);
-    }
-    this.verifyOwnership(ctx, agent);
-    const current = agent.skills ?? [];
-    if (current.includes(skill)) {
-      throw new Error(`Skill "${skill}" is already installed on agent "${agentId}"`);
-    }
-    if (current.length >= 20) {
-      throw new Error("Agent already has the maximum of 20 skills");
-    }
-    return this.runtime.patchHermesAgent({
-      id: agentId,
-      patch: { skills: [...current, skill] },
-    });
-  }
-
-  async uninstallSkill(ctx: Context, agentId: string, skill: Skill): Promise<Agent> {
-    const agent = await this.runtime.getHermesAgent(agentId);
-    if (!agent) {
-      throw new Error(`HermesAgent "${agentId}" not found`);
-    }
-    this.verifyOwnership(ctx, agent);
-    const current = agent.skills ?? [];
-    if (!current.includes(skill)) {
-      throw new Error(`Skill "${skill}" is not installed on agent "${agentId}"`);
-    }
-    return this.runtime.patchHermesAgent({
-      id: agentId,
-      patch: { skills: current.filter((s) => s !== skill) },
-    });
   }
 
   private async checkSharedEnvSetsAccessible(setIds: string[] | undefined): Promise<void> {


### PR DESCRIPTION
## Summary
- Removes the `installSkill` and `uninstallSkill` tRPC procedures and their backing `AgentUseCase` methods
- Neither is called from the client UI, and neither has any other server-side caller (e.g. webhooks), making them fully dead code end-to-end
- Cleans up the now-unused `Skill`/`SkillSchema` imports left behind in both files

## Test plan
- [x] `pnpm lint` passes (no new errors)
- [x] `pnpm format:check` shows no new issues in touched files
- [x] `tsc --noEmit` shows no new errors (one pre-existing error confirmed present on base branch)
- [x] Agent usecase test suite passes (28/28)
- [x] Grep confirms zero remaining references to `installSkill`/`uninstallSkill` in the codebase