### PR TITLE
feat: add Slack config schema to hermes-config

### DIFF
--- a/apps/dashboard/src/entities/hermes-config.ts
+++ b/apps/dashboard/src/entities/hermes-config.ts
@@ -272,26 +272,22 @@ export const SlackSchema = z
       .array(z.string())
       .optional()
       .describe(
-        "Slack channel IDs the bot is allowed to respond in. " +
-          "When set, messages from channels NOT in this list are silently ignored."
+        "Slack channel IDs the bot is allowed to respond in. Messages from " +
+          "channels not in this list are silently ignored."
       ),
     unauthorized_dm_behavior: z
       .literal("ignore")
       .default("ignore")
       .optional()
       .describe(
-        'What happens when an unauthorized user DMs the bot. Must be "ignore" — ' +
-          "the message is silently dropped." 
+        "What happens when an unauthorized user DMs the bot. Always \"ignore\" " +
+          "(silently drop); the upstream \"pair\" default is intentionally disallowed."
       ),
   })
   .describe(
     `Slack messaging platform configuration. \
-
-Example:
-  slack:
-    allowed_channels:
-      - C0123456789
-    unauthorized_dm_behavior: ignore`
+Requires env vars: SLACK_BOT_TOKEN (sensitive), SLACK_APP_TOKEN (sensitive), \
+SLACK_HOME_CHANNEL, and SLACK_ALLOWED_USERS.`
   );
 
 export type Slack = z.infer<typeof SlackSchema>;

--- a/apps/dashboard/src/entities/hermes-config.ts
+++ b/apps/dashboard/src/entities/hermes-config.ts
@@ -261,6 +261,41 @@ export const PlatformsSchema = z
 
 export type Platforms = z.infer<typeof PlatformsSchema>;
 
+// Slack
+// https://hermes-agent.nousresearch.com/docs/user-guide/messaging/slack
+//
+// Only the essential fields are validated here; the rest pass through
+// via looseObject so users can configure whatever the Hermes agent supports.
+export const SlackSchema = z
+  .looseObject({
+    allowed_channels: z
+      .array(z.string())
+      .optional()
+      .describe(
+        "Slack channel IDs the bot is allowed to respond in. " +
+          "When set, messages from channels NOT in this list are silently ignored."
+      ),
+    unauthorized_dm_behavior: z
+      .literal("ignore")
+      .default("ignore")
+      .optional()
+      .describe(
+        'What happens when an unauthorized user DMs the bot. Must be "ignore" — ' +
+          "the message is silently dropped." 
+      ),
+  })
+  .describe(
+    `Slack messaging platform configuration. \
+
+Example:
+  slack:
+    allowed_channels:
+      - C0123456789
+    unauthorized_dm_behavior: ignore`
+  );
+
+export type Slack = z.infer<typeof SlackSchema>;
+
 // API server
 // https://hermes-agent.nousresearch.com/docs/user-guide/features/api-server
 //
@@ -310,6 +345,7 @@ export const ConfigSchema = z
     model: ModelSchema.optional().describe("Model configuration to use."),
     platforms: PlatformsSchema.optional(),
     api_server: ApiServerSchema.optional(),
+    slack: SlackSchema.optional(),
   })
   .optional()
   .describe(


### PR DESCRIPTION
## Summary

Add a top-level `slack` key to `ConfigSchema` in `hermes-config.ts`, based on the [Slack messaging docs](https://hermes-agent.nousresearch.com/docs/user-guide/messaging/slack).

The schema is a `z.looseObject()` with only two validated fields essential for AI generation:

- **`allowed_channels`** — channel allowlist; messages from channels not in this list are silently ignored.
- **`unauthorized_dm_behavior`** — locked to `"ignore"` via `z.literal("ignore")` so the AI can never generate the upstream `"pair"` default (which would prompt unauthorized users for a pairing code).

All other Slack fields (`require_mention`, `strict_mention`, `mention_patterns`, `reply_prefix`, `channel_prompts`, `channel_skill_bindings`, and everything under `platforms.slack`) pass through unchanged via `looseObject`.

The schema description notes the required env vars: `SLACK_BOT_TOKEN` (sensitive), `SLACK_APP_TOKEN` (sensitive), `SLACK_HOME_CHANNEL`, and `SLACK_ALLOWED_USERS`.

## Verification

- `pnpm --filter @hermeum/dashboard lint` — passes (0 errors)
- `pnpm --filter @hermeum/dashboard test` — all 109 tests pass
- `pnpm --filter @hermeum/dashboard typecheck` — one pre-existing error in `client.test.ts:233` (unrelated `model.provider` type narrowing, present on base branch)