### PR TITLE
refactor: refactor agent-config chat system prompt

### DIFF
--- a/apps/dashboard/src/server/usecases/chat.test.ts
+++ b/apps/dashboard/src/server/usecases/chat.test.ts
@@ -52,7 +52,10 @@ describe("ChatUseCase.getAgentConfigContext", () => {
 
     const { instructions } = await useCase.getAgentConfigContext();
 
-    expect(instructions).toBe(AGENT_CONFIG_CHAT_SYSTEM_PROMPT);
+    // The base prompt is always followed by the available-documents block,
+    // even when there are no docs and no agent types.
+    expect(instructions).toContain(AGENT_CONFIG_CHAT_SYSTEM_PROMPT);
+    expect(instructions).toBe(AGENT_CONFIG_CHAT_SYSTEM_PROMPT + "\n\n" + "Available documents (read with `readDocument` before writing any config section you're not fully sure about):\n");
   });
 
   it("appends the configured agent types to the instructions", async () => {
@@ -102,16 +105,16 @@ describe("ChatUseCase.getAgentConfigContext", () => {
     expect(tools.updateAgentConfig!.execute).toBeUndefined();
   });
 
-  it("exposes listDocuments and readDocument as server-executed tools", async () => {
+  it("does not expose a listDocuments tool (the list is embedded in the prompt)", async () => {
     const useCase = new ChatUseCase(undefined, makeFiles());
 
     const { tools } = await useCase.getAgentConfigContext();
 
-    expect(tools.listDocuments?.execute).toBeDefined();
+    expect(tools.listDocuments).toBeUndefined();
     expect(tools.readDocument?.execute).toBeDefined();
   });
 
-  it("lists documents with the frontmatter description when present", async () => {
+  it("embeds the available documents in the instructions with frontmatter descriptions", async () => {
     const useCase = new ChatUseCase(
       undefined,
       makeFiles({
@@ -120,12 +123,11 @@ describe("ChatUseCase.getAgentConfigContext", () => {
       })
     );
 
-    const { tools } = await useCase.getAgentConfigContext();
-    const result = await tools.listDocuments!.execute!({}, callOptions);
+    const { instructions } = await useCase.getAgentConfigContext();
 
-    expect(result).toEqual({
-      documents: [{ name: "model", description: "Model configuration" }, { name: "webhook" }],
-    });
+    expect(instructions).toContain("- model: Model configuration");
+    expect(instructions).toContain("- webhook");
+    expect(instructions).not.toContain("- webhook:");
   });
 
   it("reads multiple documents in one call", async () => {

--- a/apps/dashboard/src/server/usecases/chat.ts
+++ b/apps/dashboard/src/server/usecases/chat.ts
@@ -20,7 +20,8 @@ export interface AgentConfigContext {
 
 export class ChatUseCase extends HermeumConfigLoadable(BaseUseCase) {
   // Everything the chat route needs for an agent-config conversation turn:
-  // the system prompt, a context block describing the current draft, and the
+  // the system prompt (with the available doc list and configured agent types
+  // appended), a context block describing the current draft, and the
   // client-side tool the model uses to apply config changes.
   async getAgentConfigContext(currentConfig?: AgentInput): Promise<AgentConfigContext> {
     return {
@@ -30,7 +31,7 @@ export class ChatUseCase extends HermeumConfigLoadable(BaseUseCase) {
           ? "There is no agent config draft yet."
           : "Current agent config draft as JSON:\n\n" + JSON.stringify(currentConfig, null, 2),
       tools: {
-        ...this.buildDocumentTools(),
+        readDocument: this.buildReadDocumentTool(),
         updateAgentConfig: tool({
           description:
             "Replace the agent config draft with a full updated definition. " +
@@ -44,85 +45,86 @@ export class ChatUseCase extends HermeumConfigLoadable(BaseUseCase) {
     };
   }
 
-  // Server-executed tools that let the model pull Hermes agent configuration
-  // documentation on demand, instead of carrying it all in the tool schema.
-  private buildDocumentTools(): ToolSet {
-    return {
-      listDocuments: tool({
-        description:
-          "List the available Hermes agent configuration documents, with a " +
-          "one-line description of each.",
-        inputSchema: z.object({}),
-        execute: async () => {
-          const files = await this.files.listFiles(DOCS_PATH);
-          return {
-            documents: files
-              .filter((file) => file.path.endsWith(".md"))
-              .map(({ name, data }) =>
-                typeof data.description === "string"
-                  ? { name, description: data.description }
-                  : { name }
-              ),
-          };
-        },
+  // Server-executed tool that lets the model pull a Hermes agent configuration
+  // document on demand. The list of available documents is embedded in the
+  // system prompt up front, so the model can plan a single batched call
+  // without first calling a list tool.
+  private buildReadDocumentTool(): ToolSet[string] {
+    return tool({
+      description:
+        "Read one or more Hermes agent configuration documents by name " +
+        "(names are listed in the system prompt). Pass every document you " +
+        "need in a single call to minimize round-trips.",
+      inputSchema: z.object({
+        names: z.array(z.string()).min(1).describe("Document names listed in the system prompt."),
       }),
-      readDocument: tool({
-        description:
-          "Read one or more Hermes agent configuration documents by name. " +
-          "Pass every document you need in a single call to minimize round-trips.",
-        inputSchema: z.object({
-          names: z.array(z.string()).min(1).describe("Document names from listDocuments."),
-        }),
-        execute: async ({ names }) => ({
-          documents: await Promise.all(
-            names.map(async (name) => {
-              const file = DOCUMENT_NAME_RE.test(name)
-                ? await this.files.readFile(`${DOCS_PATH}/${name}.md`)
-                : null;
-              return file === null
-                ? {
-                    name,
-                    error: `Document "${name}" not found. Call listDocuments for available names.`,
-                  }
-                : { name, content: file.content };
-            })
-          ),
-        }),
+      execute: async ({ names }) => ({
+        documents: await Promise.all(
+          names.map(async (name) => {
+            const file = DOCUMENT_NAME_RE.test(name)
+              ? await this.files.readFile(`${DOCS_PATH}/${name}.md`)
+              : null;
+            return file === null
+              ? {
+                  name,
+                  error: `Document "${name}" not found. Use the names listed in the system prompt.`,
+                }
+              : { name, content: file.content };
+          })
+        ),
       }),
-    };
+    });
   }
 
   private async buildInstructions(): Promise<string> {
-    const { agentTypes } = await this.loadHermeumConfig();
-    if (!agentTypes) {
-      return AGENT_CONFIG_CHAT_SYSTEM_PROMPT;
-    }
+    const [docList, { agentTypes }] = await Promise.all([
+      this.buildDocumentList(),
+      this.loadHermeumConfig(),
+    ]);
 
-    // Append a list of configured agent types to the system prompt.
-    const lines = Object.entries(agentTypes).map(
-      ([key, t]) => `- ${key}${t.description ? `: ${t.description}` : ""}`
-    );
-    return (
-      AGENT_CONFIG_CHAT_SYSTEM_PROMPT +
-      "\n\nAgent types (optional — set `type` only if the request clearly " +
-      "matches one; otherwise omit):\n" +
-      lines.join("\n")
-    );
+    let instructions = AGENT_CONFIG_CHAT_SYSTEM_PROMPT + "\n\n" + docList;
+
+    if (agentTypes) {
+      const lines = Object.entries(agentTypes).map(
+        ([key, t]) => `- ${key}${t.description ? `: ${t.description}` : ""}`
+      );
+      instructions +=
+        "\n\nAgent types (optional — set `type` only if the request clearly " +
+        "matches one; otherwise omit):\n" +
+        lines.join("\n");
+    }
+    return instructions;
+  }
+
+  // Build the "Available documents:" block listing every Hermes config doc the
+  // model can request via `readDocument`. Embedded up front so the model can
+  // skip the list-tool round-trip and batch-read directly.
+  private async buildDocumentList(): Promise<string> {
+    const files = await this.files.listFiles(DOCS_PATH);
+    const lines = files
+      .filter((file) => file.path.endsWith(".md"))
+      .map(({ name, data }) =>
+        typeof data.description === "string" ? `- ${name}: ${data.description}` : `- ${name}`
+      );
+    return "Available documents (read with `readDocument` before writing any " +
+      "config section you're not fully sure about):\n" +
+      lines.join("\n");
   }
 }
 
 // Field semantics live in the tool input schema's .describe() texts; this
 // prompt carries the conversational behavior and cross-field rules instead.
+// The available documents and configured agent types are appended at runtime.
 export const AGENT_CONFIG_CHAT_SYSTEM_PROMPT = `\
 You help a user workshop the definition of a new autonomous agent through
 conversation. The current draft is shown to you as JSON; the user also sees
 it in an editor and may change it by hand between messages.
 
-Detailed documentation about the config fields is available through tools:
-call \`listDocuments\` to see what's covered, then \`readDocument\` (batching
-every document you need into one call) to read up on any config section you
-are not fully sure about BEFORE writing it into the draft. Don't guess at
-field semantics that a document can settle.
+Detailed documentation about the config fields is available through the
+\`readDocument\` tool — the names of the available documents are listed below.
+Batch every document you need into a single call, and read up on any config
+section you are not fully sure about BEFORE writing it into the draft. Don't
+guess at field semantics that a document can settle.
 
 Whenever the draft should change, call the \`updateAgentConfig\` tool with the
 FULL updated definition — keep every field not affected by the change

--- a/apps/dashboard/src/server/usecases/chat.ts
+++ b/apps/dashboard/src/server/usecases/chat.ts
@@ -129,24 +129,4 @@ FULL updated definition — keep every field not affected by the change
 unchanged. After a config update, reply with one short sentence noting what
 changed plus a brief question about what to refine next (e.g. the tone, the
 scope, or the tools setup). Ask at most one question at a time, and keep all
-replies concise.
-
-Tailor every field to the specific request — don't fall back to generic or
-placeholder-sounding content:
-- \`name\` and \`description\` should reflect what this particular agent does,
-  not a generic template.
-- \`soul\` should be written for this agent's actual job and tone, using the
-  request's own domain language where possible — not a reused boilerplate
-  personality.
-- Only set \`config\` sub-features (model, webhooks, api_server) that the
-  request actually needs to work. Infer the ones required to fulfill the
-  request even if unstated (e.g. "on every new GitHub issue" implies a
-  webhook route), but don't add unrelated ones "just in case".
-- Webhook routes, prompts, and skills should be built from what the request
-  says triggers the agent and what it should do — not copied from an
-  unrelated example.
-- When the request is ambiguous or gives no basis for a field, omit that
-  field rather than guessing or inventing detail that wasn't asked for.
-- Never invent values for sensitive env vars: a sensitive var may only hold
-  the "<fill-me>" placeholder, or "<secret>" when it already held "<secret>"
-  in the current draft.`;
+replies concise.`;


### PR DESCRIPTION
## Summary

Refreshes the agent-config chat system prompt in `apps/dashboard/src/server/usecases/chat.ts` to match the current schema and streamline the document-fetching flow.

### Changes

- **Drop stale tailoring block** (`4307240`) — Removed the \"Tailor every field...\" bullet list from `AGENT_CONFIG_CHAT_SYSTEM_PROMPT`. Its enumeration of `config` sub-features (`model`, `webhooks`, `api_server`) no longer matched the inlined `ConfigSchema` (which types `web`, `browser`, `api_server`, `platforms.webhook`) and duplicated guidance already carried by the schema `.describe()` texts and the `readDocument` tool, matching the file's stated philosophy that field specifics belong in schema/docs, not the prompt.

- **Embed hermes-config doc list in prompt, drop `listDocuments` tool** (`e5168b3`) — The available Hermes config documents (name + frontmatter description) are now listed in the system prompt up front instead of via a `listDocuments` tool. The model can plan a single batched `readDocument` call immediately, skipping the list round-trip. The doc list and hermeum config are fetched in parallel in `buildInstructions`.

### Verification

- `pnpm --filter @hermeum/dashboard test -- src/server/usecases/chat.test.ts` — 10/10 passing
- `pnpm --filter @hermeum/dashboard typecheck` — clean
- `pnpm --filter @hermeum/dashboard lint` — only pre-existing unrelated warnings