### PR TITLE
feat: add web search config and provision SearXNG sidecar

### DIFF
--- a/apps/dashboard/src/entities/agent.test.ts
+++ b/apps/dashboard/src/entities/agent.test.ts
@@ -290,3 +290,31 @@ describe("AgentInputObjectSchema as LLM structured-output schema", () => {
     expect(() => z.toJSONSchema(AgentInputObjectSchema)).not.toThrow();
   });
 });
+
+describe("AgentInputSchema web config validation", () => {
+  it("accepts a searxng search_backend with a paired extract_backend", () => {
+    const result = AgentInputSchema.safeParse({
+      config: { web: { search_backend: "searxng", extract_backend: "firecrawl" } },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts the single-backend form", () => {
+    const result = AgentInputSchema.safeParse({ config: { web: { backend: "searxng" } } });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an unknown search backend", () => {
+    const result = AgentInputSchema.safeParse({
+      config: { web: { search_backend: "google" } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an extract backend that doesn't support extraction", () => {
+    const result = AgentInputSchema.safeParse({
+      config: { web: { extract_backend: "ddgs" } },
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/dashboard/src/entities/hermes-config.ts
+++ b/apps/dashboard/src/entities/hermes-config.ts
@@ -305,11 +305,56 @@ Example — expose the agent over HTTP for a browser client:
 
 export type ApiServer = z.infer<typeof ApiServerSchema>;
 
+// Web Search & Extract
+// https://hermes-agent.nousresearch.com/docs/user-guide/features/web-search
+export const WebSearchBackendSchema = z
+  .enum(["firecrawl", "searxng", "brave-free", "ddgs", "tavily", "exa", "parallel", "xai"])
+  .describe("Web search backend provider.");
+
+export type WebSearchBackend = z.infer<typeof WebSearchBackendSchema>;
+
+export const WebExtractBackendSchema = z
+  .enum(["firecrawl", "tavily", "exa", "parallel"])
+  .describe(
+    "Web extract backend provider. Only Firecrawl, Tavily, Exa, and Parallel " +
+      "support extraction; the others are search-only."
+  );
+
+export type WebExtractBackend = z.infer<typeof WebExtractBackendSchema>;
+
+export const WebSchema = z
+  .looseObject({
+    backend: WebSearchBackendSchema.optional().describe(
+      "Single backend for both search and extract. Use search_backend / " +
+        "extract_backend to set them independently."
+    ),
+    search_backend: WebSearchBackendSchema.optional().describe(
+      'Backend for the web_search tool. Prefer "searxng" — it is natively ' +
+        "supported and provisions a self-hosted SearXNG sidecar in the agent's " +
+        "pod with no external API key required."
+    ),
+    extract_backend: WebExtractBackendSchema.optional().describe(
+      "Backend for the web_extract tool. Required only when search_backend is " +
+        "search-only (e.g. searxng, ddgs) and you also need URL extraction."
+    ),
+  })
+  .describe(
+    `Web search & extract configuration. \
+The agent uses these backends for its web_search and web_extract tools.
+
+Example — free self-hosted search with Firecrawl extraction:
+  search_backend: "searxng"
+  extract_backend: "firecrawl"`
+  );
+
+export type Web = z.infer<typeof WebSchema>;
+
 export const ConfigSchema = z
   .looseObject({
     model: ModelSchema.optional().describe("Model configuration to use."),
     platforms: PlatformsSchema.optional(),
     api_server: ApiServerSchema.optional(),
+    web: WebSchema.optional(),
   })
   .optional()
   .describe(

--- a/apps/dashboard/src/server/infras/kubernetes/client.test.ts
+++ b/apps/dashboard/src/server/infras/kubernetes/client.test.ts
@@ -202,6 +202,42 @@ describe("agentToHermesAgent config.apiServer wiring", () => {
   });
 });
 
+describe("agentToHermesAgent spec.searxng wiring", () => {
+  it("enables searxng and keeps web in raw when search_backend is searxng", () => {
+    const hermesAgent = agentToHermesAgent(
+      makeAgent({ config: { web: { search_backend: "searxng", extract_backend: "firecrawl" } } })
+    );
+    expect(hermesAgent.spec.searxng).toEqual({ enabled: true });
+    expect(hermesAgent.spec.hermes?.config?.raw).toEqual({
+      web: { search_backend: "searxng", extract_backend: "firecrawl" },
+    });
+  });
+
+  it("enables searxng when backend is searxng (single-backend form)", () => {
+    const hermesAgent = agentToHermesAgent(makeAgent({ config: { web: { backend: "searxng" } } }));
+    expect(hermesAgent.spec.searxng).toEqual({ enabled: true });
+  });
+
+  it("leaves searxng undefined for a non-searxng backend", () => {
+    const hermesAgent = agentToHermesAgent(
+      makeAgent({ config: { web: { search_backend: "firecrawl" } } })
+    );
+    expect(hermesAgent.spec.searxng).toBeUndefined();
+    expect(hermesAgent.spec.hermes?.config?.raw).toEqual({ web: { search_backend: "firecrawl" } });
+  });
+
+  it("leaves searxng undefined when web config is absent", () => {
+    const hermesAgent = agentToHermesAgent(makeAgent());
+    expect(hermesAgent.spec.searxng).toBeUndefined();
+  });
+
+  it("round-trips web config through the CR", () => {
+    const config = { web: { search_backend: "searxng" as const } };
+    const hermesAgent = agentToHermesAgent(makeAgent({ config }));
+    expect(mapHermesConfig(hermesAgent.spec.hermes?.config)).toEqual(config);
+  });
+});
+
 describe("mapHermesConfig", () => {
   it("folds apiServer back into config as snake_case api_server without existingSecret", () => {
     expect(

--- a/apps/dashboard/src/server/infras/kubernetes/client.ts
+++ b/apps/dashboard/src/server/infras/kubernetes/client.ts
@@ -150,7 +150,12 @@ export function agentToHermesAgent(agent: Agent): HermesAgent {
   }
 
   const hermes: Partial<HermesAgentSpec["hermes"]> = {};
+  // Enable the SearXNG sidecar when the agent asks for the searxng backend.
+  let searxngEnabled = false;
   if (agent.config !== undefined) {
+    searxngEnabled =
+      agent.config.web?.search_backend === "searxng" ||
+      agent.config.web?.backend === "searxng";
     // The Hermes agent has no api_server section in config.yaml — it belongs to
     // the CR's dedicated config.apiServer field, so keep it out of raw.
     const { api_server: apiServer, ...rawConfig } = agent.config;
@@ -207,6 +212,7 @@ export function agentToHermesAgent(agent: Agent): HermesAgent {
   const spec: HermesAgentSpec = {
     ...(agent.suspended !== undefined && { suspend: agent.suspended }),
     ...(Object.keys(hermes).length > 0 && { hermes: hermes as HermesAgentSpec["hermes"] }),
+    ...(searxngEnabled && { searxng: { enabled: true } }),
     podAnnotations: { [HermeumPodAnnotation.EnvHash]: hashAgentEnv(agent.env) },
   };
 


### PR DESCRIPTION
## Summary

Adds a `web` section to the Hermes agent config schema (`WebSchema`) mirroring the upstream [web search & extract](https://hermes-agent.nousresearch.com/docs/user-guide/features/web-search) config, and provisions a self-hosted SearXNG sidecar when the `searxng` backend is selected.

## Changes

- **`hermes-config.ts`**: New `WebSchema` (loose object) with `backend`, `search_backend`, and `extract_backend` fields. `search_backend` prefers `searxng` as natively supported (no external API key required). Added to `ConfigSchema`.
- **`client.ts`**: When `web.search_backend` (or `web.backend`) is `"searxng"`, `agentToHermesAgent` sets `spec.searxng.enabled = true` on the HermesAgent CR so the operator provisions the SearXNG sidecar. The `web` block stays in `config.raw` for the agent to read.
- **Tests**: SearXNG wiring tests in `client.test.ts` (enabled via both forms, undefined for other backends, round-trip) and web config validation tests in `agent.test.ts`.

## Test plan

- [x] `pnpm test` — 118 passed
- [x] `pnpm lint` — no new issues
- [x] `pnpm typecheck` — no new errors (one pre-existing error on untouched test)