### PR TITLE
refactor: move verifyOwnership into an OwnershipGuarded mixin

### DIFF
--- a/apps/dashboard/src/server/usecases/agent.ts
+++ b/apps/dashboard/src/server/usecases/agent.ts
@@ -2,15 +2,14 @@ import { z } from "zod";
 
 import { Agent, AgentInput, AgentInputSchema, Context, Env, JsonPatchOp } from "@/entities";
 
-import { BaseUseCase, HermeumConfigLoadable } from "./mixin";
-import { verifyOwnership } from "./authz";
+import { BaseUseCase, HermeumConfigLoadable, OwnershipGuarded } from "./mixin";
 
 export const ListAgentsFilterSchema = z.object({
   archived: z.boolean().optional(),
 });
 export type ListAgentsFilter = z.infer<typeof ListAgentsFilterSchema>;
 
-export class AgentUseCase extends HermeumConfigLoadable(BaseUseCase) {
+export class AgentUseCase extends OwnershipGuarded(HermeumConfigLoadable(BaseUseCase)) {
   async getmutatingWebhookJsonPatch(agent: Agent): Promise<JsonPatchOp[] | null> {
     if (!agent.type) return null;
     const { agentTypes } = await this.loadHermeumConfig();
@@ -31,7 +30,7 @@ export class AgentUseCase extends HermeumConfigLoadable(BaseUseCase) {
     agentInput = AgentInputSchema.parse(agentInput);
 
     await this.checkAgentInputAllowed(agentInput);
-    return this.runtime.createHermesAgent({ ...agentInput, userId: ctx.user!.id });
+    return this.runtime.createHermesAgent({ ...agentInput, userId: this.requireUser(ctx).id });
   }
 
   async updateHermesAgent(ctx: Context, id: string, patch: AgentInput): Promise<Agent> {
@@ -39,7 +38,7 @@ export class AgentUseCase extends HermeumConfigLoadable(BaseUseCase) {
     if (!agent) {
       throw new Error(`HermesAgent ${id} not found`);
     }
-    verifyOwnership(ctx, agent);
+    this.verifyOwnership(ctx, agent);
 
     patch = AgentInputSchema.parse(patch);
 
@@ -65,7 +64,7 @@ export class AgentUseCase extends HermeumConfigLoadable(BaseUseCase) {
     if (!agent) {
       throw new Error(`HermesAgent ${id} not found`);
     }
-    verifyOwnership(ctx, agent);
+    this.verifyOwnership(ctx, agent);
     return this.runtime.archiveHermesAgent(id);
   }
 
@@ -74,7 +73,7 @@ export class AgentUseCase extends HermeumConfigLoadable(BaseUseCase) {
     if (!agent) {
       throw new Error(`HermesAgent ${id} not found`);
     }
-    verifyOwnership(ctx, agent);
+    this.verifyOwnership(ctx, agent);
     return this.runtime.patchHermesAgent({ id, patch: { suspended: true } });
   }
 
@@ -83,7 +82,7 @@ export class AgentUseCase extends HermeumConfigLoadable(BaseUseCase) {
     if (!agent) {
       throw new Error(`HermesAgent ${id} not found`);
     }
-    verifyOwnership(ctx, agent);
+    this.verifyOwnership(ctx, agent);
     return this.runtime.patchHermesAgent({ id, patch: { suspended: false } });
   }
 
@@ -92,7 +91,7 @@ export class AgentUseCase extends HermeumConfigLoadable(BaseUseCase) {
     if (!agent) {
       throw new Error(`HermesAgent ${agentId} not found`);
     }
-    verifyOwnership(ctx, agent);
+    this.verifyOwnership(ctx, agent);
     return this.runtime.getGatewayToken(agentId);
   }
 

--- a/apps/dashboard/src/server/usecases/authz.ts
+++ b/apps/dashboard/src/server/usecases/authz.ts
@@ -1,7 +1,0 @@
-import { Context } from "@/entities";
-
-export function verifyOwnership(ctx: Context, resource: { userId: string }): void {
-  if (ctx.user!.id !== resource.userId) {
-    throw new Error("You don't have permission to perform this action");
-  }
-}

--- a/apps/dashboard/src/server/usecases/mixin.ts
+++ b/apps/dashboard/src/server/usecases/mixin.ts
@@ -1,6 +1,6 @@
 import { parse } from "yaml";
 
-import { HermeumConfig, HermeumConfigSchema } from "@/entities";
+import { Context, HermeumConfig, HermeumConfigSchema, User } from "@/entities";
 import { config } from "@/server/libs/config";
 
 import { KubernetesClient } from "../infras/kubernetes/client";
@@ -38,6 +38,28 @@ export function HermeumConfigLoadable<TBase extends Constructor<{ files: FileAda
         this.#cachedHermeumConfig = HermeumConfigSchema.parse(raw);
       }
       return this.#cachedHermeumConfig;
+    }
+  };
+}
+
+// Mixin adding resource-ownership authorization to a use case class. The
+// protectedProcedure router gate guarantees a session is present, but the
+// Context type still carries a nullable user, so requireUser centralizes the
+// non-null assertion as defense-in-depth. Compose with:
+//   class MyUseCase extends OwnershipGuarded(BaseUseCase) { ... }
+export function OwnershipGuarded<TBase extends Constructor>(Base: TBase) {
+  return class extends Base {
+    requireUser(ctx: Context): User {
+      if (!ctx.user) {
+        throw new Error("Not authenticated");
+      }
+      return ctx.user;
+    }
+
+    verifyOwnership(ctx: Context, resource: { userId: string }): void {
+      if (this.requireUser(ctx).id !== resource.userId) {
+        throw new Error("You don't have permission to perform this action");
+      }
     }
   };
 }

--- a/apps/dashboard/src/server/usecases/shared-env-set.ts
+++ b/apps/dashboard/src/server/usecases/shared-env-set.ts
@@ -1,8 +1,7 @@
 import { z } from "zod";
 
 import { Context, EnvVar, EnvVarSchema, SharedEnvSet } from "@/entities";
-import { BaseUseCase } from "./mixin";
-import { verifyOwnership } from "./authz";
+import { BaseUseCase, OwnershipGuarded } from "./mixin";
 
 export const CreateSharedEnvSetInputSchema = z.object({
   name: z.string().min(1),
@@ -21,7 +20,7 @@ export const UpdateSharedEnvSetInputSchema = z.object({
 });
 export type UpdateSharedEnvSetInput = z.infer<typeof UpdateSharedEnvSetInputSchema>;
 
-export class SharedEnvSetUseCase extends BaseUseCase {
+export class SharedEnvSetUseCase extends OwnershipGuarded(BaseUseCase) {
 
   async listSharedEnvSets(ctx: Context, input?: ListSharedEnvSetsInput): Promise<SharedEnvSet[]> {
     return this.runtime.listSharedEnvSets(input);
@@ -32,7 +31,7 @@ export class SharedEnvSetUseCase extends BaseUseCase {
   }
 
   async createSharedEnvSet(ctx: Context, input: CreateSharedEnvSetInput): Promise<SharedEnvSet> {
-    return this.runtime.createSharedEnvSet({ ...input, userId: ctx.user!.id });
+    return this.runtime.createSharedEnvSet({ ...input, userId: this.requireUser(ctx).id });
   }
 
   async updateSharedEnvSet(
@@ -44,7 +43,7 @@ export class SharedEnvSetUseCase extends BaseUseCase {
     if (!envSet) {
       throw new Error(`Shared env set "${id}" not found`);
     }
-    verifyOwnership(ctx, envSet);
+    this.verifyOwnership(ctx, envSet);
     return this.runtime.patchSharedEnvSet(id, {
       ...(input.name !== undefined && { name: input.name }),
       ...(input.description !== undefined && { description: input.description }),
@@ -56,7 +55,7 @@ export class SharedEnvSetUseCase extends BaseUseCase {
     if (!envSet) {
       throw new Error(`Shared env set "${id}" not found`);
     }
-    verifyOwnership(ctx, envSet);
+    this.verifyOwnership(ctx, envSet);
     return this.runtime.archiveSharedEnvSet(id);
   }
 
@@ -66,7 +65,7 @@ export class SharedEnvSetUseCase extends BaseUseCase {
     if (!envSet) {
       throw new Error(`Shared env set "${setId}" not found`);
     }
-    verifyOwnership(ctx, envSet);
+    this.verifyOwnership(ctx, envSet);
     if (envSet.envVars.some((e) => e.name === envVar.name)) {
       throw new Error(`Env var "${envVar.name}" already exists in shared env set "${setId}"`);
     }
@@ -79,7 +78,7 @@ export class SharedEnvSetUseCase extends BaseUseCase {
     if (!envSet) {
       throw new Error(`Shared env set "${setId}" not found`);
     }
-    verifyOwnership(ctx, envSet);
+    this.verifyOwnership(ctx, envSet);
     if (!envSet.envVars.some((e) => e.name === envVar.name)) {
       throw new Error(`Env var "${envVar.name}" not found in shared env set "${setId}"`);
     }
@@ -91,7 +90,7 @@ export class SharedEnvSetUseCase extends BaseUseCase {
     if (!envSet) {
       throw new Error(`Shared env set "${setId}" not found`);
     }
-    verifyOwnership(ctx, envSet);
+    this.verifyOwnership(ctx, envSet);
     if (!envSet.envVars.some((e) => e.name === name)) {
       throw new Error(`Env var "${name}" not found in shared env set "${setId}"`);
     }


### PR DESCRIPTION
## Summary

`verifyOwnership` in `authz.ts` was the only cross-cutting usecase concern implemented as an imported free function, making it the odd one out in an otherwise class+mixin-based usecase layer (`HermeumConfigLoadable` already lives in `mixin.ts`, composed by 3 of 4 usecase classes).

This PR moves it into an `OwnershipGuarded` functional mixin so all shared usecase behavior flows through `mixin.ts`, and adds a `requireUser(ctx)` helper to centralize the `ctx.user` non-null assertion.

## Changes

- **`mixin.ts`** — add `OwnershipGuarded<TBase extends Constructor>(Base)` mixin exposing:
  - `requireUser(ctx): User` — throws `new Error("Not authenticated")` when `ctx.user` is null (defense-in-depth; plain `Error` keeps the usecase layer decoupled from tRPC).
  - `verifyOwnership(ctx, resource)` — unchanged logic, now built on `requireUser`.
- **`agent.ts`** — `extends OwnershipGuarded(HermeumConfigLoadable(BaseUseCase))`; 5 call sites → `this.verifyOwnership(...)`; create path → `this.requireUser(ctx).id`.
- **`shared-env-set.ts`** — `extends OwnershipGuarded(BaseUseCase)`; 5 call sites → `this.verifyOwnership(...)`; create path → `this.requireUser(ctx).id`.
- **`authz.ts`** — deleted (verified no other importers).

`TemplateUseCase` and `ChatUseCase` opt out of the mixin since they have no per-resource ownership checks.

## Why centralize `ctx.user!`

`protectedProcedure` in `routers/trpc/shared.ts:23` narrows `ctx.session` to non-null but passes `ctx.user` through **unchanged** — the type stays nullable even though a session implies a user. Previously the non-null assertion was duplicated as `ctx.user!` at two create paths (`agent.ts`, `shared-env-set.ts`) and inside `verifyOwnership`. `requireUser` collapses all three into one place.

## Verification

- `pnpm test` → **167/167 passed** (incl. all 17 in `agent.test.ts`; `verifyOwnership` was never mocked so behavior is identical).
- `pnpm lint` → **0 errors** (2 pre-existing warnings in unrelated client UI files).
- `pnpm typecheck` → 1 pre-existing error in `kubernetes/client.test.ts:302` (untouched mock literal-type issue); all changed files typecheck clean.

## Tradeoffs

The function is 4 lines of logic, so the mixin is somewhat ceremonial — the win is **consistency** with the existing mixin idiom and **opt-in composability**, not brevity. The alternative considered was leaving `verifyOwnership` as a pure function and only adding `requireUser`; rejected because it would leave the usecase layer half-mixin/half-free-function.