### PR TITLE
refactor: remove unused @ai-sdk/anthropic dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ dist
 
 agent-config.yaml
 .worktrees/
+.wtp.yml

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -17,7 +17,6 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@ai-sdk/anthropic": "^4.0.8",
     "@ai-sdk/openai": "^4.0.8",
     "@codemirror/lang-json": "^6.0.2",
     "@codemirror/lang-yaml": "^6.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
 
   apps/dashboard:
     dependencies:
-      '@ai-sdk/anthropic':
-        specifier: ^4.0.8
-        version: 4.0.8(zod@4.3.6)
       '@ai-sdk/openai':
         specifier: ^4.0.8
         version: 4.0.8(zod@4.3.6)
@@ -254,12 +251,6 @@ importers:
   packages/typescript-config: {}
 
 packages:
-
-  '@ai-sdk/anthropic@4.0.8':
-    resolution: {integrity: sha512-ZqT9kLxS2Cbo/4juwtEGbYyP0jNQTnUUKy2nQ8Vn28xqNu50+TukO/oCEWCpm18YbQq7N+hr6ClJs/ATTFpBTg==}
-    engines: {node: '>=22'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
 
   '@ai-sdk/gateway@4.0.12':
     resolution: {integrity: sha512-Y7Fy8xJwPz7ZC0DhSQG3HIVk+drup42hrIj6yqKlib3CxwiR0F7nYyUI8+kPrEtbZEoyKoRstvT4/o0HEyFBHA==}
@@ -4634,12 +4625,6 @@ packages:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
 snapshots:
-
-  '@ai-sdk/anthropic@4.0.8(zod@4.3.6)':
-    dependencies:
-      '@ai-sdk/provider': 4.0.2
-      '@ai-sdk/provider-utils': 5.0.5(zod@4.3.6)
-      zod: 4.3.6
 
   '@ai-sdk/gateway@4.0.12(zod@4.3.6)':
     dependencies:


### PR DESCRIPTION
## Summary

Removed the unused `@ai-sdk/anthropic` package from `apps/dashboard`.

- The package had **zero imports** in the codebase — the dashboard's AI generator (`src/server/infras/ai-sdk.ts`) only uses `@ai-sdk/openai`.
- Remaining "anthropic" string references are legitimate domain data: a valid model provider in the Hermes config enum, test fixtures, and example strings — not uses of this npm package.

## Changes
- `apps/dashboard/package.json` — removed `@ai-sdk/anthropic` dependency
- `pnpm-lock.yaml` — updated via `pnpm install`

## Verification
- `pnpm typecheck` — no new errors (the one pre-existing error in `client.test.ts` is unrelated; confirmed via `git stash`)
- `pnpm test` — all 118 tests pass