### PR TITLE
docs: add hermes-config docs for webhooks, api-server, web-search, browser

### DIFF
--- a/apps/dashboard/docs/hermes-config/api-server.md
+++ b/apps/dashboard/docs/hermes-config/api-server.md
@@ -1,0 +1,39 @@
+---
+name: api-server
+description: API server configuration — OpenAI-compatible HTTP endpoint env vars.
+---
+
+# API server configuration
+
+Exposes hermes-agent as an OpenAI-compatible HTTP endpoint. Any frontend that
+speaks the OpenAI format — Open WebUI, LobeChat, LibreChat, NextChat, ChatBox,
+and hundreds more — can connect and use the agent as a backend with its full
+toolset (terminal, file operations, web search, memory, skills).
+
+## Configuration
+
+The API server is configured entirely through environment variables —
+`config.yaml` support is not yet available. Set them in `~/.hermes/.env` (or
+a profile's `.env` for multi-instance setups).
+
+## Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `API_SERVER_ENABLED` | `false` | Enable the API server. |
+| `API_SERVER_PORT` | `8642` | HTTP server port. |
+| `API_SERVER_HOST` | `127.0.0.1` | Bind address. Defaults to localhost only; set to `0.0.0.0` to expose on a LAN. |
+| `API_SERVER_KEY` | _(required)_ | Bearer token for auth. Required for every deployment, including loopback. Set via env var, not `config.yaml`, to avoid exposing credentials in plain text. |
+| `API_SERVER_CORS_ORIGINS` | _(none)_ | Comma-separated allowed browser origins. Required only if a browser must call Hermes directly. |
+| `API_SERVER_MODEL_NAME` | _(profile name)_ | Model name advertised on `/v1/models`. Defaults to the profile name, or `hermes-agent` for the default profile. |
+
+## Example
+
+`~/.hermes/.env`:
+
+```bash
+API_SERVER_ENABLED=true
+API_SERVER_KEY=change-me-local-dev
+# Optional: only if a browser must call Hermes directly
+# API_SERVER_CORS_ORIGINS=http://localhost:3000
+```

--- a/apps/dashboard/docs/hermes-config/browser.md
+++ b/apps/dashboard/docs/hermes-config/browser.md
@@ -1,0 +1,120 @@
+---
+name: browser
+description: Browser automation configuration (`config.browser`) — providers, timeouts, Camofox, and env vars.
+---
+
+# Browser automation configuration (`config.browser`)
+
+Configures the `browser_*` toolset. Multiple backends are supported —
+cloud providers (Browserbase, Browser Use, Firecrawl), local
+Chromium-family browsers via CDP (`/browser connect` or `cdp_url`),
+Camofox (local anti-detection Firefox), or the local `agent-browser`
+CLI driving a local Chromium install.
+
+**Default backend:** Camofox is preferred because Hermeum supports it
+natively. When the user does not specify a backend, select Camofox.
+`CAMOFOX_URL` and `CAMOFOX_API_KEY` are set automatically by Hermeum,
+so they do not need to be configured explicitly. Only choose a
+different backend when the user explicitly requests one.
+
+## Fields
+
+- `cloud_provider` — explicitly selects the browser backend. Values:
+  `camofox` (Hermeum default — local anti-detection Firefox),
+  `browserbase`, `browser-use`, `firecrawl`, `local`. When set to
+  `local`, cloud fallback is disabled and the local `agent-browser`
+  CLI / CDP path is used. When unset, the backend is auto-detected
+  from credentials (Browser Use → Browserbase). Selecting `camofox`
+  routes all browser tools through the Camofox server; `CAMOFOX_URL`
+  and `CAMOFOX_API_KEY` are set automatically by Hermeum.
+- `inactivity_timeout` — seconds of inactivity before a browser session
+  is auto-cleaned up (default `120`).
+- `command_timeout` — timeout in seconds for individual browser commands
+  (screenshot, navigate, etc.) (default `30`).
+- `record_sessions` — auto-record browser sessions as WebM videos to
+  `~/.hermes/browser_recordings/` (default `false`). Recordings older
+  than 72 hours are auto-cleaned.
+- `allow_private_urls` — allow navigating to private/internal IPs
+  (`localhost`, `127.0.0.1`, `192.168.x.x`, `10.x.x.x`, etc.)
+  (default `false`).
+- `engine` — browser engine for local mode: `auto` (default Chrome),
+  `lightpanda` (faster, no screenshots), `chrome` (default `auto`).
+  Also settable via `AGENT_BROWSER_ENGINE`.
+- `auto_local_for_private_urls` — when a cloud provider is configured,
+  auto-spawn a local Chromium sidecar for LAN/loopback URLs instead of
+  sending them to the cloud (default `true`). Public URLs continue to
+  use the cloud provider in the same conversation.
+- `cdp_url` — optional persistent CDP endpoint for attaching to an
+  existing Chromium/Chrome instance. When set, `browser_cdp` and the
+  CDP supervisor are available.
+- `allow_unsafe_evaluate` — allow `browser_console(expression=...)` to
+  use sensitive JS primitives (cookies/storage/clipboard/network/form
+  values) (default `false`).
+- `dialog_policy` — how native JS dialogs (`alert`/`confirm`/`prompt`/
+  `beforeunload`) are handled: `must_respond` (default; surface in
+  snapshot, wait for explicit `browser_dialog()` call, safety
+  auto-dismiss after `dialog_timeout_s`), `auto_dismiss`, or
+  `auto_accept`.
+- `dialog_timeout_s` — safety auto-dismiss timeout under
+  `must_respond` (default `300`).
+- `camofox.managed_persistence` — send a stable profile-scoped
+  `userId` to Camofox so cookies/logins survive across agent restarts
+  (default `false`).
+- `camofox.user_id` — Camofox `userId` for externally managed sessions.
+  Setting this opts the session into "externally managed" mode
+  (Hermes skips destructive cleanup and `DELETE /sessions/<id>`).
+- `camofox.session_key` — `sessionKey` (a.k.a. `listItemId`) sent on
+  tab creation; used to match an existing tab during adoption.
+- `camofox.adopt_existing_tab` — when `true`, Hermes calls
+  `GET /tabs?userId=<user_id>` on first use and reuses an existing tab
+  before creating a new one (default `false`).
+- `camofox.rewrite_loopback_urls` — rewrite loopback page URLs
+  (`localhost`/`127.0.0.1`/`::1`) to `loopback_host_alias` when Camofox
+  runs in Docker (default `false`). Only applies to page navigation
+  URLs; `CAMOFOX_URL` itself is unchanged.
+- `camofox.loopback_host_alias` — host alias for loopback rewriting
+  (default `host.docker.internal`).
+
+## Environment variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `BROWSERBASE_API_KEY` | Browserbase API key for cloud browser. | _(none)_ |
+| `BROWSERBASE_PROJECT_ID` | Browserbase project ID (required with `BROWSERBASE_API_KEY` for cloud browser). | _(none)_ |
+| `BROWSER_USE_API_KEY` | Browser Use API key for cloud browser. Browserbase takes priority if both are set. | _(none)_ |
+| `FIRECRAWL_API_KEY` | Firecrawl API key. Enables Firecrawl as a cloud browser provider. | _(none)_ |
+| `FIRECRAWL_API_URL` | Firecrawl API URL for self-hosted instances. | _(cloud)_ |
+| `FIRECRAWL_BROWSER_TTL` | Firecrawl browser session TTL in seconds. | `300` |
+| `CAMOFOX_URL` | Camofox browser server URL for local anti-detection browsing. Set automatically by Hermeum when Camofox is the selected backend. | _(auto)_ |
+| `CAMOFOX_API_KEY` | Optional bearer token sent as `Authorization` header to a remote/authenticated Camofox server. Set automatically by Hermeum when Camofox is the selected backend. | _(auto)_ |
+| `CAMOFOX_USER_ID` | Env-var mirror of `browser.camofox.user_id`. Takes precedence over `config.yaml`. | _(none)_ |
+| `CAMOFOX_SESSION_KEY` | Env-var mirror of `browser.camofox.session_key`. Takes precedence over `config.yaml`. | _(none)_ |
+| `CAMOFOX_ADOPT_EXISTING_TAB` | Env-var mirror of `browser.camofox.adopt_existing_tab`. Takes precedence over `config.yaml`. | _(none)_ |
+| `CAMOFOX_REWRITE_LOOPBACK_URLS` | Env-var mirror of `browser.camofox.rewrite_loopback_urls`. Takes precedence over `config.yaml`. | _(none)_ |
+| `CAMOFOX_LOOPBACK_HOST_ALIAS` | Env-var mirror of `browser.camofox.loopback_host_alias`. Takes precedence over `config.yaml`. | `host.docker.internal` |
+| `AGENT_BROWSER_ENGINE` | Env-var mirror of `browser.engine`: `auto`, `lightpanda`, `chrome`. | `auto` |
+| `AGENT_BROWSER_ARGS` | Extra Chromium launch flags (comma- or newline-separated). Hermes auto-injects `--no-sandbox,--disable-dev-shm-usage` when it detects root or AppArmor-restricted unprivileged user namespaces, so most users don't need to set this. | _(none)_ |
+| `BROWSER_INACTIVITY_TIMEOUT` | Env-var mirror of `browser.inactivity_timeout`. | `120` |
+| `BROWSERBASE_PROXIES` | Enable residential proxies for better CAPTCHA solving (Browserbase). | `true` |
+| `BROWSERBASE_ADVANCED_STEALTH` | Advanced stealth with custom Chromium build (requires Browserbase Scale Plan). | `false` |
+| `BROWSERBASE_KEEP_ALIVE` | Session reconnection after disconnects (requires Browserbase paid plan). | `true` |
+| `BROWSERBASE_SESSION_TIMEOUT` | Custom Browserbase session timeout in seconds (max `21600` = 6 hours). | _(project default)_ |
+
+## Example
+
+`~/.hermes/config.yaml`:
+
+```yaml
+browser:
+  dialog_policy: must_respond
+  camofox:
+    managed_persistence: true
+    rewrite_loopback_urls: true
+```
+
+`~/.hermes/.env`:
+
+```bash
+# CAMOFOX_URL and CAMOFOX_API_KEY are set automatically by Hermeum —
+# no need to set them here.
+```

--- a/apps/dashboard/docs/hermes-config/web-search.md
+++ b/apps/dashboard/docs/hermes-config/web-search.md
@@ -1,0 +1,80 @@
+---
+name: web-search
+description: Web search & extract configuration (`config.web`) — backends, per-capability split, and env vars.
+---
+
+# Web search & extract configuration (`config.web`)
+
+Configures the `web_search` and `web_extract` tools. Multiple backend
+providers are supported — either a single shared backend for both
+capabilities, or a per-capability split (e.g. free SearXNG for search,
+Firecrawl for extract).
+
+**Default backend:** SearXNG is preferred because Hermeum supports it
+natively. When the user does not specify a backend, select SearXNG
+(`search_backend: "searxng"`). `SEARXNG_URL` is set automatically by
+Hermeum, so it does not need to be configured explicitly. Only choose
+a different backend when the user explicitly requests one.
+
+## Fields
+
+- `backend` — shared fallback for both `web_search` and `web_extract`.
+  Values: `firecrawl`, `searxng`, `brave-free`, `ddgs`, `tavily`, `exa`,
+  `parallel`, `xai`.
+- `search_backend` — per-capability override for `web_search`. When set,
+  takes precedence over `backend`.
+- `extract_backend` — per-capability override for `web_extract`. When set,
+  takes precedence over `backend`. Note: some backends are search-only
+  (SearXNG, Brave, DDGS, xAI) and cannot extract — pair them with an
+  extract-capable backend via this field.
+- `extract_char_limit` — per-page character budget for `web_extract`
+  (default `15000`). Larger pages are truncated; the full text is stored
+  in `~/.hermes/cache/web/`.
+
+**Priority order (per capability):**
+
+1. `web.search_backend` / `web.extract_backend` (explicit per-capability)
+2. `web.backend` (shared fallback)
+3. Auto-detect from environment variables
+
+Auto-detection picks the first available backend based on which
+credentials are set, in this order: `FIRECRAWL_API_KEY` /
+`FIRECRAWL_API_URL` → `PARALLEL_API_KEY` → `TAVILY_API_KEY` →
+`EXA_API_KEY` → `SEARXNG_URL`. xAI is **not** in the auto-detection
+chain — having `XAI_API_KEY` set does not automatically route web
+traffic through xAI (those credentials are also used for inference /
+TTS / image gen). Opt in explicitly with `web.backend: "xai"`.
+
+## Environment variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `FIRECRAWL_API_KEY` | Firecrawl API key. Enables search + extract. Free tier: 500 credits/month. | _(none)_ |
+| `FIRECRAWL_API_URL` | Firecrawl API URL for self-hosted instances. When set, the API key is optional (disable server auth with `USE_DB_AUTHENTICATION=false`). | _(cloud)_ |
+| `SEARXNG_URL` | URL of a SearXNG instance. Search-only; no API key required. Free (self-hosted). Set automatically by Hermeum when SearXNG is the selected backend. | _(auto)_ |
+| `BRAVE_SEARCH_API_KEY` | Brave Search API subscription token. Search-only. Free tier: 2,000 queries/month. | _(none)_ |
+| `TAVILY_API_KEY` | Tavily API key. Enables search + extract. Free tier: 1,000 searches/month. | _(none)_ |
+| `EXA_API_KEY` | Exa API key. Enables search + extract. Free tier: 1,000 searches/month. | _(none)_ |
+| `PARALLEL_API_KEY` | Parallel API key. Enables search + extract. Paid. | _(none)_ |
+| `XAI_API_KEY` | xAI (Grok) API key. Search-only; not in the auto-detection chain — opt in with `web.backend: "xai"`. Paid. | _(none)_ |
+
+DDGS (DuckDuckGo) needs no env var — it is always available as a
+search-only backend via `web.backend: "ddgs"` (uses the `ddgs` Python
+package, lazy-installed on first use).
+
+## Example
+
+`~/.hermes/config.yaml`:
+
+```yaml
+web:
+  search_backend: "searxng"     # free, self-hosted, Hermeum default
+  extract_backend: "firecrawl" # paid, high-quality extraction
+```
+
+`~/.hermes/.env`:
+
+```bash
+# SEARXNG_URL is set automatically by Hermeum — no need to set it here.
+FIRECRAWL_API_KEY=fc-your-key-here
+```

--- a/apps/dashboard/docs/hermes-config/webhooks.md
+++ b/apps/dashboard/docs/hermes-config/webhooks.md
@@ -1,0 +1,126 @@
+---
+description: Webhook platform configuration (`platforms.webhook`) — routes, delivery targets, prompt templates, and env vars.
+---
+
+# Webhook configuration (`platforms.webhook`)
+
+Configures the webhook adapter, which runs an HTTP server that accepts POST
+requests, validates HMAC signatures, transforms payloads into agent prompts,
+and routes responses back to a configured target platform.
+
+## Fields
+
+- `enabled` — enable the webhook platform adapter (bool).
+- `extra.port` — HTTP server port for receiving webhooks (default `8644`).
+- `extra.rate_limit` — per-route rate limit in requests per minute
+  (default `30`).
+- `extra.max_body_bytes` — maximum request body size in bytes before the
+  body is read (default `1048576`, i.e. 1 MB).
+- `extra.routes` — map of named routes. Each key is the route name and
+  becomes the URL path (`/webhooks/<route-name>`). Each value is a route
+  object (see [Route fields](#route-fields)).
+
+The HMAC secret is **not** set in `config.yaml` — it lives in the
+`WEBHOOK_SECRET` environment variable (see [Environment variables](#environment-variables))
+to avoid exposing credentials in plain text.
+
+## Route fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `events` | No | List of event types to accept (e.g. `["pull_request"]`). If empty, all events are accepted. Event type is read from `X-GitHub-Event`, `X-GitLab-Event`, or `event_type` in the payload. |
+| `prompt` | No | Template string with dot-notation payload access (e.g. `{pull_request.title}`). If omitted, the full JSON payload is dumped into the prompt. See [Prompt templates](#prompt-templates). |
+| `skills` | No | List of skill names to load for the agent run. |
+| `deliver` | No | Where to send the response (default `log`). See [Delivery targets](#delivery-targets). |
+| `deliver_extra` | No | Additional delivery config — keys depend on `deliver` type (e.g. `repo`, `pr_number`, `chat_id`). Values support the same `{dot.notation}` templates as `prompt`. |
+| `deliver_only` | No | If `true`, skip the agent entirely — the rendered `prompt` template becomes the literal message that gets delivered. Zero LLM cost, sub-second delivery. Requires `deliver` to be a real target (not `log`). |
+
+## Delivery targets
+
+The `deliver` field controls where the agent's response goes after processing
+the webhook event.
+
+| Value | Description |
+|-------|-------------|
+| `log` | Logs the response to the gateway log output. Default; useful for testing. |
+| `github_comment` | Posts the response as a PR/issue comment via the `gh` CLI. Requires `deliver_extra.repo` and `deliver_extra.pr_number`. The `gh` CLI must be installed and authenticated on the gateway host. |
+| `telegram` | Routes the response to Telegram. Uses the home channel, or `chat_id` in `deliver_extra`. |
+| `discord` | Routes the response to Discord. Uses the home channel, or `chat_id` in `deliver_extra`. |
+| `slack` | Routes the response to Slack. Uses the home channel, or `chat_id` in `deliver_extra`. |
+| `signal` | Routes the response to Signal. Uses the home channel, or `chat_id` in `deliver_extra`. |
+| `sms` | Routes the response to SMS via Twilio. Uses the home channel, or `chat_id` in `deliver_extra`. |
+| `whatsapp` | Routes the response to WhatsApp. Uses the home channel, or `chat_id` in `deliver_extra`. |
+| `matrix` | Routes the response to Matrix. Uses the home channel, or `chat_id` in `deliver_extra`. |
+| `mattermost` | Routes the response to Mattermost. Uses the home channel, or `chat_id` in `deliver_extra`. |
+| `homeassistant` | Routes the response to Home Assistant. Uses the home channel, or `chat_id` in `deliver_extra`. |
+| `email` | Routes the response to Email. Uses the home channel, or `chat_id` in `deliver_extra`. |
+| `dingtalk` | Routes the response to DingTalk. Uses the home channel, or `chat_id` in `deliver_extra`. |
+| `feishu` | Routes the response to Feishu/Lark. Uses the home channel, or `chat_id` in `deliver_extra`. |
+| `wecom` | Routes the response to WeCom. Uses the home channel, or `chat_id` in `deliver_extra`. |
+| `weixin` | Routes the response to Weixin (WeChat). Uses the home channel, or `chat_id` in `deliver_extra`. |
+| `bluebubbles` | Routes the response to BlueBubbles (iMessage). Uses the home channel, or `chat_id` in `deliver_extra`. |
+| `qqbot` | Routes the response to QQ Bot. Uses the home channel, or `chat_id` in `deliver_extra`. |
+
+For cross-platform delivery, the target platform must also be enabled and
+connected in the gateway. If no `chat_id` is provided in `deliver_extra`,
+the response is sent to that platform's configured home channel.
+
+## Prompt templates
+
+Prompts use dot-notation to access nested fields in the webhook payload:
+
+- `{pull_request.title}` resolves to `payload["pull_request"]["title"]`
+- `{repository.full_name}` resolves to `payload["repository"]["full_name"]`
+- `{__raw__}` — special token that dumps the **entire payload** as indented
+  JSON (truncated at 4000 characters). Useful for monitoring alerts or
+  generic webhooks where the agent needs the full context.
+- Missing keys are left as the literal `{key}` string (no error).
+- Nested dicts and lists are JSON-serialized and truncated at 2000
+  characters.
+
+You can mix `{__raw__}` with regular template variables:
+
+```yaml
+prompt: "PR #{pull_request.number} by {pull_request.user.login}: {__raw__}"
+```
+
+If no `prompt` template is configured for a route, the entire payload is
+dumped as indented JSON (truncated at 4000 characters).
+
+The same dot-notation templates work in `deliver_extra` values.
+
+## Environment variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `WEBHOOK_ENABLED` | Enable the webhook platform adapter. | `false` |
+| `WEBHOOK_PORT` | HTTP server port for receiving webhooks. | `8644` |
+| `WEBHOOK_SECRET` | Global HMAC secret used for signature validation on all routes. Set via environment variable, not `config.yaml`, to avoid exposing credentials in plain text. | _(none)_ |
+
+## Example
+
+```yaml
+platforms:
+  webhook:
+    enabled: true
+    extra:
+      port: 8644
+      routes:
+        github-pr:
+          events: ["pull_request"]
+          prompt: |
+            Review this pull request:
+            Repository: {repository.full_name}
+            PR #{number}: {pull_request.title}
+            Author: {pull_request.user.login}
+            URL: {pull_request.html_url}
+            Diff URL: {pull_request.diff_url}
+            Action: {action}
+          skills: ["github-code-review"]
+          deliver: "github_comment"
+          deliver_extra:
+            repo: "{repository.full_name}"
+            pr_number: "{number}"
+```
+
+The HMAC secret is provided via the `WEBHOOK_SECRET` environment variable.

--- a/apps/dashboard/docs/hermes-config/webhooks.md
+++ b/apps/dashboard/docs/hermes-config/webhooks.md
@@ -1,4 +1,5 @@
 ---
+name: webhooks
 description: Webhook platform configuration (`platforms.webhook`) — routes, delivery targets, prompt templates, and env vars.
 ---
 


### PR DESCRIPTION
## Summary

Adds four new hermes-config reference documents under `apps/dashboard/docs/hermes-config/` that feed the LLM agent-config chat the semantics of `config.yaml` fields and environment variables for each platform adapter.

## Files

- **`webhooks.md`** — `platforms.webhook` routes, delivery targets, dot-notation prompt templates, and env vars. Secrets (`WEBHOOK_SECRET`) deliberately kept out of `config.yaml` and routed through the env var to avoid exposing credentials in plain text.
- **`api-server.md`** — OpenAI-compatible API server env vars (`API_SERVER_ENABLED`, `API_SERVER_PORT`, `API_SERVER_HOST`, `API_SERVER_KEY`, `API_SERVER_CORS_ORIGINS`, `API_SERVER_MODEL_NAME`). `config.yaml` support is not yet available upstream, so this doc is env-var-only.
- **`web-search.md`** — `config.web` fields (`backend`, `search_backend`, `extract_backend`, `extract_char_limit`), per-capability split, and env vars for all 8 backends. States that **SearXNG is the Hermeum default** (native support, `SEARXNG_URL` auto-set).
- **`browser.md`** — `config.browser` fields (including `cloud_provider` with `camofox` as a value, timeouts, `camofox.*` subtree), full env var table, and an example. States that **Camofox is the Hermeum default** (`CAMOFOX_URL` and `CAMOFOX_API_KEY` auto-set).

## Style

Each doc follows the established frontmatter (`name` + `description`) and section pattern (`## Fields` / `## Environment variables` / `## Example`) set by `model.md`. Secrets stay in `.env`; behavioral settings in `config.yaml` — matching the AGENTS.md `.env`-is-for-secrets-only rule.

## Source material

Distilled from the vendored hermes-agent docs at `vendor/hermes-agent/website/docs/user-guide/` (`messaging/webhooks.md`, `features/api-server.md`, `features/web-search.md`, `features/browser.md`) plus the `DEFAULT_CONFIG` and `OPTIONAL_ENV_VARS` entries in `vendor/hermes-agent/hermes_cli/config.py`. Setup walkthroughs, troubleshooting, and tool reference sections were intentionally omitted to keep the docs focused on `config.yaml` + env var surface.

## Test plan

- [x] Docs render correctly in the dashboard's agent-config chat (loaded via the `readDocument` tool).
- [x] LLM drafts that enable `platforms.webhook` or `config.api_server` still pass the existing `requireSensitiveEnv` Zod validation.
- [ ] No secrets appear in any `config.yaml` example block.