### PR TITLE
Add optional tools parameter to generateAgentInput

### DIFF
--- a/apps/dashboard/src/server/infras/ai-sdk.ts
+++ b/apps/dashboard/src/server/infras/ai-sdk.ts
@@ -1,10 +1,21 @@
 import { createOpenAI } from "@ai-sdk/openai";
-import { generateText, NoObjectGeneratedError, Output } from "ai";
+import { generateText, isStepCount, NoObjectGeneratedError, Output, tool, ToolSet } from "ai";
 
 import { AgentInput, AgentInputObjectSchema } from "@/entities";
 import { config } from "@/server/libs/config";
 
-import { AiGenerator } from "../usecases/adaptors/generator";
+import { AiGenerator, AiGeneratorTool } from "../usecases/adaptors/generator";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function toToolSet(tools?: Record<string, AiGeneratorTool<any>>): ToolSet | undefined {
+  if (!tools) return undefined;
+  return Object.fromEntries(
+    Object.entries(tools).map(([name, t]) => [
+      name,
+      tool({ description: t.description, inputSchema: t.inputSchema, execute: t.execute }),
+    ])
+  );
+}
 
 export class AiSdkGenerator implements AiGenerator {
   // Lazy: built on first use so the dashboard boots without any AI config
@@ -23,16 +34,26 @@ export class AiSdkGenerator implements AiGenerator {
     return this.openai(config.openaiModel);
   }
 
-  async generateAgentInput(input: { system: string; prompt: string }): Promise<AgentInput> {
+  async generateAgentInput(input: {
+    system: string;
+    prompt: string;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    tools?: Record<string, AiGeneratorTool<any>>;
+  }): Promise<AgentInput> {
     try {
       // Explicitly disable strict JSON schema mode — the schema uses
       // looseObject/record/optionals, which strict mode rejects. Chat
       // Completions models default this to false, but Responses API models
       // (e.g. gpt-5.5) default it to true, so it must be set here.
+      const tools = toToolSet(input.tools);
+      // Default stopWhen is isStepCount(1), which leaves no room for a tool
+      // call followed by the structured-output step.
+      const toolOptions = tools ? { tools, stopWhen: isStepCount(5) } : {};
       const result = await generateText({
         model: this.model(),
         system: input.system,
         prompt: input.prompt,
+        ...toolOptions,
         output: Output.object({ schema: AgentInputObjectSchema }),
         providerOptions: {
           openai: { strictJsonSchema: false },

--- a/apps/dashboard/src/server/usecases/adaptors/generator.ts
+++ b/apps/dashboard/src/server/usecases/adaptors/generator.ts
@@ -1,8 +1,26 @@
+import { z } from "zod";
+
 import { AgentInput } from "@/entities";
+
+// Kept independent of the `ai` package's own `Tool`/`ToolSet` types so this
+// adaptor boundary has no AI-SDK-specific dependency; implementations adapt
+// it to whatever the underlying SDK expects.
+export interface AiGeneratorTool<TInput = unknown> {
+  description: string;
+  inputSchema: z.ZodType<TInput>;
+  execute: (input: TInput) => unknown | Promise<unknown>;
+}
 
 // Single LLM-call primitive. The usecase composes the system and user
 // prompts; the implementation owns model selection and structured-output
 // mechanics.
 export interface AiGenerator {
-  generateAgentInput(input: { system: string; prompt: string }): Promise<AgentInput>;
+  generateAgentInput(input: {
+    system: string;
+    prompt: string;
+    // `any` here (matching the `ai` package's own `ToolSet`) is what lets a
+    // single record hold tools with different input types.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    tools?: Record<string, AiGeneratorTool<any>>;
+  }): Promise<AgentInput>;
 }


### PR DESCRIPTION
## Summary
- Add an `AiGeneratorTool` type (`description` / `inputSchema` / `execute`) and an optional `tools` param to `AiGenerator.generateAgentInput`, kept independent of the `ai` package's own `Tool`/`ToolSet` types.
- `AiSdkGenerator.generateAgentInput` converts the abstract tools into the AI SDK's `tool()`/`ToolSet` and passes them to `generateText`, following the [structured outputs with tools](https://ai-sdk.dev/docs/ai-sdk-core/generating-structured-data#generating-structured-outputs-with-tools) pattern.
- Sets `stopWhen: isStepCount(5)` only when tools are supplied, since the default `stopWhen` of 1 step leaves no room for a tool call before the structured-output step.
- No existing caller passes `tools` yet (`AgentUseCase`/tRPC router untouched), so behavior is unchanged for current usage — this is plumbing for future in-process callers.

## Test plan
- [x] `pnpm lint` — 0 errors (2 pre-existing unrelated warnings)
- [x] `pnpm format:check` — no new formatting issues
- [x] `pnpm --filter dashboard run typecheck` — no new errors (1 pre-existing unrelated error in `client.test.ts`)
- [x] `pnpm --filter dashboard exec vitest run src/server/usecases/agent.test.ts` — 28/28 passing