### PR TITLE
feat: add browser config and provision Camofox sidecar

### DIFF
--- a/apps/dashboard/src/entities/agent.test.ts
+++ b/apps/dashboard/src/entities/agent.test.ts
@@ -318,3 +318,26 @@ describe("AgentInputSchema web config validation", () => {
     expect(result.success).toBe(false);
   });
 });
+
+describe("AgentInputSchema browser config validation", () => {
+  it("accepts cloud_provider: camofox", () => {
+    const result = AgentInputSchema.safeParse({
+      config: { browser: { cloud_provider: "camofox" } },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a cloud provider", () => {
+    const result = AgentInputSchema.safeParse({
+      config: { browser: { cloud_provider: "browserbase" } },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an unknown cloud provider", () => {
+    const result = AgentInputSchema.safeParse({
+      config: { browser: { cloud_provider: "playwright" } },
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/dashboard/src/entities/hermes-config.ts
+++ b/apps/dashboard/src/entities/hermes-config.ts
@@ -380,6 +380,31 @@ Example — free self-hosted search with Firecrawl extraction:
 
 export type Web = z.infer<typeof WebSchema>;
 
+// Browser
+// https://hermes-agent.nousresearch.com/docs/user-guide/features/browser
+export const BrowserCloudProviderSchema = z
+  .enum(["browserbase", "browser-use", "firecrawl", "camofox"])
+  .describe(
+    'Browser automation provider. Prefer "camofox" - it is natively' + 
+      "supported provisions a self-hosted Camofox sidecar in the agent's pod — no API key required." + 
+      "The others require their respective API-key env vars.");
+
+export type BrowserCloudProvider = z.infer<typeof BrowserCloudProviderSchema>;
+
+export const BrowserSchema = z
+  .looseObject({
+    cloud_provider: BrowserCloudProviderSchema.optional(),
+  })
+  .optional()
+  .describe(
+    `Browser automation configuration.
+
+Example — self-hosted anti-detection browsing:
+  cloud_provider: "camofox"`
+  );
+
+export type Browser = z.infer<typeof BrowserSchema>;
+
 export const ConfigSchema = z
   .looseObject({
     model: ModelSchema.optional(),
@@ -387,6 +412,7 @@ export const ConfigSchema = z
     api_server: ApiServerSchema.optional(),
     slack: SlackSchema.optional(),
     web: WebSchema.optional(),
+    browser: BrowserSchema,
   })
   .optional()
   .describe(

--- a/apps/dashboard/src/server/infras/kubernetes/client.test.ts
+++ b/apps/dashboard/src/server/infras/kubernetes/client.test.ts
@@ -238,6 +238,39 @@ describe("agentToHermesAgent spec.searxng wiring", () => {
   });
 });
 
+describe("agentToHermesAgent spec.camofox wiring", () => {
+  it("enables camofox and keeps browser in raw when cloud_provider is camofox", () => {
+    const hermesAgent = agentToHermesAgent(
+      makeAgent({ config: { browser: { cloud_provider: "camofox" } } })
+    );
+    expect(hermesAgent.spec.camofox).toEqual({ enabled: true });
+    expect(hermesAgent.spec.hermes?.config?.raw).toEqual({
+      browser: { cloud_provider: "camofox" },
+    });
+  });
+
+  it("leaves camofox undefined for a non-camofox cloud provider", () => {
+    const hermesAgent = agentToHermesAgent(
+      makeAgent({ config: { browser: { cloud_provider: "browserbase" } } })
+    );
+    expect(hermesAgent.spec.camofox).toBeUndefined();
+    expect(hermesAgent.spec.hermes?.config?.raw).toEqual({
+      browser: { cloud_provider: "browserbase" },
+    });
+  });
+
+  it("leaves camofox undefined when browser config is absent", () => {
+    const hermesAgent = agentToHermesAgent(makeAgent());
+    expect(hermesAgent.spec.camofox).toBeUndefined();
+  });
+
+  it("round-trips browser config through the CR", () => {
+    const config = { browser: { cloud_provider: "camofox" as const } };
+    const hermesAgent = agentToHermesAgent(makeAgent({ config }));
+    expect(mapHermesConfig(hermesAgent.spec.hermes?.config)).toEqual(config);
+  });
+});
+
 describe("mapHermesConfig", () => {
   it("folds apiServer back into config as snake_case api_server without existingSecret", () => {
     expect(

--- a/apps/dashboard/src/server/infras/kubernetes/client.ts
+++ b/apps/dashboard/src/server/infras/kubernetes/client.ts
@@ -150,12 +150,15 @@ export function agentToHermesAgent(agent: Agent): HermesAgent {
   }
 
   const hermes: Partial<HermesAgentSpec["hermes"]> = {};
-  // Enable the SearXNG sidecar when the agent asks for the searxng backend.
+  // Enable self-hosted sidecars when the agent asks for them.
+  // SearXNG: web search backend; Camofox: browser automation cloud provider.
   let searxngEnabled = false;
+  let camofoxEnabled = false;
   if (agent.config !== undefined) {
     searxngEnabled =
       agent.config.web?.search_backend === "searxng" ||
       agent.config.web?.backend === "searxng";
+    camofoxEnabled = agent.config.browser?.cloud_provider === "camofox";
     // The Hermes agent has no api_server section in config.yaml — it belongs to
     // the CR's dedicated config.apiServer field, so keep it out of raw.
     const { api_server: apiServer, ...rawConfig } = agent.config;
@@ -213,6 +216,7 @@ export function agentToHermesAgent(agent: Agent): HermesAgent {
     ...(agent.suspended !== undefined && { suspend: agent.suspended }),
     ...(Object.keys(hermes).length > 0 && { hermes: hermes as HermesAgentSpec["hermes"] }),
     ...(searxngEnabled && { searxng: { enabled: true } }),
+    ...(camofoxEnabled && { camofox: { enabled: true } }),
     podAnnotations: { [HermeumPodAnnotation.EnvHash]: hashAgentEnv(agent.env) },
   };
 


### PR DESCRIPTION
## Summary

Add browser automation configuration to the Hermes agent config schema following [the browser docs](https://hermes-agent.nousresearch.com/docs/user-guide/features/browser).

## Changes

- **`hermes-config.ts`**: Add `BrowserCloudProviderSchema` enum (`browserbase`, `browser-use`, `firecrawl`, `camofox`) and `BrowserSchema` (looseObject with `cloud_provider`), wired into `ConfigSchema` as `browser`. The `looseObject` allows pass-through of all other documented browser fields (camofox sub-config, cdp_url, record_sessions, dialog_policy, etc.).
- **`client.ts`**: In `agentToHermesAgent`, enable the Camofox sidecar on the HermesAgent CR when `cloud_provider: camofox` — mirroring how the SearXNG sidecar is enabled for the `searxng` web search backend. Browser config stays in `raw` since it's part of config.yaml.
- **Tests**: Add browser config validation tests (`agent.test.ts`) and Camofox CR wiring tests (`client.test.ts`) covering enable/disable/round-trip cases.

## Test plan

- [x] `pnpm test` — 125 tests pass
- [x] `pnpm lint` — no new errors
- [x] `pnpm typecheck` — no new errors (one pre-existing error unrelated to this change)