### PR TITLE
feat: add `packages` field to `AgentInput` for pip/npm pre-install

### DIFF
--- a/apps/dashboard/src/client/ui/routes/agents/$id.tsx
+++ b/apps/dashboard/src/client/ui/routes/agents/$id.tsx
@@ -235,6 +235,21 @@ function AgentDetailPage() {
               </div>
             )}
 
+            {/* packages */}
+            {agent.packages?.pip && agent.packages.pip.length > 0 && (
+              <div className="py-8 flex flex-col gap-3">
+                <p className="text-sm font-medium">Python Packages</p>
+                <ButtonList items={agent.packages.pip} max={10} />
+              </div>
+            )}
+
+            {agent.packages?.npm && agent.packages.npm.length > 0 && (
+              <div className="py-8 flex flex-col gap-3">
+                <p className="text-sm font-medium">npm Packages</p>
+                <ButtonList items={agent.packages.npm} max={10} />
+              </div>
+            )}
+
             {/* env */}
             {agent.env && agent.env.length > 0 && (
               <div className="py-8 flex flex-col gap-3">

--- a/apps/dashboard/src/entities/agent.test.ts
+++ b/apps/dashboard/src/entities/agent.test.ts
@@ -114,6 +114,38 @@ describe("AgentInputSchema packages validation", () => {
     const result = AgentInputSchema.safeParse({ packages: { pip: [123] } });
     expect(result.success).toBe(false);
   });
+
+  it("accepts valid pip specifiers (name, version pin, extras, chained constraints)", () => {
+    const result = AgentInputSchema.safeParse({
+      packages: {
+        pip: ["requests", "pandas==2.1.0", "mypackage[extra1,extra2]>=1.0", "numpy>=1.20,<2.0"],
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects pip specifiers with shell metacharacters or whitespace", () => {
+    for (const bad of ["requests; rm -rf /", "package with space", "$(evil)", "a|b", "`x`"]) {
+      const result = AgentInputSchema.safeParse({ packages: { pip: [bad] } });
+      expect(result.success).toBe(false);
+    }
+  });
+
+  it("accepts valid npm specifiers (name, scoped, versioned)", () => {
+    const result = AgentInputSchema.safeParse({
+      packages: {
+        npm: ["typescript", "typescript@^5.0.0", "@anthropic-ai/sdk", "@anthropic-ai/sdk@1.2.3"],
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects npm specifiers with shell metacharacters or whitespace", () => {
+    for (const bad of ["typescript; rm -rf /", "package with space", "$(evil)", "a|b", "`x`"]) {
+      const result = AgentInputSchema.safeParse({ packages: { npm: [bad] } });
+      expect(result.success).toBe(false);
+    }
+  });
 });
 
 describe("AgentInputObjectSchema as LLM structured-output schema", () => {

--- a/apps/dashboard/src/entities/agent.test.ts
+++ b/apps/dashboard/src/entities/agent.test.ts
@@ -92,6 +92,30 @@ describe("AgentInputSchema env placeholder validation", () => {
   });
 });
 
+describe("AgentInputSchema packages validation", () => {
+  it("succeeds with pip and npm package lists", () => {
+    const result = AgentInputSchema.safeParse({
+      packages: { pip: ["requests", "pandas==2.1.0"], npm: ["typescript"] },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("succeeds when packages is omitted entirely", () => {
+    const result = AgentInputSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  it("succeeds with only pip or only npm set", () => {
+    expect(AgentInputSchema.safeParse({ packages: { pip: ["requests"] } }).success).toBe(true);
+    expect(AgentInputSchema.safeParse({ packages: { npm: ["typescript"] } }).success).toBe(true);
+  });
+
+  it("fails when a package entry is not a string", () => {
+    const result = AgentInputSchema.safeParse({ packages: { pip: [123] } });
+    expect(result.success).toBe(false);
+  });
+});
+
 describe("AgentInputObjectSchema as LLM structured-output schema", () => {
   it("accepts a representative generated payload", () => {
     const result = AgentInputObjectSchema.safeParse({

--- a/apps/dashboard/src/entities/agent.ts
+++ b/apps/dashboard/src/entities/agent.ts
@@ -104,17 +104,41 @@ export const PluginsSchema = z
 
 export type Plugins = z.infer<typeof PluginsSchema>;
 
+export const PipPackageSchema = z
+  .string()
+  .min(1)
+  .max(128, "Package specifier exceeds maximum length of 128 characters")
+  .regex(
+    /^[A-Za-z0-9][A-Za-z0-9._-]*(\[[A-Za-z0-9,_-]+\])?([<>=!~]=?[A-Za-z0-9.*+]+(,[<>=!~]=?[A-Za-z0-9.*+]+)*)?$/,
+    "Invalid pip package specifier. Expected a name, optionally followed by extras and a " +
+      'version constraint, e.g. "requests" or "pandas==2.1.0".'
+  );
+
+export type PipPackage = z.infer<typeof PipPackageSchema>;
+
+export const NpmPackageSchema = z
+  .string()
+  .min(1)
+  .max(128, "Package specifier exceeds maximum length of 128 characters")
+  .regex(
+    /^(@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*(@[A-Za-z0-9^~.*+<>=-]+)?$/,
+    "Invalid npm package specifier. Expected a name, optionally scoped and followed by a " +
+      'version, e.g. "typescript" or "@anthropic-ai/sdk@^1.0.0".'
+  );
+
+export type NpmPackage = z.infer<typeof NpmPackageSchema>;
+
 export const PackagesSchema = z
   .object({
     pip: z
-      .array(z.string())
+      .array(PipPackageSchema)
       .max(50)
       .optional()
       .describe(
         'Python package specifiers to install via `uv pip install` (e.g. "requests", "pandas==2.1.0").'
       ),
     npm: z
-      .array(z.string())
+      .array(NpmPackageSchema)
       .max(50)
       .optional()
       .describe(

--- a/apps/dashboard/src/entities/agent.ts
+++ b/apps/dashboard/src/entities/agent.ts
@@ -104,6 +104,28 @@ export const PluginsSchema = z
 
 export type Plugins = z.infer<typeof PluginsSchema>;
 
+export const PackagesSchema = z
+  .object({
+    pip: z
+      .array(z.string())
+      .max(50)
+      .optional()
+      .describe(
+        'Python package specifiers to install via `uv pip install` (e.g. "requests", "pandas==2.1.0").'
+      ),
+    npm: z
+      .array(z.string())
+      .max(50)
+      .optional()
+      .describe(
+        'npm package specifiers to install via `npm install` (e.g. "@anthropic-ai/sdk", "typescript@^5.0.0").'
+      ),
+  })
+  .optional()
+  .describe("Python and npm packages to pre-install before the agent starts.");
+
+export type Packages = z.infer<typeof PackagesSchema>;
+
 export const StorageSchema = z
   .object({
     enabled: z.boolean().default(true),
@@ -141,6 +163,7 @@ export const AgentInputObjectSchema = z.object({
   env: EnvSchema,
   skills: SkillsSchema,
   plugins: PluginsSchema,
+  packages: PackagesSchema,
   sharedEnvSets: z
     .array(z.string())
     .optional()

--- a/apps/dashboard/src/server/infras/kubernetes/client.test.ts
+++ b/apps/dashboard/src/server/infras/kubernetes/client.test.ts
@@ -4,6 +4,7 @@ import {
   agentEnvResourceName,
   agentToHermesAgent,
   hashAgentEnv,
+  mapHermesAgent,
   mapHermesConfig,
   maskSensitiveEnv,
   splitAgentEnv,
@@ -105,6 +106,36 @@ describe("agentToHermesAgent workspace.dotEnv wiring", () => {
       configMapRef: { name: "agent-1-dot-env" },
       secretRef: { name: "agent-1-dot-env" },
     });
+  });
+});
+
+describe("agentToHermesAgent packages wiring", () => {
+  it("nests pip and npm install lists under the CR shape", () => {
+    const hermesAgent = agentToHermesAgent(
+      makeAgent({ packages: { pip: ["requests", "pandas==2.1.0"], npm: ["typescript"] } })
+    );
+    expect(hermesAgent.spec.hermes?.packages).toEqual({
+      pip: { install: ["requests", "pandas==2.1.0"] },
+      npm: { install: ["typescript"] },
+    });
+  });
+
+  it("omits pip/npm keys that are undefined", () => {
+    const hermesAgent = agentToHermesAgent(makeAgent({ packages: { pip: ["requests"] } }));
+    expect(hermesAgent.spec.hermes?.packages).toEqual({ pip: { install: ["requests"] } });
+  });
+
+  it("leaves packages undefined when not set on the agent", () => {
+    const hermesAgent = agentToHermesAgent(makeAgent());
+    expect(hermesAgent.spec.hermes?.packages).toBeUndefined();
+  });
+
+  it("round-trips through mapHermesAgent back to flat arrays", () => {
+    const hermesAgent = agentToHermesAgent(
+      makeAgent({ packages: { pip: ["requests"], npm: ["typescript"] } })
+    );
+    const roundTripped = mapHermesAgent(hermesAgent);
+    expect(roundTripped.packages).toEqual({ pip: ["requests"], npm: ["typescript"] });
   });
 });
 

--- a/apps/dashboard/src/server/infras/kubernetes/client.ts
+++ b/apps/dashboard/src/server/infras/kubernetes/client.ts
@@ -193,6 +193,12 @@ export function agentToHermesAgent(agent: Agent): HermesAgent {
   if (agent.plugins !== undefined) {
     hermes.plugins = agent.plugins.map((identifier) => ({ identifier }));
   }
+  if (agent.packages !== undefined) {
+    hermes.packages = {
+      ...(agent.packages.pip !== undefined && { pip: { install: agent.packages.pip } }),
+      ...(agent.packages.npm !== undefined && { npm: { install: agent.packages.npm } }),
+    };
+  }
   hermes.image = { repository: config.hermesImageRepository, tag: config.hermesImageTag };
 
   const spec: HermesAgentSpec = {
@@ -246,6 +252,14 @@ export function mapHermesAgent(raw: HermesAgent): Agent {
     soul: raw.spec.hermes?.workspace?.files?.["SOUL.md"],
     skills: raw.spec.hermes?.skills?.map((s) => s.identifier),
     plugins: raw.spec.hermes?.plugins?.map((p) => p.identifier),
+    packages: raw.spec.hermes?.packages && {
+      ...(raw.spec.hermes.packages.pip?.install !== undefined && {
+        pip: raw.spec.hermes.packages.pip.install,
+      }),
+      ...(raw.spec.hermes.packages.npm?.install !== undefined && {
+        npm: raw.spec.hermes.packages.npm.install,
+      }),
+    },
     suspended: raw.spec.suspend,
     archived: raw.metadata?.labels?.[HermeumLabel.Archived] === "true",
     phase: raw.status?.phase as AgentPhase | undefined,


### PR DESCRIPTION
## Summary
- Adds a `packages` field to `AgentInput` (`{ pip?: string[], npm?: string[] }`) so agents can pre-install Python/npm packages before starting, mirroring the `HermesAgent` CRD's existing `spec.hermes.packages` support.
- Wires it through the same path as `skills`/`plugins`: entity schema → create/patch mapping (`agentToHermesAgent`) → round-trip mapping (`mapHermesAgent`) → agent detail view (new "Python Packages" / "npm Packages" sections).
- Validates each package specifier with a regex, since these strings flow into a shell exec (`uv pip install` / `npm install`) — rejects anything containing shell metacharacters or whitespace instead of accepting arbitrary strings.

## Test plan
- [x] `pnpm lint` — clean (pre-existing unrelated warnings only)
- [x] `pnpm format:check` — clean for touched files
- [x] `pnpm vitest run src/entities/agent.test.ts src/server/infras/kubernetes/client.test.ts` — 48/48 passing
- [x] Manually verified end-to-end in the browser: created an agent via the YAML editor with `packages: { pip: [requests], npm: [typescript] }`, confirmed via `kubectl` that the CR stored `spec.hermes.packages.pip.install`/`npm.install` correctly, and confirmed the detail page renders both sections.
- [x] Manually verified an invalid pip specifier (`"requests; rm -rf /"`) is rejected client-side with a clear validation error.