### PR TITLE
Add crons to AgentInput

### DIFF
--- a/apps/dashboard/src/entities/agent.test.ts
+++ b/apps/dashboard/src/entities/agent.test.ts
@@ -92,6 +92,123 @@ describe("AgentInputSchema env placeholder validation", () => {
   });
 });
 
+describe("AgentInputSchema crons validation", () => {
+  function makeCron(overrides: Record<string, unknown> = {}) {
+    return {
+      name: "daily-standup",
+      schedule: "0 9 * * *",
+      prompt: "Summarize yesterday's activity.",
+      ...overrides,
+    };
+  }
+
+  it("accepts a full valid cron", () => {
+    const result = AgentInputSchema.safeParse({
+      crons: [makeCron({ deliver: "slack", repeat: 3, skills: ["standup-summarizer"] })],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a cron missing name", () => {
+    const cron = makeCron();
+    delete (cron as Record<string, unknown>).name;
+    const result = AgentInputSchema.safeParse({ crons: [cron] });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a cron missing schedule", () => {
+    const cron = makeCron();
+    delete (cron as Record<string, unknown>).schedule;
+    const result = AgentInputSchema.safeParse({ crons: [cron] });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a cron missing prompt", () => {
+    const cron = makeCron();
+    delete (cron as Record<string, unknown>).prompt;
+    const result = AgentInputSchema.safeParse({ crons: [cron] });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects deliver: github_comment (not a valid cron delivery target)", () => {
+    const result = AgentInputSchema.safeParse({
+      crons: [makeCron({ deliver: "github_comment" })],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an unrecognized deliver platform", () => {
+    const result = AgentInputSchema.safeParse({ crons: [makeCron({ deliver: "carrier-pigeon" })] });
+    expect(result.success).toBe(false);
+  });
+
+  it.each(["slack", "origin", "local", "all"])("accepts deliver: %s", (deliver) => {
+    const result = AgentInputSchema.safeParse({ crons: [makeCron({ deliver })] });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a deliver target with a :target suffix", () => {
+    const result = AgentInputSchema.safeParse({
+      crons: [makeCron({ deliver: "telegram:123456" })],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a deliver target with a topic suffix", () => {
+    const result = AgentInputSchema.safeParse({
+      crons: [makeCron({ deliver: "telegram:-100123:17585" })],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a comma-separated fan-out deliver value", () => {
+    const result = AgentInputSchema.safeParse({
+      crons: [makeCron({ deliver: "telegram,discord" })],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a malformed comma-separated deliver value", () => {
+    const result = AgentInputSchema.safeParse({
+      crons: [makeCron({ deliver: "telegram,,discord" })],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it.each(["30m", "2h", "1d", "every 30m", "every 2h", "0 */6 * * *", "2026-03-15T09:00:00"])(
+    "accepts schedule: %s",
+    (schedule) => {
+      const result = AgentInputSchema.safeParse({ crons: [makeCron({ schedule })] });
+      expect(result.success).toBe(true);
+    }
+  );
+
+  it.each(["daily", "every", "30 minutes", "0 9 * *"])(
+    "rejects invalid schedule: %s",
+    (schedule) => {
+      const result = AgentInputSchema.safeParse({ crons: [makeCron({ schedule })] });
+      expect(result.success).toBe(false);
+    }
+  );
+
+  it("rejects a non-positive repeat", () => {
+    const result = AgentInputSchema.safeParse({ crons: [makeCron({ repeat: 0 })] });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a non-integer repeat", () => {
+    const result = AgentInputSchema.safeParse({ crons: [makeCron({ repeat: 1.5 })] });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts loose skill strings that would fail the strict top-level SkillSchema", () => {
+    const result = AgentInputSchema.safeParse({
+      crons: [makeCron({ skills: ["bad skill!"] })],
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
 describe("AgentInputObjectSchema as LLM structured-output schema", () => {
   it("accepts a representative generated payload", () => {
     const result = AgentInputObjectSchema.safeParse({

--- a/apps/dashboard/src/entities/agent.ts
+++ b/apps/dashboard/src/entities/agent.ts
@@ -104,6 +104,118 @@ export const PluginsSchema = z
 
 export type Plugins = z.infer<typeof PluginsSchema>;
 
+// https://hermes-agent.nousresearch.com/docs/user-guide/features/cron#schedule-formats
+// Relative delay ("30m", "2h", "1d") | interval ("every 30m") |
+// 5-field cron expression ("0 9 * * *") | ISO timestamp ("2026-03-15T09:00:00")
+const CRON_SCHEDULE_PATTERN =
+  /^\d+[mhd]$|^every \d+[mhd]$|^[0-9*/,-]+(?:\s+[0-9*/,-]+){4}$|^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z?$/;
+
+export const CronScheduleSchema = z
+  .string()
+  .regex(
+    CRON_SCHEDULE_PATTERN,
+    'Schedule must be a relative delay ("30m", "2h", "1d"), an interval ("every 30m"), ' +
+      'a 5-field cron expression ("0 9 * * *"), or an ISO timestamp ("2026-03-15T09:00:00").'
+  )
+  .describe(
+    `When to run this cron.
+
+- Relative delay (one-shot): "30m", "2h", "1d"
+- Interval (recurring): "every 30m", "every 2h", "every 1d"
+- Cron expression (5-field): "0 9 * * *" (daily at 9am), "0 */6 * * *" (every 6 hours)
+- ISO timestamp (one-time): "2026-03-15T09:00:00"`
+  );
+
+export type CronSchedule = z.infer<typeof CronScheduleSchema>;
+
+// https://hermes-agent.nousresearch.com/docs/user-guide/features/cron#delivery-options
+const CRON_DELIVER_PLATFORMS = [
+  "origin",
+  "local",
+  "telegram",
+  "discord",
+  "slack",
+  "whatsapp",
+  "signal",
+  "matrix",
+  "mattermost",
+  "email",
+  "sms",
+  "homeassistant",
+  "dingtalk",
+  "feishu",
+  "wecom",
+  "weixin",
+  "bluebubbles",
+  "qqbot",
+  "all",
+] as const;
+
+// Only the platform prefix is validated — anything after ":" (a chat id, channel
+// name, or topic) is passed through as-is.
+function isKnownCronDeliverPlatform(target: string): boolean {
+  const platform = target.split(":")[0] ?? "";
+  return (CRON_DELIVER_PLATFORMS as readonly string[]).includes(platform);
+}
+
+export const CronDeliverSchema = z
+  .string()
+  .refine((value) => value.split(",").every(isKnownCronDeliverPlatform), {
+    message:
+      `Deliver must be one of ${CRON_DELIVER_PLATFORMS.join(", ")}, optionally with a ` +
+      '":target" suffix (e.g. "telegram:123456"), or a comma-separated list of these ' +
+      '(e.g. "telegram,discord").',
+  })
+  .optional()
+  .describe(
+    `Where to send the cron's output.
+
+- "origin": back to the source that created the cron.
+- "local": save to ~/.hermes/cron/output/.
+- "all": fan out to every connected home channel.
+- A platform home channel: "telegram", "discord", "slack", "whatsapp", "signal", "matrix", \
+"mattermost", "email", "sms", "homeassistant", "dingtalk", "feishu", "wecom", "weixin", \
+"bluebubbles", "qqbot".
+- A specific target: "telegram:123456", "discord:#engineering" (not validated further).
+- Comma-separated fan-out: "telegram,discord".`
+  );
+
+export type CronDeliver = z.infer<typeof CronDeliverSchema>;
+
+export const AgentCronSchema = z
+  .object({
+    name: z.string().min(1).describe("Cron job name."),
+    schedule: CronScheduleSchema,
+    prompt: z.string().min(1).describe("Prompt to run when this cron triggers."),
+    deliver: CronDeliverSchema,
+    repeat: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe("Number of times to repeat the run. Omit to run once per trigger."),
+    skills: z.array(z.string()).optional().describe("Skill names to load for this cron's run."),
+  })
+  .describe(
+    `A scheduled cron job that triggers an agent run.
+
+Example — daily standup summary:
+  name: daily-standup
+  schedule: "0 9 * * *"
+  prompt: Summarize yesterday's activity across tracked repos.
+  deliver: slack`
+  );
+
+export type AgentCron = z.infer<typeof AgentCronSchema>;
+
+export const CronsSchema = z
+  .array(AgentCronSchema)
+  .max(20)
+  .optional()
+  .describe("Scheduled cron jobs for the agent.");
+
+export type Crons = z.infer<typeof CronsSchema>;
+
 export const StorageSchema = z
   .object({
     enabled: z.boolean().default(true),
@@ -141,6 +253,7 @@ export const AgentInputObjectSchema = z.object({
   env: EnvSchema,
   skills: SkillsSchema,
   plugins: PluginsSchema,
+  crons: CronsSchema,
   sharedEnvSets: z
     .array(z.string())
     .optional()

--- a/apps/dashboard/src/server/infras/kubernetes/client.test.ts
+++ b/apps/dashboard/src/server/infras/kubernetes/client.test.ts
@@ -4,11 +4,13 @@ import {
   agentEnvResourceName,
   agentToHermesAgent,
   hashAgentEnv,
+  mapHermesAgent,
   mapHermesConfig,
   maskSensitiveEnv,
   splitAgentEnv,
 } from "./client";
 import type { Agent } from "@/entities";
+import type { HermesAgent } from "./types/hermes-agent";
 
 function makeAgent(overrides: Partial<Agent> = {}): Agent {
   return {
@@ -200,6 +202,74 @@ describe("mapHermesConfig", () => {
     };
     const hermesAgent = agentToHermesAgent(makeAgent({ config }));
     expect(mapHermesConfig(hermesAgent.spec.hermes?.config)).toEqual(config);
+  });
+});
+
+describe("agentToHermesAgent crons wiring", () => {
+  it("maps agent.crons straight onto hermes.crons", () => {
+    const crons = [
+      {
+        name: "daily-standup",
+        schedule: "0 9 * * *",
+        prompt: "Summarize yesterday's activity.",
+        deliver: "slack" as const,
+        repeat: 3,
+        skills: ["standup-summarizer"],
+      },
+    ];
+    const hermesAgent = agentToHermesAgent(makeAgent({ crons }));
+    expect(hermesAgent.spec.hermes?.crons).toEqual(crons);
+  });
+
+  it("leaves hermes.crons undefined when agent.crons is undefined", () => {
+    const hermesAgent = agentToHermesAgent(makeAgent());
+    expect(hermesAgent.spec.hermes?.crons).toBeUndefined();
+  });
+});
+
+describe("mapHermesAgent crons round-trip", () => {
+  function makeRawAgent(crons: unknown): HermesAgent {
+    return {
+      spec: { hermes: { crons } },
+    } as unknown as HermesAgent;
+  }
+
+  it("round-trips supported fields", () => {
+    const crons = [
+      {
+        name: "daily-standup",
+        schedule: "0 9 * * *",
+        prompt: "Summarize yesterday's activity.",
+        deliver: "slack",
+        repeat: 3,
+        skills: ["standup-summarizer"],
+      },
+    ];
+    const agent = mapHermesAgent(makeRawAgent(crons));
+    expect(agent.crons).toEqual(crons);
+  });
+
+  it("strips unsupported HermesCron fields (script, noAgent, workdir, profile)", () => {
+    const rawCrons = [
+      {
+        name: "cleanup",
+        schedule: "0 0 * * *",
+        prompt: "Clean up temp files.",
+        script: "rm -rf /tmp/*",
+        noAgent: true,
+        workdir: "/tmp",
+        profile: "default",
+      },
+    ];
+    const agent = mapHermesAgent(makeRawAgent(rawCrons));
+    expect(agent.crons).toEqual([
+      { name: "cleanup", schedule: "0 0 * * *", prompt: "Clean up temp files." },
+    ]);
+  });
+
+  it("returns undefined when there are no crons", () => {
+    const agent = mapHermesAgent(makeRawAgent(undefined));
+    expect(agent.crons).toBeUndefined();
   });
 });
 

--- a/apps/dashboard/src/server/infras/kubernetes/client.ts
+++ b/apps/dashboard/src/server/infras/kubernetes/client.ts
@@ -193,6 +193,9 @@ export function agentToHermesAgent(agent: Agent): HermesAgent {
   if (agent.plugins !== undefined) {
     hermes.plugins = agent.plugins.map((identifier) => ({ identifier }));
   }
+  if (agent.crons !== undefined) {
+    hermes.crons = agent.crons;
+  }
   hermes.image = { repository: config.hermesImageRepository, tag: config.hermesImageTag };
 
   const spec: HermesAgentSpec = {
@@ -246,6 +249,15 @@ export function mapHermesAgent(raw: HermesAgent): Agent {
     soul: raw.spec.hermes?.workspace?.files?.["SOUL.md"],
     skills: raw.spec.hermes?.skills?.map((s) => s.identifier),
     plugins: raw.spec.hermes?.plugins?.map((p) => p.identifier),
+    // prompt is required by AgentCronSchema; dashboard-authored crons always set it.
+    crons: raw.spec.hermes?.crons?.map((c) => ({
+      name: c.name,
+      schedule: c.schedule,
+      prompt: c.prompt as string,
+      ...(c.deliver !== undefined && { deliver: c.deliver }),
+      ...(c.repeat !== undefined && { repeat: c.repeat }),
+      ...(c.skills !== undefined && { skills: c.skills }),
+    })),
     suspended: raw.spec.suspend,
     archived: raw.metadata?.labels?.[HermeumLabel.Archived] === "true",
     phase: raw.status?.phase as AgentPhase | undefined,


### PR DESCRIPTION
## Summary
- Adds a `crons` field to `AgentInput` exposing 6 of `HermesCron`'s fields: `name`, `schedule`, `prompt`, `deliver`, `repeat`, `skills` (the other fields — `script`, `noAgent`, `workdir`, `profile` — are intentionally not exposed).
- `schedule` is validated against the formats documented for Hermes cron jobs: relative delay (`"30m"`, `"2h"`, `"1d"`), interval (`"every 30m"`), 5-field cron expression (`"0 9 * * *"`), or ISO timestamp (`"2026-03-15T09:00:00"`).
- `deliver` is validated against the documented delivery platforms (`origin`, `local`, `all`, `telegram`, `discord`, `slack`, etc.), optionally with a `:target` suffix (not further validated) or a comma-separated fan-out list.
- Wires `agent.crons` <-> `hermes.crons` in the Kubernetes client mapping (`agentToHermesAgent` / `mapHermesAgent`), stripping any unsupported `HermesCron` fields when reading a cron back from the cluster.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm format:check`
- [x] `entities/agent.test.ts` and `server/infras/kubernetes/client.test.ts` (69 tests, all passing)