### PR TITLE
feat: append available agent types to system prompt

### DIFF
--- a/apps/dashboard/src/entities/hermeum-config.ts
+++ b/apps/dashboard/src/entities/hermeum-config.ts
@@ -12,6 +12,7 @@ export const JsonPatchOpSchema = z.object({
 export type JsonPatchOp = z.infer<typeof JsonPatchOpSchema>;
 
 export const AgentTypeSchema = z.object({
+  description: z.string().optional(),
   mutatingWebhookJsonPatch: z.array(JsonPatchOpSchema),
 });
 

--- a/apps/dashboard/src/server/usecases/agent.ts
+++ b/apps/dashboard/src/server/usecases/agent.ts
@@ -21,30 +21,6 @@ import { Runtime } from "./adaptors/runtime";
 import { ConfigAdaptor } from "./adaptors/config";
 import { verifyOwnership } from "./authz";
 
-// Field semantics live in the output schema's .describe() texts; this prompt
-// carries per-feature cross-field rules and worked examples instead.
-export const AGENT_INPUT_SYSTEM_PROMPT = `\
-You generate agent definitions — a JSON object that prefills the form for a
-new autonomous agent. Field semantics are defined by the output schema; use
-it to decide what each field means and how to shape it.
-
-Tailor every field to the specific request — don't fall back to generic or
-placeholder-sounding content:
-- \`name\` and \`description\` should reflect what this particular agent does,
-  not a generic template.
-- \`soul\` should be written for this agent's actual job and tone, using the
-  request's own domain language where possible — not a reused boilerplate
-  personality.
-- Only set \`config\` sub-features (model, webhooks, api_server) that the
-  request actually needs to work. Infer the ones required to fulfill the
-  request even if unstated (e.g. "on every new GitHub issue" implies a
-  webhook route), but don't add unrelated ones "just in case".
-- Webhook routes, prompts, and skills should be built from what the request
-  says triggers the agent and what it should do — not copied from an
-  unrelated example.
-- When the request is ambiguous or gives no basis for a field, omit that
-  field rather than guessing or inventing detail that wasn't asked for.`;
-
 export const ListAgentsFilterSchema = z.object({
   archived: z.boolean().optional(),
 });
@@ -168,10 +144,28 @@ export class AgentUseCase {
     }
   }
 
+  private buildSystemPrompt(): string {
+    const { agentTypes } = this.config.get();
+    if (!agentTypes) {
+      return AGENT_INPUT_SYSTEM_PROMPT;
+    }
+
+    // Append a list of configured agent types to the system prompt.
+    const lines = Object.entries(agentTypes).map(
+      ([key, t]) => `- ${key}${t.description ? `: ${t.description}` : ""}`
+    );
+    return (
+      AGENT_INPUT_SYSTEM_PROMPT +
+      "\n\nAgent types (optional — set `type` only if the request clearly " +
+      "matches one; otherwise omit):\n" +
+      lines.join("\n")
+    );
+  }
+
   async generateAgentInput(ctx: Context, prompt: Prompt): Promise<AgentInput> {
     prompt = PromptSchema.parse(prompt);
     const output = await this.generator.generateAgentInput({
-      system: AGENT_INPUT_SYSTEM_PROMPT,
+      system: this.buildSystemPrompt(),
       prompt: `Create a new Hermes agent definition from this request:\n\n${prompt}`,
     });
     return this.finalizeGeneratedAgentInput(output);
@@ -180,7 +174,7 @@ export class AgentUseCase {
   async reviseAgentInput(ctx: Context, current: AgentInput, prompt: Prompt): Promise<AgentInput> {
     prompt = PromptSchema.parse(prompt);
     const output = await this.generator.generateAgentInput({
-      system: AGENT_INPUT_SYSTEM_PROMPT,
+      system: this.buildSystemPrompt(),
       prompt:
         "Here is an existing Hermes agent definition as JSON:\n\n" +
         JSON.stringify(current, null, 2) +
@@ -233,3 +227,27 @@ export class AgentUseCase {
     return env.length > 0 ? env : parsed.env;
   }
 }
+
+// Field semantics live in the output schema's .describe() texts; this prompt
+// carries per-feature cross-field rules and worked examples instead.
+export const AGENT_INPUT_SYSTEM_PROMPT = `\
+You generate agent definitions — a JSON object that prefills the form for a
+new autonomous agent. Field semantics are defined by the output schema; use
+it to decide what each field means and how to shape it.
+
+Tailor every field to the specific request — don't fall back to generic or
+placeholder-sounding content:
+- \`name\` and \`description\` should reflect what this particular agent does,
+  not a generic template.
+- \`soul\` should be written for this agent's actual job and tone, using the
+  request's own domain language where possible — not a reused boilerplate
+  personality.
+- Only set \`config\` sub-features (model, webhooks, api_server) that the
+  request actually needs to work. Infer the ones required to fulfill the
+  request even if unstated (e.g. "on every new GitHub issue" implies a
+  webhook route), but don't add unrelated ones "just in case".
+- Webhook routes, prompts, and skills should be built from what the request
+  says triggers the agent and what it should do — not copied from an
+  unrelated example.
+- When the request is ambiguous or gives no basis for a field, omit that
+  field rather than guessing or inventing detail that wasn't asked for.`;


### PR DESCRIPTION
## Summary

- Add optional `description` field to `AgentTypeSchema` in `entities/hermeum-config.ts`
- Add `buildSystemPrompt()` to `AgentUseCase` that appends configured agent types (key + description) to the base system prompt
- Wire `buildSystemPrompt()` into both `generateAgentInput` and `reviseAgentInput`
- Move `AGENT_INPUT_SYSTEM_PROMPT` constant to the bottom of the file (per request)

The appended text marks `type` as optional so the LLM only sets it when the request clearly matches a configured agent type.

## Test plan

- [x] `pnpm test -- src/server/usecases/agent.test.ts` — 28 tests pass
- [x] `pnpm lint` — no new errors