### PR TITLE
feat: validate skill identifier formats against hub-source spec

### DIFF
--- a/apps/dashboard/src/entities/agent.test.ts
+++ b/apps/dashboard/src/entities/agent.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { z } from "zod";
 
-import { AgentInputObjectSchema, AgentInputSchema } from "./agent";
+import { AgentInputObjectSchema, AgentInputSchema, SkillSchema } from "./agent";
 
 function makeInput(overrides: Record<string, unknown> = {}) {
   return {
@@ -288,6 +288,70 @@ describe("AgentInputObjectSchema as LLM structured-output schema", () => {
 
   it("is convertible to JSON Schema for the AI SDK", () => {
     expect(() => z.toJSONSchema(AgentInputObjectSchema)).not.toThrow();
+  });
+});
+
+describe("SkillSchema identifier formats", () => {
+  // https://hermes-agent.nousresearch.com/docs/user-guide/features/skills#supported-hub-sources
+
+  const valid: string[] = [
+    "axolotl",
+    "gif-search",
+    "standup-summarizer",
+    "npm:@hermeum/github-review",
+    "pack:./local/skill",
+    "official/security/1password",
+    "official/migration/openclaw-migration",
+    "skills-sh/vercel-labs/agent-skills/vercel-react-best-practices",
+    "browse-sh/airbnb.com/search-listings-ddgioa",
+    "clawhub/some-org/some-skill",
+    "lobehub/some-org/some-skill",
+    "claude-marketplace/some-org/some-skill",
+    "well-known:https://mintlify.com/docs/.well-known/skills/mintlify",
+    "https://sharethis.chat/SKILL.md",
+    "https://example.com/my-skill/SKILL.md",
+    "openai/skills/k8s",
+    "anthropics/skills/pdf",
+    "owner/repo/skills/my-workflow",
+  ];
+
+  it.each(valid)("accepts %s", (identifier) => {
+    expect(SkillSchema.safeParse(identifier).success).toBe(true);
+  });
+
+  const invalid: string[] = [
+    "bad skill!",
+    "npm:",
+    "pack:",
+    "official/",
+    "skills-sh/",
+    "browse-sh/",
+    "clawhub/",
+    "lobehub/",
+    "claude-marketplace/",
+    "well-known:not-a-url",
+    "ftp://example.com/SKILL.md",
+    "http://",
+    "https://",
+    "/openai",
+    "openai/",
+    "1bad",
+    "with space",
+  ];
+
+  it.each(invalid)("rejects %s", (identifier) => {
+    const result = SkillSchema.safeParse(identifier);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a skill exceeding 128 characters", () => {
+    const result = SkillSchema.safeParse("a".repeat(129));
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts a 128-character skill", () => {
+    const result = SkillSchema.safeParse("a".repeat(128));
+    expect(result.success).toBe(true);
   });
 });
 

--- a/apps/dashboard/src/entities/agent.ts
+++ b/apps/dashboard/src/entities/agent.ts
@@ -76,15 +76,170 @@ instructions (those belong elsewhere in the config).
 
 export type Soul = z.infer<typeof SoulSchema>;
 
+// https://hermes-agent.nousresearch.com/docs/user-guide/features/skills#supported-hub-sources
+const SKILL_SOURCE_PREFIXES = [
+  "official/",
+  "skills-sh/",
+  "browse-sh/",
+  "clawhub/",
+  "lobehub/",
+  "claude-marketplace/",
+] as const;
+
+const SKILL_NAMESPACE_PREFIXES = ["npm:", "pack:"] as const;
+
+const SIMPLE_SLUG_RE = /^[a-zA-Z][a-zA-Z0-9_-]*$/;
+const PATH_SEGMENT_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/;
+
+function isHttpUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function validateSkillIdentifier(s: string, ctx: z.RefinementCtx): void {
+  if (s.length === 0) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Skill identifier cannot be empty.",
+      path: [],
+    });
+    return;
+  }
+
+  // Prefixed namespace forms: "npm:@scope/pkg", "pack:./local/skill"
+  const nsPrefix = SKILL_NAMESPACE_PREFIXES.find((p) => s.startsWith(p));
+  if (nsPrefix !== undefined) {
+    const rest = s.slice(nsPrefix.length);
+    if (rest.length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Skill cannot be a bare "${nsPrefix}" prefix — a package identifier must follow.`,
+        path: [],
+      });
+    } else if (!/^[^\s]+$/.test(rest)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Skill "${s}" has whitespace in the package specifier after "${nsPrefix}".`,
+        path: [],
+      });
+    }
+    return;
+  }
+
+  // URL form: "well-known:<url>" or a bare http(s) URL
+  if (s.startsWith("well-known:")) {
+    const rest = s.slice("well-known:".length);
+    if (!isHttpUrl(rest)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          'well-known: skills must be followed by a valid http(s) URL, e.g. ' +
+          '"well-known:https://mintlify.com/docs/.well-known/skills/mintlify".',
+        path: [],
+      });
+    }
+    return;
+  }
+
+  if (s.startsWith("http://") || s.startsWith("https://")) {
+    if (!isHttpUrl(s)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Direct-URL skills must be valid http(s) URLs.",
+        path: [],
+      });
+    }
+    return;
+  }
+
+  // Source-prefixed path forms: "official/...", "skills-sh/...", etc.
+  const srcPrefix = SKILL_SOURCE_PREFIXES.find((p) => s.startsWith(p));
+  if (srcPrefix !== undefined) {
+    const rest = s.slice(srcPrefix.length);
+    if (rest.length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          `Skill cannot be a bare "${srcPrefix}" prefix — at least two path segments must follow, ` +
+          `e.g. "${srcPrefix}category/skill-name".`,
+        path: [],
+      });
+      return;
+    }
+    const segments = rest.split("/");
+    if (segments.length < 2) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          `Skill "${s}" needs at least two path segments after "${srcPrefix}", ` +
+          `e.g. "${srcPrefix}category/skill-name".`,
+        path: [],
+      });
+      return;
+    }
+    const bad = segments.find((seg) => !PATH_SEGMENT_RE.test(seg));
+    if (bad !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          `Skill "${s}" has an invalid path segment "${bad}" after "${srcPrefix}". ` +
+          'Segments must start with an alphanumeric character and may contain alphanumerics, ".", "-", and "_".',
+        path: [],
+      });
+    }
+    return;
+  }
+
+  // GitHub-style path: "owner/repo/..." — ≥2 non-empty segments
+  if (s.includes("/")) {
+    if (s.startsWith("/") || s.endsWith("/")) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Skill paths must not start or end with "/", e.g. "openai/skills/k8s".',
+        path: [],
+      });
+      return;
+    }
+    const segments = s.split("/");
+    const bad = segments.find((seg) => !PATH_SEGMENT_RE.test(seg));
+    if (bad !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          `Skill "${s}" has an invalid path segment "${bad}". ` +
+          'Segments must start with an alphanumeric character and may contain alphanumerics, ".", "-", and "_".',
+        path: [],
+      });
+      return;
+    }
+    // ≥2 well-formed segments is a valid GitHub-style install path
+    return;
+  }
+
+  // Simple slug — the only no-slash form we accept
+  if (SIMPLE_SLUG_RE.test(s)) return;
+
+  ctx.addIssue({
+    code: z.ZodIssueCode.custom,
+    message:
+      `Skill "${s}" is not a recognized identifier format. Expected a simple slug ("axolotl"), ` +
+      'a namespace prefix ("npm:@scope/pkg"), a hub-source path ("official/category/skill-name", ' +
+      '"skills-sh/owner/repo/skill", "browse-sh/host/task-id"), a GitHub path ("openai/skills/k8s"), ' +
+      'a well-known endpoint ("well-known:https://example.com/.well-known/skills/x"), or a direct URL ' +
+      '("https://example.com/SKILL.md").',
+    path: [],
+  });
+}
+
 export const SkillSchema = z
   .string()
   .min(1)
   .max(128, "Skill exceeds maximum length of 128 characters")
-  .regex(
-    /^[a-zA-Z0-9@\-_/.:]+$/,
-    "Skill contains invalid characters. Allowed: alphanumeric, -, _, /, ., @"
-  )
-  .refine((s) => s !== "npm:" && s !== "pack:", "Skill cannot be a bare prefix");
+  .superRefine(validateSkillIdentifier);
 
 export type Skill = string;
 


### PR DESCRIPTION
## Summary

Replace the single permissive regex on `SkillSchema` with a `superRefine`-based validator (`validateSkillIdentifier`) that dispatches by format and validates each of the identifier shapes documented in the [Supported Hub Sources](https://hermes-agent.nousresearch.com/docs/user-guide/features/skills#supported-hub-sources) table.

## Formats validated

| Format | Example | Rule |
|--------|---------|------|
| Simple slug | `axolotl` | `^[a-zA-Z][a-zA-Z0-9_-]*$` |
| `npm:` / `pack:` prefix | `npm:@hermeum/github-review` | Non-empty spec after prefix |
| `official/`, `skills-sh/`, `browse-sh/`, `clawhub/`, `lobehub/`, `claude-marketplace/` | `official/security/1password` | Prefix + ≥2 well-formed path segments |
| `well-known:` | `well-known:https://mintlify.com/...` | Valid `http(s)` URL after prefix |
| Direct URL | `https://sharethis.chat/SKILL.md` | Valid `http(s)` URL |
| GitHub-style path | `openai/skills/k8s` | ≥2 well-formed `/`-segments, no leading/trailing slash |

Each branch produces a specific, actionable error message. Unknown formats are rejected with a message listing all accepted formats.

## Out of scope (unchanged)

- `AgentCronSchema.skills` and `WebhookRouteSchema.skills` remain deliberately loose (`z.array(z.string())`) — cron/webhook skills may reference not-yet-installed skills.
- `SkillsSchema` array wrapper unchanged (`max(20).optional()`).

## Test plan

- [x] `pnpm --filter dashboard test` — 155 tests pass (39 new cases)
- [x] `pnpm --filter dashboard lint` — clean (2 pre-existing warnings unrelated)
- [x] `pnpm --filter dashboard typecheck` — 1 pre-existing error in `client.test.ts:269` (unrelated, confirmed via `git stash`)
- [x] `z.toJSONSchema(AgentInputObjectSchema)` still works (`superRefine` is JSON-Schema-safe) — covered by existing test
- [x] Existing tests unchanged: cron skills accept loose strings, `bad skill!` rejected, `npm:@hermeum/github-review` accepted