### PR TITLE
refactor: consolidate ownership and input validation checks in AgentUseCase

### DIFF
--- a/apps/dashboard/src/server/usecases/agent.ts
+++ b/apps/dashboard/src/server/usecases/agent.ts
@@ -21,6 +21,7 @@ import { LocalConfig } from "../infras/local-hermeum-config";
 import { AiGenerator } from "./adaptors/generator";
 import { Runtime } from "./adaptors/runtime";
 import { ConfigAdaptor } from "./adaptors/config";
+import { verifyOwnership } from "./authz";
 
 // Field semantics live in the output schema's .describe() texts; this prompt
 // carries per-feature cross-field rules and worked examples instead.
@@ -92,7 +93,7 @@ export class AgentUseCase {
     if (!agent) {
       throw new Error(`HermesAgent ${id} not found`);
     }
-    this.verifyOwnership(ctx, agent);
+    verifyOwnership(ctx, agent);
 
     patch = AgentInputSchema.parse(patch);
 
@@ -121,7 +122,7 @@ export class AgentUseCase {
     if (!agent) {
       throw new Error(`HermesAgent ${id} not found`);
     }
-    this.verifyOwnership(ctx, agent);
+    verifyOwnership(ctx, agent);
     return this.runtime.archiveHermesAgent(id);
   }
 
@@ -132,7 +133,7 @@ export class AgentUseCase {
     if (!agent) {
       throw new Error(`HermesAgent "${agentId}" not found`);
     }
-    this.verifyOwnership(ctx, agent);
+    verifyOwnership(ctx, agent);
     const current = agent.skills ?? [];
     if (current.includes(skill)) {
       throw new Error(`Skill "${skill}" is already installed on agent "${agentId}"`);
@@ -151,7 +152,7 @@ export class AgentUseCase {
     if (!agent) {
       throw new Error(`HermesAgent "${agentId}" not found`);
     }
-    this.verifyOwnership(ctx, agent);
+    verifyOwnership(ctx, agent);
     const current = agent.skills ?? [];
     if (!current.includes(skill)) {
       throw new Error(`Skill "${skill}" is not installed on agent "${agentId}"`);
@@ -179,7 +180,7 @@ export class AgentUseCase {
     if (!agent) {
       throw new Error(`HermesAgent ${id} not found`);
     }
-    this.verifyOwnership(ctx, agent);
+    verifyOwnership(ctx, agent);
     return this.runtime.patchHermesAgent({ id, patch: { suspended: true } });
   }
 
@@ -188,7 +189,7 @@ export class AgentUseCase {
     if (!agent) {
       throw new Error(`HermesAgent ${id} not found`);
     }
-    this.verifyOwnership(ctx, agent);
+    verifyOwnership(ctx, agent);
     return this.runtime.patchHermesAgent({ id, patch: { suspended: false } });
   }
 
@@ -197,7 +198,7 @@ export class AgentUseCase {
     if (!agent) {
       throw new Error(`HermesAgent ${agentId} not found`);
     }
-    this.verifyOwnership(ctx, agent);
+    verifyOwnership(ctx, agent);
     return this.runtime.getGatewayToken(agentId);
   }
 
@@ -208,12 +209,6 @@ export class AgentUseCase {
     }
     if (!(agentType in agentTypes)) {
       throw new Error(`Agent type "${agentType}" is not configured`);
-    }
-  }
-
-  private verifyOwnership(ctx: Context, resource: { userId: string }): void {
-    if (ctx.user!.id !== resource.userId) {
-      throw new Error("You don't have permission to perform this action");
     }
   }
 

--- a/apps/dashboard/src/server/usecases/agent.ts
+++ b/apps/dashboard/src/server/usecases/agent.ts
@@ -81,10 +81,7 @@ export class AgentUseCase {
   async createHermesAgent(ctx: Context, agentInput: AgentInput): Promise<Agent> {
     agentInput = AgentInputSchema.parse(agentInput);
 
-    if (agentInput.type !== undefined) {
-      this.checkAgentTypeAllowed(agentInput.type);
-    }
-    await this.checkSharedEnvSetsAccessible(agentInput.sharedEnvSets);
+    await this.checkAgentInputAllowed(agentInput);
     return this.runtime.createHermesAgent({ ...agentInput, userId: ctx.user!.id });
   }
 
@@ -97,10 +94,7 @@ export class AgentUseCase {
 
     patch = AgentInputSchema.parse(patch);
 
-    if (patch.type !== undefined) {
-      this.checkAgentTypeAllowed(patch.type);
-    }
-    await this.checkSharedEnvSetsAccessible(patch.sharedEnvSets);
+    await this.checkAgentInputAllowed(patch);
     if (patch.env !== undefined) {
       this.checkEnvSensitivityNotDowngraded(agent.env, patch.env);
     }
@@ -163,18 +157,6 @@ export class AgentUseCase {
     });
   }
 
-  private async checkSharedEnvSetsAccessible(setIds: string[] | undefined): Promise<void> {
-    for (const id of setIds ?? []) {
-      const envSet = await this.runtime.getSharedEnvSet(id);
-      if (!envSet) {
-        throw new Error(`Shared env set "${id}" not found`);
-      }
-      if (envSet.archived) {
-        throw new Error(`Shared env set "${id}" is archived`);
-      }
-    }
-  }
-
   async suspendHermesAgent(ctx: Context, id: string): Promise<Agent> {
     const agent = await this.runtime.getHermesAgent(id);
     if (!agent) {
@@ -202,13 +184,26 @@ export class AgentUseCase {
     return this.runtime.getGatewayToken(agentId);
   }
 
-  private checkAgentTypeAllowed(agentType: string): void {
-    const { agentTypes } = this.config.get();
-    if (!agentTypes) {
-      throw new Error("Agent types are not configured");
+  private async checkAgentInputAllowed(
+    input: Pick<AgentInput, "type" | "sharedEnvSets">
+  ): Promise<void> {
+    if (input.type !== undefined) {
+      const { agentTypes } = this.config.get();
+      if (!agentTypes) {
+        throw new Error("Agent types are not configured");
+      }
+      if (!(input.type in agentTypes)) {
+        throw new Error(`Agent type "${input.type}" is not configured`);
+      }
     }
-    if (!(agentType in agentTypes)) {
-      throw new Error(`Agent type "${agentType}" is not configured`);
+    for (const id of input.sharedEnvSets ?? []) {
+      const envSet = await this.runtime.getSharedEnvSet(id);
+      if (!envSet) {
+        throw new Error(`Shared env set "${id}" not found`);
+      }
+      if (envSet.archived) {
+        throw new Error(`Shared env set "${id}" is archived`);
+      }
     }
   }
 

--- a/apps/dashboard/src/server/usecases/authz.ts
+++ b/apps/dashboard/src/server/usecases/authz.ts
@@ -1,0 +1,7 @@
+import { Context } from "@/entities";
+
+export function verifyOwnership(ctx: Context, resource: { userId: string }): void {
+  if (ctx.user!.id !== resource.userId) {
+    throw new Error("You don't have permission to perform this action");
+  }
+}

--- a/apps/dashboard/src/server/usecases/shared-env-set.ts
+++ b/apps/dashboard/src/server/usecases/shared-env-set.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { Context, EnvVar, EnvVarSchema, SharedEnvSet } from "@/entities";
 import { KubernetesClient } from "../infras/kubernetes/client";
 import { Runtime } from "./adaptors/runtime";
+import { verifyOwnership } from "./authz";
 
 export const CreateSharedEnvSetInputSchema = z.object({
   name: z.string().min(1),
@@ -45,7 +46,7 @@ export class SharedEnvSetUseCase {
     if (!envSet) {
       throw new Error(`Shared env set "${id}" not found`);
     }
-    this.verifyOwnership(ctx, envSet);
+    verifyOwnership(ctx, envSet);
     return this.runtime.patchSharedEnvSet(id, {
       ...(input.name !== undefined && { name: input.name }),
       ...(input.description !== undefined && { description: input.description }),
@@ -57,7 +58,7 @@ export class SharedEnvSetUseCase {
     if (!envSet) {
       throw new Error(`Shared env set "${id}" not found`);
     }
-    this.verifyOwnership(ctx, envSet);
+    verifyOwnership(ctx, envSet);
     return this.runtime.archiveSharedEnvSet(id);
   }
 
@@ -67,7 +68,7 @@ export class SharedEnvSetUseCase {
     if (!envSet) {
       throw new Error(`Shared env set "${setId}" not found`);
     }
-    this.verifyOwnership(ctx, envSet);
+    verifyOwnership(ctx, envSet);
     if (envSet.envVars.some((e) => e.name === envVar.name)) {
       throw new Error(`Env var "${envVar.name}" already exists in shared env set "${setId}"`);
     }
@@ -80,7 +81,7 @@ export class SharedEnvSetUseCase {
     if (!envSet) {
       throw new Error(`Shared env set "${setId}" not found`);
     }
-    this.verifyOwnership(ctx, envSet);
+    verifyOwnership(ctx, envSet);
     if (!envSet.envVars.some((e) => e.name === envVar.name)) {
       throw new Error(`Env var "${envVar.name}" not found in shared env set "${setId}"`);
     }
@@ -92,16 +93,10 @@ export class SharedEnvSetUseCase {
     if (!envSet) {
       throw new Error(`Shared env set "${setId}" not found`);
     }
-    this.verifyOwnership(ctx, envSet);
+    verifyOwnership(ctx, envSet);
     if (!envSet.envVars.some((e) => e.name === name)) {
       throw new Error(`Env var "${name}" not found in shared env set "${setId}"`);
     }
     return this.runtime.removeEnvVar(setId, name);
-  }
-
-  private verifyOwnership(ctx: Context, resource: { userId: string }): void {
-    if (ctx.user!.id !== resource.userId) {
-      throw new Error("You don't have permission to perform this action");
-    }
   }
 }


### PR DESCRIPTION
## Summary
- Extract the duplicated `verifyOwnership` private method out of `AgentUseCase` and `SharedEnvSetUseCase` into a shared `usecases/authz.ts` helper, so a future resource type doesn't need to reimplement it.
- Merge `checkAgentTypeAllowed` and `checkSharedEnvSetsAccessible` in `AgentUseCase` into a single `checkAgentInputAllowed` method, since they were always invoked together at both call sites (`createHermesAgent`, `updateHermesAgent`).

No behavior change — both are internal simplifications of the use-case layer.

## Test plan
- [x] `pnpm lint` — clean (only 2 pre-existing, unrelated React-hooks warnings)
- [x] `pnpm format:check` on changed files — clean
- [x] `pnpm test` — 64/64 tests pass, including ownership-check coverage in `agent.test.ts`