### PR TITLE
refactor: group hermes-config docs by frontmatter category in chat prompt

### DIFF
--- a/apps/dashboard/docs/hermes-config/api-server.md
+++ b/apps/dashboard/docs/hermes-config/api-server.md
@@ -1,5 +1,6 @@
 ---
 name: api-server
+category: platforms
 description: API server configuration — OpenAI-compatible HTTP endpoint env vars.
 ---
 

--- a/apps/dashboard/docs/hermes-config/browser.md
+++ b/apps/dashboard/docs/hermes-config/browser.md
@@ -1,5 +1,6 @@
 ---
 name: browser
+category: tools
 description: Browser automation configuration (`config.browser`) — providers, timeouts, Camofox, and env vars.
 ---
 

--- a/apps/dashboard/docs/hermes-config/model.md
+++ b/apps/dashboard/docs/hermes-config/model.md
@@ -1,4 +1,6 @@
 ---
+name: model
+category: core
 description: LLM model configuration (`config.model`) — providers, model ids, base URLs, and required API-key env vars.
 ---
 

--- a/apps/dashboard/docs/hermes-config/web-search.md
+++ b/apps/dashboard/docs/hermes-config/web-search.md
@@ -1,5 +1,6 @@
 ---
 name: web-search
+category: tools
 description: Web search & extract configuration (`config.web`) — backends, per-capability split, and env vars.
 ---
 

--- a/apps/dashboard/docs/hermes-config/webhooks.md
+++ b/apps/dashboard/docs/hermes-config/webhooks.md
@@ -1,5 +1,6 @@
 ---
 name: webhooks
+category: platforms
 description: Webhook platform configuration (`platforms.webhook`) — routes, delivery targets, prompt templates, and env vars.
 ---
 

--- a/apps/dashboard/src/server/usecases/chat.test.ts
+++ b/apps/dashboard/src/server/usecases/chat.test.ts
@@ -130,6 +130,46 @@ describe("ChatUseCase.getAgentConfigContext", () => {
     expect(instructions).not.toContain("- webhook:");
   });
 
+  it("groups documents by category alphabetically, then uncategorized last", async () => {
+    const useCase = new ChatUseCase(
+      undefined,
+      makeFiles({
+        // core
+        model: { content: "# Model", data: { category: "core", description: "Model configuration" } },
+        // tools
+        browser: { content: "# Browser", data: { category: "tools", description: "Browser automation" } },
+        "web-search": { content: "# Web", data: { category: "tools", description: "Web search" } },
+        // platforms
+        webhooks: { content: "# Webhooks", data: { category: "platforms", description: "Webhook routes" } },
+        // another category — should sort alphabetically alongside the rest
+        observability: { content: "# Obs", data: { category: "runtime", description: "Observability" } },
+        // uncategorized — trailing block
+        draft: { content: "# Draft" },
+      })
+    );
+
+    const { instructions } = await useCase.getAgentConfigContext();
+
+    // Categories are surfaced in alphabetical order, uncategorized trailing.
+    const coreIdx = instructions.indexOf("core:");
+    const platformsIdx = instructions.indexOf("platforms:");
+    const runtimeIdx = instructions.indexOf("runtime:");
+    const toolsIdx = instructions.indexOf("tools:");
+    const uncategorizedIdx = instructions.indexOf("Uncategorized:");
+    expect(coreIdx).toBeGreaterThanOrEqual(0);
+    expect(platformsIdx).toBeGreaterThan(coreIdx);
+    expect(runtimeIdx).toBeGreaterThan(platformsIdx);
+    expect(toolsIdx).toBeGreaterThan(runtimeIdx);
+    expect(uncategorizedIdx).toBeGreaterThan(toolsIdx);
+
+    // Known category blocks contain their grouped docs.
+    expect(instructions).toContain("core:\n- model: Model configuration");
+    expect(instructions).toContain("tools:\n- browser: Browser automation\n- web-search: Web search");
+    expect(instructions).toContain("platforms:\n- webhooks: Webhook routes");
+    expect(instructions).toContain("runtime:\n- observability: Observability");
+    expect(instructions).toContain("Uncategorized:\n- draft");
+  });
+
   it("reads multiple documents in one call", async () => {
     const useCase = new ChatUseCase(
       undefined,

--- a/apps/dashboard/src/server/usecases/chat.ts
+++ b/apps/dashboard/src/server/usecases/chat.ts
@@ -5,12 +5,17 @@ import { AgentInput, AgentInputObjectSchema } from "@/entities";
 import { config } from "@/server/libs/config";
 
 import { BaseUseCase, HermeumConfigLoadable } from "./mixin";
+import type { File } from "./adaptors/file";
 
 const DOCS_PATH = config.docsPath;
 
 // Document names come from the LLM; only simple slugs are accepted so a
 // crafted name can't traverse outside DOCS_PATH.
 const DOCUMENT_NAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/;
+
+// Label used for the trailing block that groups docs with no `category`
+// frontmatter field.
+const UNCATEGORIZED_LABEL = "Uncategorized";
 
 export interface AgentConfigContext {
   instructions: string;
@@ -98,17 +103,54 @@ export class ChatUseCase extends HermeumConfigLoadable(BaseUseCase) {
 
   // Build the "Available documents:" block listing every Hermes config doc the
   // model can request via `readDocument`. Embedded up front so the model can
-  // skip the list-tool round-trip and batch-read directly.
+  // skip the list-tool round-trip and batch-read directly. Docs are grouped
+  // under their frontmatter `category` (categories discovered dynamically from
+  // the docs themselves, surfaced alphabetically); docs with no `category`
+  // field are grouped together in a trailing `Uncategorized` block. When no
+  // docs exist, only the header is emitted.
   private async buildDocumentList(): Promise<string> {
-    const files = await this.files.listFiles(DOCS_PATH);
-    const lines = files
-      .filter((file) => file.path.endsWith(".md"))
-      .map(({ name, data }) =>
-        typeof data.description === "string" ? `- ${name}: ${data.description}` : `- ${name}`
-      );
+    const files = (await this.files.listFiles(DOCS_PATH)).filter((file) =>
+      file.path.endsWith(".md")
+    );
+    if (files.length === 0) {
+      return "Available documents (read with `readDocument` before writing any " +
+        "config section you're not fully sure about):\n";
+    }
+
+    const lineFor = ({ name, data }: File) =>
+      typeof data.description === "string" ? `- ${name}: ${data.description}` : `- ${name}`;
+
+    const categories = new Map<string, File[]>();
+    const uncategorized: File[] = [];
+    for (const file of files) {
+      const category =
+        typeof file.data.category === "string" ? file.data.category : undefined;
+      if (category === undefined) {
+        uncategorized.push(file);
+        continue;
+      } 
+
+      const bucket = categories.get(category) ?? [];
+      bucket.push(file);
+      categories.set(category, bucket);
+    }
+
+    const orderedCategories = [...categories.keys()].sort((a, b) =>
+      a.localeCompare(b)
+    );
+
+    const blocks: string[] = [];
+    for (const category of orderedCategories) {
+      const lines = categories.get(category)!.map(lineFor).join("\n");
+      blocks.push(`${category}:\n${lines}`);
+    }
+    if (uncategorized.length > 0) {
+      blocks.push(`${UNCATEGORIZED_LABEL}:\n${uncategorized.map(lineFor).join("\n")}`);
+    }
+
     return "Available documents (read with `readDocument` before writing any " +
       "config section you're not fully sure about):\n" +
-      lines.join("\n");
+      blocks.join("\n\n");
   }
 }
 


### PR DESCRIPTION
## Summary

Adds a `category:` frontmatter field to each `hermes-config` doc and has `buildDocumentList` surface them as grouped sections in the agent-config chat system prompt.

## Changes

- **Docs** (`apps/dashboard/docs/hermes-config/*.md`): add `category:` to frontmatter on all five files; add `name: model` to `model.md` for consistency.
  - `model.md` → `core`
  - `browser.md`, `web-search.md` → `tools`
  - `webhooks.md`, `api-server.md` → `platforms`
- **Code** (`apps/dashboard/src/server/usecases/chat.ts`): rework `buildDocumentList` to emit grouped sections (`core:` / `tools:` / `platforms:` …). Categories are discovered dynamically from the docs themselves and surfaced alphabetically — no hardcoded order. Docs with no `category` frontmatter field are grouped together in a trailing `Uncategorized:` block. Empty-docs case preserves the trailing newline the existing assertion expects.
- **Tests** (`apps/dashboard/src/server/usecases/chat.test.ts`): add a test asserting categories appear alphabetically with uncategorized trailing, and that each block contains its grouped docs.

## Design notes

- Filesystem stays flat; no renames. No changes to `LocalFiles`, `readDocument`, `DOCUMENT_NAME_RE`, or the path-traversal guard.
- The `FileAdaptor` contract is unchanged.

## Verification

```
pnpm test        → 168/168 pass
pnpm typecheck   → clean
pnpm lint        → clean (2 pre-existing unrelated warnings)
```

## Files

| File | Change |
|---|---|
| `docs/hermes-config/{api-server,browser,model,web-search,webhooks}.md` | +`category` frontmatter |
| `src/server/usecases/chat.ts` | grouped `buildDocumentList` |
| `src/server/usecases/chat.test.ts` | +grouping test |