### PR TITLE
refactor: map webhook ports via hermes.ports/networking like api server

### DIFF
--- a/apps/dashboard/docs/hermes-config/webhooks.md
+++ b/apps/dashboard/docs/hermes-config/webhooks.md
@@ -99,6 +99,20 @@ The same dot-notation templates work in `deliver_extra` values.
 | `WEBHOOK_PORT` | HTTP server port for receiving webhooks. | `8644` |
 | `WEBHOOK_SECRET` | Global HMAC secret used for signature validation on all routes. Set via environment variable, not `config.yaml`, to avoid exposing credentials in plain text. | _(none)_ |
 
+The dashboard reads `WEBHOOK_ENABLED` / `WEBHOOK_PORT` to drive the agent's
+Kubernetes container and Service port mappings, mirroring the
+`API_SERVER_*` env vars (see [api-server.md](./api-server.md)). The secret
+flows to the agent through its env Secret/ConfigMap alongside other
+sensitive env vars — no separate `secretRef` is wired into the CR.
+
+### Configuration preferred over env vars
+
+Webhook can be configured through either `config.platforms.webhook`
+(`enabled`, `extra.port`) **or** env vars (`WEBHOOK_ENABLED`,
+`WEBHOOK_PORT`). The `config.yaml` fields are preferred and take
+precedence over the env vars when both are set; the env vars act as a
+fallback for deployments that don't set `config.yaml`.
+
 ## Example
 
 ```yaml

--- a/apps/dashboard/src/entities/agent.test.ts
+++ b/apps/dashboard/src/entities/agent.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { z } from "zod";
 
-import { AgentInputObjectSchema, AgentInputSchema, SkillSchema, isApiServerEnabled, getApiServerPort } from "./agent";
+import { AgentInputObjectSchema, AgentInputSchema, SkillSchema, isApiServerEnabled, getApiServerPort, isWebhookEnabled, getWebhookPort } from "./agent";
 
 function makeInput(overrides: Record<string, unknown> = {}) {
   return {
@@ -11,22 +11,39 @@ function makeInput(overrides: Record<string, unknown> = {}) {
 }
 
 describe("AgentInputSchema webhook secret validation", () => {
-  it("fails when webhook is enabled and env is missing", () => {
+  it("fails when webhook is enabled via config and env is missing", () => {
     const result = AgentInputSchema.safeParse(makeInput());
     expect(result.success).toBe(false);
   });
 
-  it("fails when webhook is enabled and env lacks a sensitive WEBHOOK_SECRET", () => {
+  it("fails when webhook is enabled via config and env lacks a sensitive WEBHOOK_SECRET", () => {
     const result = AgentInputSchema.safeParse(
       makeInput({ env: [{ name: "WEBHOOK_SECRET", value: "shh" }] })
     );
     expect(result.success).toBe(false);
   });
 
-  it("succeeds when webhook is enabled and env has a sensitive WEBHOOK_SECRET", () => {
+  it("succeeds when webhook is enabled via config and env has a sensitive WEBHOOK_SECRET", () => {
     const result = AgentInputSchema.safeParse(
       makeInput({ env: [{ name: "WEBHOOK_SECRET", value: "shh", sensitive: true }] })
     );
+    expect(result.success).toBe(true);
+  });
+
+  it("fails when webhook is enabled via WEBHOOK_ENABLED env var and WEBHOOK_SECRET is missing", () => {
+    const result = AgentInputSchema.safeParse({
+      env: [{ name: "WEBHOOK_ENABLED", value: "true" }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("succeeds when webhook is enabled via WEBHOOK_ENABLED env var and WEBHOOK_SECRET is sensitive", () => {
+    const result = AgentInputSchema.safeParse({
+      env: [
+        { name: "WEBHOOK_ENABLED", value: "true" },
+        { name: "WEBHOOK_SECRET", value: "shh", sensitive: true },
+      ],
+    });
     expect(result.success).toBe(true);
   });
 
@@ -39,6 +56,54 @@ describe("AgentInputSchema webhook secret validation", () => {
 
   it("succeeds when webhook config is omitted entirely", () => {
     const result = AgentInputSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("AgentInputSchema webhook env-vs-config precedence", () => {
+  it("prefers config.platforms.webhook.enabled over WEBHOOK_ENABLED env var", () => {
+    const input = {
+      env: [
+        { name: "WEBHOOK_ENABLED", value: "true" },
+        { name: "WEBHOOK_SECRET", value: "shh", sensitive: true },
+      ],
+      config: { platforms: { webhook: { enabled: false } } },
+    };
+    const result = AgentInputSchema.safeParse(input);
+    expect(result.success).toBe(true);
+    expect(isWebhookEnabled(input as never)).toBe(false);
+  });
+
+  it("prefers config.platforms.webhook.extra.port over WEBHOOK_PORT env var", () => {
+    const input = {
+      env: [
+        { name: "WEBHOOK_ENABLED", value: "true" },
+        { name: "WEBHOOK_PORT", value: "9001" },
+        { name: "WEBHOOK_SECRET", value: "shh", sensitive: true },
+      ],
+      config: { platforms: { webhook: { enabled: true, extra: { port: 9000 } } } },
+    };
+    const result = AgentInputSchema.safeParse(input);
+    expect(result.success).toBe(true);
+    expect(getWebhookPort(input as never)).toBe(9000);
+  });
+
+  it("succeeds when only the env var path is used", () => {
+    const result = AgentInputSchema.safeParse({
+      env: [
+        { name: "WEBHOOK_ENABLED", value: "true" },
+        { name: "WEBHOOK_PORT", value: "9000" },
+        { name: "WEBHOOK_SECRET", value: "shh", sensitive: true },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("succeeds when only the config path is used", () => {
+    const result = AgentInputSchema.safeParse({
+      config: { platforms: { webhook: { enabled: true, extra: { port: 9000 } } } },
+      env: [{ name: "WEBHOOK_SECRET", value: "shh", sensitive: true }],
+    });
     expect(result.success).toBe(true);
   });
 });
@@ -123,6 +188,88 @@ describe("getApiServerPort", () => {
     expect(getApiServerPort({ env: [{ name: "API_SERVER_PORT", value: "-1" }] })).toBe(8642);
     expect(getApiServerPort({ env: [{ name: "API_SERVER_PORT", value: "abc" }] })).toBe(8642);
     expect(getApiServerPort({ env: [{ name: "API_SERVER_PORT", value: "1.5" }] })).toBe(8642);
+  });
+});
+
+describe("isWebhookEnabled", () => {
+  it("returns true when WEBHOOK_ENABLED is \"true\" (case-insensitive)", () => {
+    for (const value of ["true", "TRUE", "True"]) {
+      expect(
+        isWebhookEnabled({ env: [{ name: "WEBHOOK_ENABLED", value }] })
+      ).toBe(true);
+    }
+  });
+
+  it("returns false for non-\"true\" WEBHOOK_ENABLED values", () => {
+    for (const value of ["false", "1", "yes", "on", "", "true "]) {
+      expect(
+        isWebhookEnabled({ env: [{ name: "WEBHOOK_ENABLED", value }] })
+      ).toBe(false);
+    }
+  });
+
+  it("returns true when config.platforms.webhook.enabled is true", () => {
+    expect(
+      isWebhookEnabled({ config: { platforms: { webhook: { enabled: true } } } })
+    ).toBe(true);
+  });
+
+  it("returns false when config.platforms.webhook.enabled is false or absent", () => {
+    expect(
+      isWebhookEnabled({ config: { platforms: { webhook: { enabled: false } } } })
+    ).toBe(false);
+    expect(isWebhookEnabled({ config: { platforms: { webhook: {} } } })).toBe(false);
+    expect(isWebhookEnabled({})).toBe(false);
+  });
+
+  it("prefers config.platforms.webhook.enabled over the WEBHOOK_ENABLED env var", () => {
+    expect(
+      isWebhookEnabled({
+        env: [{ name: "WEBHOOK_ENABLED", value: "true" }],
+        config: { platforms: { webhook: { enabled: false } } },
+      })
+    ).toBe(false);
+    expect(
+      isWebhookEnabled({
+        env: [{ name: "WEBHOOK_ENABLED", value: "false" }],
+        config: { platforms: { webhook: { enabled: true } } },
+      })
+    ).toBe(true);
+  });
+});
+
+describe("getWebhookPort", () => {
+  it("returns the parsed port when WEBHOOK_PORT is a positive integer", () => {
+    expect(getWebhookPort({ env: [{ name: "WEBHOOK_PORT", value: "9000" }] })).toBe(9000);
+  });
+
+  it("falls back to 8644 when WEBHOOK_PORT is missing or empty", () => {
+    expect(getWebhookPort({})).toBe(8644);
+    expect(getWebhookPort({ env: [] })).toBe(8644);
+    expect(getWebhookPort({ env: [{ name: "WEBHOOK_PORT", value: "" }] })).toBe(8644);
+    expect(getWebhookPort({ env: [{ name: "WEBHOOK_PORT", value: "   " }] })).toBe(8644);
+  });
+
+  it("falls back to 8644 when WEBHOOK_PORT is not a positive integer", () => {
+    expect(getWebhookPort({ env: [{ name: "WEBHOOK_PORT", value: "0" }] })).toBe(8644);
+    expect(getWebhookPort({ env: [{ name: "WEBHOOK_PORT", value: "-1" }] })).toBe(8644);
+    expect(getWebhookPort({ env: [{ name: "WEBHOOK_PORT", value: "abc" }] })).toBe(8644);
+    expect(getWebhookPort({ env: [{ name: "WEBHOOK_PORT", value: "1.5" }] })).toBe(8644);
+  });
+
+  it("returns the config.platforms.webhook.extra.port when WEBHOOK_PORT env var is absent", () => {
+    expect(
+      getWebhookPort({ config: { platforms: { webhook: { extra: { port: 9000 } } } } })
+    ).toBe(9000);
+  });
+
+  it("prefers config.platforms.webhook.extra.port over the WEBHOOK_PORT env var", () => {
+    expect(
+      getWebhookPort({
+        env: [{ name: "WEBHOOK_PORT", value: "9001" }],
+        config: { platforms: { webhook: { extra: { port: 9000 } } } },
+      })
+    ).toBe(9000);
   });
 });
 

--- a/apps/dashboard/src/entities/agent.ts
+++ b/apps/dashboard/src/entities/agent.ts
@@ -522,8 +522,8 @@ export const AgentInputSchema = AgentInputObjectSchema.superRefine((data, ctx) =
       });
     }
   };
-  if (data.config?.platforms?.webhook?.enabled === true) {
-    requireSensitiveEnv("WEBHOOK_SECRET", "config.platforms.webhook.enabled");
+  if (isWebhookEnabled(data)) {
+    requireSensitiveEnv("WEBHOOK_SECRET", "webhook enabled (env var or config)");
   }
   if (isApiServerEnabled(data)) {
     requireSensitiveEnv("API_SERVER_KEY", "env.API_SERVER_ENABLED");
@@ -562,6 +562,34 @@ export function getApiServerPort(input: AgentInput): number {
   if (raw === undefined || raw.trim() === "") return API_SERVER_DEFAULT_PORT;
   const n = Number(raw);
   return Number.isInteger(n) && n > 0 ? n : API_SERVER_DEFAULT_PORT;
+}
+
+// Webhook settings can be configured via config.yaml
+// (config.platforms.webhook.enabled / extra.port) or via env vars
+// (WEBHOOK_ENABLED / WEBHOOK_PORT). config.yaml is preferred and takes
+// precedence over the env vars; the env vars act as a fallback when the
+// corresponding config field is absent.
+const WEBHOOK_DEFAULT_PORT = 8644;
+
+export function isWebhookEnabled(input: AgentInput): boolean {
+  const configEnabled = input.config?.platforms?.webhook?.enabled;
+  if (configEnabled !== undefined) return configEnabled;
+  return (
+    input.env?.some(
+      (v) => v.name === "WEBHOOK_ENABLED" && v.value.toLowerCase() === "true",
+    ) ?? false
+  );
+}
+
+export function getWebhookPort(input: AgentInput): number {
+  const configPort = input.config?.platforms?.webhook?.extra?.port;
+  if (configPort !== undefined) return configPort;
+  const envRaw = input.env?.find((v) => v.name === "WEBHOOK_PORT")?.value;
+  if (envRaw !== undefined && envRaw.trim() !== "") {
+    const n = Number(envRaw);
+    return Number.isInteger(n) && n > 0 ? n : WEBHOOK_DEFAULT_PORT;
+  }
+  return WEBHOOK_DEFAULT_PORT;
 }
 
 export const AgentPhaseSchema = z.enum([

--- a/apps/dashboard/src/server/infras/kubernetes/client.test.ts
+++ b/apps/dashboard/src/server/infras/kubernetes/client.test.ts
@@ -140,29 +140,122 @@ describe("agentToHermesAgent packages wiring", () => {
   });
 });
 
-describe("agentToHermesAgent config.webhook wiring", () => {
-  it("maps enabled and extra.port, and derives secretRef when enabled", () => {
+describe("agentToHermesAgent config.webhook no longer populated", () => {
+  it("does not write hermes.config.webhook even when config.platforms.webhook is set", () => {
     const hermesAgent = agentToHermesAgent(
       makeAgent({ config: { platforms: { webhook: { enabled: true, extra: { port: 8644 } } } } })
     );
-    expect(hermesAgent.spec.hermes?.config?.webhook).toEqual({
-      enabled: true,
-      port: 8644,
-      secretRef: { name: "agent-1-dot-env", key: "WEBHOOK_SECRET" },
+    expect(hermesAgent.spec.hermes?.config?.webhook).toBeUndefined();
+    // The raw config still passes through unchanged.
+    expect(hermesAgent.spec.hermes?.config?.raw).toEqual({
+      platforms: { webhook: { enabled: true, extra: { port: 8644 } } },
     });
-  });
-
-  it("omits secretRef when webhook is disabled", () => {
-    const hermesAgent = agentToHermesAgent(
-      makeAgent({ config: { platforms: { webhook: { enabled: false } } } })
-    );
-    expect(hermesAgent.spec.hermes?.config?.webhook).toEqual({ enabled: false });
   });
 
   it("leaves config.webhook undefined when there's no platforms.webhook", () => {
     const hermesAgent = agentToHermesAgent(makeAgent({ config: { platforms: {} } }));
     expect(hermesAgent.spec.hermes?.config?.webhook).toBeUndefined();
     expect(hermesAgent.spec.hermes?.config?.raw).toEqual({ platforms: {} });
+  });
+});
+
+describe("agentToHermesAgent webhook networking wiring", () => {
+  it("exposes the default webhook container and service ports when WEBHOOK_ENABLED=true", () => {
+    const hermesAgent = agentToHermesAgent(
+      makeAgent({ env: [{ name: "WEBHOOK_ENABLED", value: "true" }] })
+    );
+    expect(hermesAgent.spec.hermes?.ports).toEqual([
+      { name: "webhook", containerPort: 8644, protocol: "TCP" },
+    ]);
+    expect(hermesAgent.spec.networking?.service?.ports).toEqual([
+      { name: "webhook", port: 8644, targetPort: 8644, protocol: "TCP" },
+    ]);
+  });
+
+  it("uses WEBHOOK_PORT when set", () => {
+    const hermesAgent = agentToHermesAgent(
+      makeAgent({
+        env: [
+          { name: "WEBHOOK_ENABLED", value: "true" },
+          { name: "WEBHOOK_PORT", value: "9000" },
+        ],
+      })
+    );
+    expect(hermesAgent.spec.hermes?.ports).toEqual([
+      { name: "webhook", containerPort: 9000, protocol: "TCP" },
+    ]);
+    expect(hermesAgent.spec.networking?.service?.ports).toEqual([
+      { name: "webhook", port: 9000, targetPort: 9000, protocol: "TCP" },
+    ]);
+  });
+
+  it("uses config.platforms.webhook.extra.port when WEBHOOK_PORT env var is absent", () => {
+    const hermesAgent = agentToHermesAgent(
+      makeAgent({ config: { platforms: { webhook: { enabled: true, extra: { port: 9000 } } } } })
+    );
+    expect(hermesAgent.spec.hermes?.ports).toEqual([
+      { name: "webhook", containerPort: 9000, protocol: "TCP" },
+    ]);
+    expect(hermesAgent.spec.networking?.service?.ports).toEqual([
+      { name: "webhook", port: 9000, targetPort: 9000, protocol: "TCP" },
+    ]);
+  });
+
+  it("falls back to the default 8644 port when neither WEBHOOK_PORT nor extra.port is set", () => {
+    const hermesAgent = agentToHermesAgent(
+      makeAgent({ config: { platforms: { webhook: { enabled: true } } } })
+    );
+    expect(hermesAgent.spec.hermes?.ports).toEqual([
+      { name: "webhook", containerPort: 8644, protocol: "TCP" },
+    ]);
+  });
+
+  it("prefers config.platforms.webhook.extra.port over the WEBHOOK_PORT env var", () => {
+    const hermesAgent = agentToHermesAgent(
+      makeAgent({
+        env: [
+          { name: "WEBHOOK_ENABLED", value: "true" },
+          { name: "WEBHOOK_PORT", value: "9001" },
+        ],
+        config: { platforms: { webhook: { enabled: true, extra: { port: 9000 } } } },
+      })
+    );
+    expect(hermesAgent.spec.hermes?.ports).toEqual([
+      { name: "webhook", containerPort: 9000, protocol: "TCP" },
+    ]);
+  });
+
+  it("leaves ports and networking undefined when webhook is disabled", () => {
+    const hermesAgent = agentToHermesAgent(
+      makeAgent({ env: [{ name: "WEBHOOK_ENABLED", value: "false" }] })
+    );
+    expect(hermesAgent.spec.hermes?.ports).toBeUndefined();
+    expect(hermesAgent.spec.networking).toBeUndefined();
+  });
+
+  it("leaves ports and networking undefined when webhook config is absent", () => {
+    const hermesAgent = agentToHermesAgent(makeAgent());
+    expect(hermesAgent.spec.hermes?.ports).toBeUndefined();
+    expect(hermesAgent.spec.networking).toBeUndefined();
+  });
+
+  it("merges api-server and webhook entries into one networking.service.ports array when both are enabled", () => {
+    const hermesAgent = agentToHermesAgent(
+      makeAgent({
+        env: [
+          { name: "API_SERVER_ENABLED", value: "true" },
+          { name: "WEBHOOK_ENABLED", value: "true" },
+        ],
+      })
+    );
+    expect(hermesAgent.spec.hermes?.ports).toEqual([
+      { name: "api-server", containerPort: 8642, protocol: "TCP" },
+      { name: "webhook", containerPort: 8644, protocol: "TCP" },
+    ]);
+    expect(hermesAgent.spec.networking?.service?.ports).toEqual([
+      { name: "api-server", port: 8642, targetPort: 8642, protocol: "TCP" },
+      { name: "webhook", port: 8644, targetPort: 8644, protocol: "TCP" },
+    ]);
   });
 });
 

--- a/apps/dashboard/src/server/infras/kubernetes/client.ts
+++ b/apps/dashboard/src/server/infras/kubernetes/client.ts
@@ -11,7 +11,9 @@ import {
   SharedEnvSet,
   SharedEnvSetEnvVar,
   getApiServerPort,
+  getWebhookPort,
   isApiServerEnabled,
+  isWebhookEnabled,
 } from "@/entities";
 import { config } from "@/server/libs/config";
 import {
@@ -23,7 +25,13 @@ import {
   Runtime,
   SharedEnvSetPatch,
 } from "../../usecases/adaptors/runtime";
-import { HermesAgent, HermesAgentList, HermesAgentSpec, HermesConfig } from "./types/hermes-agent";
+import {
+  HermesAgent,
+  HermesAgentList,
+  HermesAgentSpec,
+  HermesConfig,
+  ServicePort,
+} from "./types/hermes-agent";
 
 const enum HermesGroup {
   Default = "agents.hermeum.app",
@@ -162,33 +170,40 @@ export function agentToHermesAgent(agent: Agent): HermesAgent {
       agent.config.web?.backend === "searxng";
     camofoxEnabled = agent.config.browser?.cloud_provider === "camofox";
     hermes.config = { raw: agent.config };
-    const webhook = agent.config.platforms?.webhook;
-    if (webhook !== undefined) {
-      hermes.config.webhook = {
-        ...(webhook.enabled !== undefined && { enabled: webhook.enabled }),
-        ...(webhook.extra?.port !== undefined && { port: webhook.extra.port }),
-        ...(webhook.enabled === true && {
-          secretRef: { name: agentEnvResourceName(agent.id), key: "WEBHOOK_SECRET" },
-        }),
-      };
-    }
   }
   // Expose the API server container + service ports when the agent opts in via
   // the API_SERVER_ENABLED env var.
   const apiServerPort = isApiServerEnabled(agent) ? getApiServerPort(agent) : null;
-  let apiServerNetworking: HermesAgentSpec["networking"] | undefined;
+  // Expose the webhook container + service ports when the agent opts in via
+  // the WEBHOOK_ENABLED env var OR config.platforms.webhook.enabled.
+  const webhookPort = isWebhookEnabled(agent) ? getWebhookPort(agent) : null;
+  const servicePorts: ServicePort[] = [];
   if (apiServerPort !== null) {
     hermes.ports = [
+      ...(hermes.ports ?? []),
       { name: "api-server", containerPort: apiServerPort, protocol: "TCP" },
     ];
-    apiServerNetworking = {
-      service: {
-        ports: [
-          { name: "api-server", port: apiServerPort, targetPort: apiServerPort, protocol: "TCP" },
-        ],
-      },
-    };
+    servicePorts.push({
+      name: "api-server",
+      port: apiServerPort,
+      targetPort: apiServerPort,
+      protocol: "TCP",
+    });
   }
+  if (webhookPort !== null) {
+    hermes.ports = [
+      ...(hermes.ports ?? []),
+      { name: "webhook", containerPort: webhookPort, protocol: "TCP" },
+    ];
+    servicePorts.push({
+      name: "webhook",
+      port: webhookPort,
+      targetPort: webhookPort,
+      protocol: "TCP",
+    });
+  }
+  const networking =
+    servicePorts.length > 0 ? { service: { ports: servicePorts } } : undefined;
   if (agent.sharedEnvSets !== undefined) {
     hermes.envFrom = agent.sharedEnvSets.map((name) => ({ secretRef: { name } }));
   }
@@ -222,7 +237,7 @@ export function agentToHermesAgent(agent: Agent): HermesAgent {
     ...(Object.keys(hermes).length > 0 && { hermes: hermes as HermesAgentSpec["hermes"] }),
     ...(searxngEnabled && { searxng: { enabled: true } }),
     ...(camofoxEnabled && { camofox: { enabled: true } }),
-    ...(apiServerNetworking !== undefined && { networking: apiServerNetworking }),
+    ...(networking !== undefined && { networking }),
     podAnnotations: { [HermeumPodAnnotation.EnvHash]: hashAgentEnv(agent.env) },
   };
 


### PR DESCRIPTION
## Summary

Webhook port mapping now uses the same mechanism as the API server instead of writing to `hermes.config.webhook`.

## Changes

- **`agent.ts`**: New `isWebhookEnabled()` / `getWebhookPort()` helpers mirroring the API server helpers. `config.platforms.webhook` (`enabled`, `extra.port`) is **preferred** over `WEBHOOK_ENABLED` / `WEBHOOK_PORT` env vars; env vars act as a fallback when the corresponding config field is absent. `WEBHOOK_SECRET` required-env validation re-gated onto `isWebhookEnabled(data)` so it fires whether enabled via env var or config.
- **`client.ts`**: Dropped the `hermes.config.webhook` write block. Webhook now projects onto `hermes.ports` + `spec.networking.service.ports` (name `webhook`, default port `8644`). When both API server and webhook are enabled, their entries **merge into one** `networking.service.ports` array (fixes a latent overwrite from the separate-spread pattern).
- **`hermes-agent.ts`**: No change — `HermesWebhook` interface and `webhook?` on `HermesConfig` stay defined (operator-facing) but are no longer written by the dashboard.
- **Docs (`webhooks.md`)**: Notes that config.yaml is preferred over env vars; secret flows via env Secret/ConfigMap (no separate `secretRef`).
- **Tests**: `agent.test.ts` adds `isWebhookEnabled`/`getWebhookPort` cases + precedence tests; `client.test.ts` replaces the old `config.webhook wiring` block with networking-wiring tests including the merged-ports case.

## Behavior

| Aspect | Resolution |
|---|---|
| Enablement | `config.platforms.webhook.enabled` wins; else `WEBHOOK_ENABLED=true` |
| Port | `config.platforms.webhook.extra.port` wins; else `WEBHOOK_PORT`; default `8644` |
| Networking | `hermes.ports` + `networking.service.ports` entry named `webhook` |
| Both API server + webhook | Merged into one `service.ports` array |
| `hermes.config.webhook` | No longer populated by the dashboard |
| `WEBHOOK_SECRET` | Required sensitive env when webhook enabled; flows via `hermes.workspace.dotEnv` |

## Verification

- `pnpm typecheck` — clean
- `pnpm test` — 197 passed
- `pnpm lint` — only pre-existing warnings (unrelated to this change)