### PR TITLE
Remove api_server config, drive API server via env vars

### DIFF
--- a/apps/dashboard/docs/hermes-config/api-server.md
+++ b/apps/dashboard/docs/hermes-config/api-server.md
@@ -13,8 +13,8 @@ toolset (terminal, file operations, web search, memory, skills).
 ## Configuration
 
 The API server is configured entirely through environment variables —
-`config.yaml` support is not yet available. Set them in `~/.hermes/.env` (or
-a profile's `.env` for multi-instance setups).
+`config.yaml` support is not yet available. Set the env vars below on the agent
+(in `~/.hermes/.env`, or a profile's `.env` for multi-instance setups).
 
 ## Environment variables
 

--- a/apps/dashboard/docs/hermes-config/api-server.md
+++ b/apps/dashboard/docs/hermes-config/api-server.md
@@ -13,8 +13,7 @@ toolset (terminal, file operations, web search, memory, skills).
 ## Configuration
 
 The API server is configured entirely through environment variables —
-`config.yaml` support is not yet available. Set the env vars below on the agent
-(in `~/.hermes/.env`, or a profile's `.env` for multi-instance setups).
+`config.yaml` support is not yet available. Set the env vars below on the agent.
 
 ## Environment variables
 

--- a/apps/dashboard/src/entities/agent.test.ts
+++ b/apps/dashboard/src/entities/agent.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { z } from "zod";
 
-import { AgentInputObjectSchema, AgentInputSchema, SkillSchema } from "./agent";
+import { AgentInputObjectSchema, AgentInputSchema, SkillSchema, isApiServerEnabled, getApiServerPort } from "./agent";
 
 function makeInput(overrides: Record<string, unknown> = {}) {
   return {
@@ -46,33 +46,83 @@ describe("AgentInputSchema webhook secret validation", () => {
 describe("AgentInputSchema api server key validation", () => {
   function makeApiServerInput(overrides: Record<string, unknown> = {}) {
     return {
-      config: { api_server: { enabled: true } },
+      env: [{ name: "API_SERVER_ENABLED", value: "true" }],
       ...overrides,
     };
   }
 
   it("fails when the api server is enabled and env is missing", () => {
-    const result = AgentInputSchema.safeParse(makeApiServerInput());
+    const result = AgentInputSchema.safeParse({ env: [{ name: "API_SERVER_ENABLED", value: "true" }] });
     expect(result.success).toBe(false);
   });
 
   it("fails when the api server is enabled and env lacks a sensitive API_SERVER_KEY", () => {
     const result = AgentInputSchema.safeParse(
-      makeApiServerInput({ env: [{ name: "API_SERVER_KEY", value: "shh" }] })
+      makeApiServerInput({ env: [
+        { name: "API_SERVER_ENABLED", value: "true" },
+        { name: "API_SERVER_KEY", value: "shh" },
+      ] })
     );
     expect(result.success).toBe(false);
   });
 
   it("succeeds when the api server is enabled and env has a sensitive API_SERVER_KEY", () => {
     const result = AgentInputSchema.safeParse(
-      makeApiServerInput({ env: [{ name: "API_SERVER_KEY", value: "shh", sensitive: true }] })
+      makeApiServerInput({ env: [
+        { name: "API_SERVER_ENABLED", value: "true" },
+        { name: "API_SERVER_KEY", value: "shh", sensitive: true },
+      ] })
     );
     expect(result.success).toBe(true);
   });
 
   it("succeeds when the api server is disabled regardless of env", () => {
-    const result = AgentInputSchema.safeParse({ config: { api_server: { enabled: false } } });
+    const result = AgentInputSchema.safeParse({ env: [{ name: "API_SERVER_ENABLED", value: "false" }] });
     expect(result.success).toBe(true);
+  });
+});
+
+describe("isApiServerEnabled", () => {
+  it("returns true when API_SERVER_ENABLED is \"true\" (case-insensitive)", () => {
+    for (const value of ["true", "TRUE", "True"]) {
+      expect(
+        isApiServerEnabled({ env: [{ name: "API_SERVER_ENABLED", value }] })
+      ).toBe(true);
+    }
+  });
+
+  it("returns false for non-\"true\" values", () => {
+    for (const value of ["false", "1", "yes", "on", "", "true "]) {
+      expect(
+        isApiServerEnabled({ env: [{ name: "API_SERVER_ENABLED", value }] })
+      ).toBe(false);
+    }
+  });
+
+  it("returns false when env is absent or has no API_SERVER_ENABLED var", () => {
+    expect(isApiServerEnabled({})).toBe(false);
+    expect(isApiServerEnabled({ env: [] })).toBe(false);
+    expect(isApiServerEnabled({ env: [{ name: "OTHER", value: "true" }] })).toBe(false);
+  });
+});
+
+describe("getApiServerPort", () => {
+  it("returns the parsed port when API_SERVER_PORT is a positive integer", () => {
+    expect(getApiServerPort({ env: [{ name: "API_SERVER_PORT", value: "9000" }] })).toBe(9000);
+  });
+
+  it("falls back to 8642 when API_SERVER_PORT is missing or empty", () => {
+    expect(getApiServerPort({})).toBe(8642);
+    expect(getApiServerPort({ env: [] })).toBe(8642);
+    expect(getApiServerPort({ env: [{ name: "API_SERVER_PORT", value: "" }] })).toBe(8642);
+    expect(getApiServerPort({ env: [{ name: "API_SERVER_PORT", value: "   " }] })).toBe(8642);
+  });
+
+  it("falls back to 8642 when API_SERVER_PORT is not a positive integer", () => {
+    expect(getApiServerPort({ env: [{ name: "API_SERVER_PORT", value: "0" }] })).toBe(8642);
+    expect(getApiServerPort({ env: [{ name: "API_SERVER_PORT", value: "-1" }] })).toBe(8642);
+    expect(getApiServerPort({ env: [{ name: "API_SERVER_PORT", value: "abc" }] })).toBe(8642);
+    expect(getApiServerPort({ env: [{ name: "API_SERVER_PORT", value: "1.5" }] })).toBe(8642);
   });
 });
 

--- a/apps/dashboard/src/entities/agent.ts
+++ b/apps/dashboard/src/entities/agent.ts
@@ -92,14 +92,6 @@ const BrowserConfigSchema = z
   })
   .optional();
 
-const ApiServerConfigSchema = z
-  .looseObject({
-    enabled: z.boolean().optional(),
-    port: z.number().int().optional(),
-    cors_origins: z.array(z.string()).optional(),
-  })
-  .optional();
-
 const WebhookConfigSchema = z
   .looseObject({
     enabled: z.boolean().optional(),
@@ -121,7 +113,6 @@ export const ConfigSchema = z
   .looseObject({
     web: WebConfigSchema,
     browser: BrowserConfigSchema,
-    api_server: ApiServerConfigSchema,
     platforms: PlatformsConfigSchema,
   })
   .optional()
@@ -534,8 +525,8 @@ export const AgentInputSchema = AgentInputObjectSchema.superRefine((data, ctx) =
   if (data.config?.platforms?.webhook?.enabled === true) {
     requireSensitiveEnv("WEBHOOK_SECRET", "config.platforms.webhook.enabled");
   }
-  if (data.config?.api_server?.enabled === true) {
-    requireSensitiveEnv("API_SERVER_KEY", "config.api_server.enabled");
+  if (isApiServerEnabled(data)) {
+    requireSensitiveEnv("API_SERVER_KEY", "env.API_SERVER_ENABLED");
   }
 
   data.env?.forEach((v, i) => {
@@ -552,6 +543,27 @@ export const AgentInputSchema = AgentInputObjectSchema.superRefine((data, ctx) =
 });
 
 export type AgentInput = z.infer<typeof AgentInputSchema>;
+
+// API server settings are configured exclusively via env vars (see
+// docs/hermes-config/api-server.md); the dashboard no longer surfaces an
+// `api_server` block in `config`. These helpers read those env vars off an
+// `AgentInput`.
+const API_SERVER_DEFAULT_PORT = 8642;
+
+export function isApiServerEnabled(input: AgentInput): boolean {
+  return (
+    input.env?.some(
+      (v) => v.name === "API_SERVER_ENABLED" && v.value.toLowerCase() === "true"
+    ) ?? false
+  );
+}
+
+export function getApiServerPort(input: AgentInput): number {
+  const raw = input.env?.find((v) => v.name === "API_SERVER_PORT")?.value;
+  if (raw === undefined || raw.trim() === "") return API_SERVER_DEFAULT_PORT;
+  const n = Number(raw);
+  return Number.isInteger(n) && n > 0 ? n : API_SERVER_DEFAULT_PORT;
+}
 
 export const AgentPhaseSchema = z.enum([
   "Pending",

--- a/apps/dashboard/src/entities/agent.ts
+++ b/apps/dashboard/src/entities/agent.ts
@@ -545,8 +545,7 @@ export const AgentInputSchema = AgentInputObjectSchema.superRefine((data, ctx) =
 export type AgentInput = z.infer<typeof AgentInputSchema>;
 
 // API server settings are configured exclusively via env vars (see
-// docs/hermes-config/api-server.md); the dashboard no longer surfaces an
-// `api_server` block in `config`. These helpers read those env vars off an
+// docs/hermes-config/api-server.md). These helpers read those env vars off an
 // `AgentInput`.
 const API_SERVER_DEFAULT_PORT = 8642;
 

--- a/apps/dashboard/src/server/infras/kubernetes/client.test.ts
+++ b/apps/dashboard/src/server/infras/kubernetes/client.test.ts
@@ -166,42 +166,6 @@ describe("agentToHermesAgent config.webhook wiring", () => {
   });
 });
 
-describe("agentToHermesAgent config.apiServer wiring", () => {
-  it("maps api_server fields, derives existingSecret when enabled, and strips it from raw", () => {
-    const hermesAgent = agentToHermesAgent(
-      makeAgent({
-        config: {
-          model: { provider: "anthropic", default: "claude-sonnet-5" },
-          api_server: { enabled: true, port: 8642, cors_origins: ["https://app.example.com"] },
-        },
-      })
-    );
-    expect(hermesAgent.spec.hermes?.config?.apiServer).toEqual({
-      enabled: true,
-      port: 8642,
-      corsOrigins: ["https://app.example.com"],
-      existingSecret: { name: "agent-1-dot-env", key: "API_SERVER_KEY" },
-    });
-    expect(hermesAgent.spec.hermes?.config?.raw).toEqual({
-      model: { provider: "anthropic", default: "claude-sonnet-5" },
-    });
-  });
-
-  it("omits existingSecret when the api server is disabled", () => {
-    const hermesAgent = agentToHermesAgent(
-      makeAgent({ config: { api_server: { enabled: false } } })
-    );
-    expect(hermesAgent.spec.hermes?.config?.apiServer).toEqual({ enabled: false });
-    expect(hermesAgent.spec.hermes?.config?.raw).toEqual({});
-  });
-
-  it("leaves config.apiServer undefined when there's no api_server", () => {
-    const hermesAgent = agentToHermesAgent(makeAgent({ config: { platforms: {} } }));
-    expect(hermesAgent.spec.hermes?.config?.apiServer).toBeUndefined();
-    expect(hermesAgent.spec.hermes?.config?.raw).toEqual({ platforms: {} });
-  });
-});
-
 describe("agentToHermesAgent spec.searxng wiring", () => {
   it("enables searxng and keeps web in raw when search_backend is searxng", () => {
     const hermesAgent = agentToHermesAgent(
@@ -272,24 +236,7 @@ describe("agentToHermesAgent spec.camofox wiring", () => {
 });
 
 describe("mapHermesConfig", () => {
-  it("folds apiServer back into config as snake_case api_server without existingSecret", () => {
-    expect(
-      mapHermesConfig({
-        raw: { platforms: {} },
-        apiServer: {
-          enabled: true,
-          port: 8642,
-          corsOrigins: ["https://app.example.com"],
-          existingSecret: { name: "agent-1-dot-env", key: "API_SERVER_KEY" },
-        },
-      })
-    ).toEqual({
-      platforms: {},
-      api_server: { enabled: true, port: 8642, cors_origins: ["https://app.example.com"] },
-    });
-  });
-
-  it("returns raw unchanged when apiServer is absent", () => {
+  it("returns raw unchanged", () => {
     expect(mapHermesConfig({ raw: { platforms: {} } })).toEqual({ platforms: {} });
     expect(mapHermesConfig(undefined)).toBeUndefined();
   });
@@ -297,7 +244,6 @@ describe("mapHermesConfig", () => {
   it("round-trips an agent config through the CR", () => {
     const config = {
       model: { provider: "anthropic", default: "claude-sonnet-5" },
-      api_server: { enabled: true, port: 8642 },
     };
     const hermesAgent = agentToHermesAgent(makeAgent({ config }));
     expect(mapHermesConfig(hermesAgent.spec.hermes?.config)).toEqual(config);

--- a/apps/dashboard/src/server/infras/kubernetes/client.test.ts
+++ b/apps/dashboard/src/server/infras/kubernetes/client.test.ts
@@ -250,6 +250,51 @@ describe("mapHermesConfig", () => {
   });
 });
 
+describe("agentToHermesAgent api server networking wiring", () => {
+  it("exposes the default api-server container and service ports when API_SERVER_ENABLED=true", () => {
+    const hermesAgent = agentToHermesAgent(
+      makeAgent({ env: [{ name: "API_SERVER_ENABLED", value: "true" }] })
+    );
+    expect(hermesAgent.spec.hermes?.ports).toEqual([
+      { name: "api-server", containerPort: 8642, protocol: "TCP" },
+    ]);
+    expect(hermesAgent.spec.networking?.service?.ports).toEqual([
+      { name: "api-server", port: 8642, targetPort: 8642, protocol: "TCP" },
+    ]);
+  });
+
+  it("uses API_SERVER_PORT when set", () => {
+    const hermesAgent = agentToHermesAgent(
+      makeAgent({
+        env: [
+          { name: "API_SERVER_ENABLED", value: "true" },
+          { name: "API_SERVER_PORT", value: "9000" },
+        ],
+      })
+    );
+    expect(hermesAgent.spec.hermes?.ports).toEqual([
+      { name: "api-server", containerPort: 9000, protocol: "TCP" },
+    ]);
+    expect(hermesAgent.spec.networking?.service?.ports).toEqual([
+      { name: "api-server", port: 9000, targetPort: 9000, protocol: "TCP" },
+    ]);
+  });
+
+  it("leaves ports and networking undefined when API_SERVER_ENABLED is false", () => {
+    const hermesAgent = agentToHermesAgent(
+      makeAgent({ env: [{ name: "API_SERVER_ENABLED", value: "false" }] })
+    );
+    expect(hermesAgent.spec.hermes?.ports).toBeUndefined();
+    expect(hermesAgent.spec.networking).toBeUndefined();
+  });
+
+  it("leaves ports and networking undefined when env is absent", () => {
+    const hermesAgent = agentToHermesAgent(makeAgent());
+    expect(hermesAgent.spec.hermes?.ports).toBeUndefined();
+    expect(hermesAgent.spec.networking).toBeUndefined();
+  });
+});
+
 describe("agentToHermesAgent crons wiring", () => {
   it("maps agent.crons straight onto hermes.crons", () => {
     const crons = [

--- a/apps/dashboard/src/server/infras/kubernetes/client.ts
+++ b/apps/dashboard/src/server/infras/kubernetes/client.ts
@@ -159,20 +159,7 @@ export function agentToHermesAgent(agent: Agent): HermesAgent {
       agent.config.web?.search_backend === "searxng" ||
       agent.config.web?.backend === "searxng";
     camofoxEnabled = agent.config.browser?.cloud_provider === "camofox";
-    // The Hermes agent has no api_server section in config.yaml — it belongs to
-    // the CR's dedicated config.apiServer field, so keep it out of raw.
-    const { api_server: apiServer, ...rawConfig } = agent.config;
-    hermes.config = { raw: rawConfig };
-    if (apiServer !== undefined) {
-      hermes.config.apiServer = {
-        ...(apiServer.enabled !== undefined && { enabled: apiServer.enabled }),
-        ...(apiServer.port !== undefined && { port: apiServer.port }),
-        ...(apiServer.cors_origins !== undefined && { corsOrigins: apiServer.cors_origins }),
-        ...(apiServer.enabled === true && {
-          existingSecret: { name: agentEnvResourceName(agent.id), key: "API_SERVER_KEY" },
-        }),
-      };
-    }
+    hermes.config = { raw: agent.config };
     const webhook = agent.config.platforms?.webhook;
     if (webhook !== undefined) {
       hermes.config.webhook = {
@@ -233,22 +220,11 @@ export function agentToHermesAgent(agent: Agent): HermesAgent {
   };
 }
 
-// Rebuild the agent config from the CR: api_server lives in the dedicated
-// config.apiServer field (not raw), so fold it back in for round-tripping.
-// existingSecret is derived from the agent id at build time and is not mapped back.
+// Rebuild the agent config from the CR. The dashboard no longer surfaces an
+// `api_server` block — API server settings are configured via env vars — so
+// all typed config fields pass through `raw` unchanged.
 export function mapHermesConfig(config: HermesConfig | undefined): Agent["config"] {
-  const apiServer = config?.apiServer;
-  if (apiServer === undefined) {
-    return config?.raw;
-  }
-  return {
-    ...config?.raw,
-    api_server: {
-      ...(apiServer.enabled !== undefined && { enabled: apiServer.enabled }),
-      ...(apiServer.port !== undefined && { port: apiServer.port }),
-      ...(apiServer.corsOrigins !== undefined && { cors_origins: apiServer.corsOrigins }),
-    },
-  };
+  return config?.raw;
 }
 
 export function mapHermesAgent(raw: HermesAgent): Agent {

--- a/apps/dashboard/src/server/infras/kubernetes/client.ts
+++ b/apps/dashboard/src/server/infras/kubernetes/client.ts
@@ -174,8 +174,7 @@ export function agentToHermesAgent(agent: Agent): HermesAgent {
     }
   }
   // Expose the API server container + service ports when the agent opts in via
-  // the API_SERVER_ENABLED env var. The dashboard no longer surfaces an
-  // `api_server` block in config, so these ports must be wired explicitly.
+  // the API_SERVER_ENABLED env var.
   const apiServerPort = isApiServerEnabled(agent) ? getApiServerPort(agent) : null;
   let apiServerNetworking: HermesAgentSpec["networking"] | undefined;
   if (apiServerPort !== null) {
@@ -240,9 +239,8 @@ export function agentToHermesAgent(agent: Agent): HermesAgent {
   };
 }
 
-// Rebuild the agent config from the CR. The dashboard no longer surfaces an
-// `api_server` block — API server settings are configured via env vars — so
-// all typed config fields pass through `raw` unchanged.
+// Rebuild the agent config from the CR. API server settings are configured
+// via env vars, so all typed config fields pass through `raw` unchanged.
 export function mapHermesConfig(config: HermesConfig | undefined): Agent["config"] {
   return config?.raw;
 }

--- a/apps/dashboard/src/server/infras/kubernetes/client.ts
+++ b/apps/dashboard/src/server/infras/kubernetes/client.ts
@@ -10,6 +10,8 @@ import {
   EnvVar,
   SharedEnvSet,
   SharedEnvSetEnvVar,
+  getApiServerPort,
+  isApiServerEnabled,
 } from "@/entities";
 import { config } from "@/server/libs/config";
 import {
@@ -171,6 +173,23 @@ export function agentToHermesAgent(agent: Agent): HermesAgent {
       };
     }
   }
+  // Expose the API server container + service ports when the agent opts in via
+  // the API_SERVER_ENABLED env var. The dashboard no longer surfaces an
+  // `api_server` block in config, so these ports must be wired explicitly.
+  const apiServerPort = isApiServerEnabled(agent) ? getApiServerPort(agent) : null;
+  let apiServerNetworking: HermesAgentSpec["networking"] | undefined;
+  if (apiServerPort !== null) {
+    hermes.ports = [
+      { name: "api-server", containerPort: apiServerPort, protocol: "TCP" },
+    ];
+    apiServerNetworking = {
+      service: {
+        ports: [
+          { name: "api-server", port: apiServerPort, targetPort: apiServerPort, protocol: "TCP" },
+        ],
+      },
+    };
+  }
   if (agent.sharedEnvSets !== undefined) {
     hermes.envFrom = agent.sharedEnvSets.map((name) => ({ secretRef: { name } }));
   }
@@ -204,6 +223,7 @@ export function agentToHermesAgent(agent: Agent): HermesAgent {
     ...(Object.keys(hermes).length > 0 && { hermes: hermes as HermesAgentSpec["hermes"] }),
     ...(searxngEnabled && { searxng: { enabled: true } }),
     ...(camofoxEnabled && { camofox: { enabled: true } }),
+    ...(apiServerNetworking !== undefined && { networking: apiServerNetworking }),
     podAnnotations: { [HermeumPodAnnotation.EnvHash]: hashAgentEnv(agent.env) },
   };
 


### PR DESCRIPTION
## Summary

The `api_server` block in the agent config was a dummy setting — hermes-agent configures the API server exclusively via env vars (`API_SERVER_ENABLED`, `API_SERVER_PORT`, etc). This PR removes the config block and replaces it with env-var-driven helpers, then wires the Kubernetes container + service ports explicitly since the operator no longer auto-derives them.

## What changed

### 1. Drop `api_server` from `ConfigSchema` (`714ec19`)
- Remove `ApiServerConfigSchema` and the `api_server` field from `ConfigSchema` in `entities/agent.ts`.
- Add exported helpers that take an `AgentInput`:
  - `isApiServerEnabled(input)` — true only when `API_SERVER_ENABLED="true"` (case-insensitive)
  - `getApiServerPort(input)` — parses `API_SERVER_PORT`, defaulting to `8642`; falls back to default for missing/empty/non-positive/non-integer values
- Rewrite `AgentInputSchema.superRefine` to require a sensitive `API_SERVER_KEY` env var when `isApiServerEnabled(data)` is true (was previously gated on `config.api_server.enabled`).
- Drop the `api_server` round-trip wiring in `kubernetes/client.ts` (`mapHermesConfig` now just returns `config?.raw`).
- Keep `HermesConfig.apiServer` and the `HermesAPIServer` interface in the CRD type as-is for future use.
- Update `docs/hermes-config/api-server.md` to note the dashboard no longer surfaces an `api_server` config block.

### 2. Wire API server container + service ports (`30753fc`)
- In `agentToHermesAgent`, when `isApiServerEnabled(agent)` is true:
  - populate `hermes.ports` with `{ name: "api-server", containerPort, protocol: "TCP" }`
  - populate `spec.networking.service.ports` with the matching `ServicePort` (same port, `targetPort`, protocol)
- The container and service port wiring live in one consolidated block for readability; the `spec` spread references the captured `apiServerNetworking` value.
- `service.type` is left undefined (operator default applies, typically `ClusterIP`).

## Test plan
- [x] `pnpm --filter @hermeum/dashboard typecheck` — clean
- [x] `pnpm --filter @hermeum/dashboard test` — 173/173 pass (4 new tests for the networking wiring, updated api-server key validation tests, new unit tests for the helpers)
- [x] `pnpm --filter @hermeum/dashboard lint` — clean (only 2 pre-existing unrelated warnings)

## Reviewer notes
- `HermesConfig.apiServer` and `HermesAPIServer` are intentionally kept in `types/hermes-agent.ts` — the dashboard simply no longer populates that CRD field. Existing CRs with `config.apiServer` set are unaffected on read (the field is just ignored by the dashboard on the write path).
- The API server port wiring runs off `agent.env` independently of `agent.config`, so it works even when the agent has no config block.