### PR TITLE
refactor: revive hermes-config schemas in expandable entities/hermes-config/ dir

### DIFF
--- a/apps/dashboard/src/entities/agent.test.ts
+++ b/apps/dashboard/src/entities/agent.test.ts
@@ -565,18 +565,18 @@ describe("AgentInputSchema web config validation", () => {
     expect(result.success).toBe(true);
   });
 
-  it("passes search_backend through without enum validation", () => {
+  it("rejects an unknown search_backend", () => {
     const result = AgentInputSchema.safeParse({
       config: { web: { search_backend: "google" } },
     });
-    expect(result.success).toBe(true);
+    expect(result.success).toBe(false);
   });
 
-  it("passes extract_backend through without enum validation", () => {
+  it("rejects a search-only backend used as extract_backend", () => {
     const result = AgentInputSchema.safeParse({
       config: { web: { extract_backend: "ddgs" } },
     });
-    expect(result.success).toBe(true);
+    expect(result.success).toBe(false);
   });
 });
 
@@ -595,10 +595,10 @@ describe("AgentInputSchema browser config validation", () => {
     expect(result.success).toBe(true);
   });
 
-  it("passes cloud_provider through without enum validation", () => {
+  it("rejects an unknown cloud_provider", () => {
     const result = AgentInputSchema.safeParse({
       config: { browser: { cloud_provider: "playwright" } },
     });
-    expect(result.success).toBe(true);
+    expect(result.success).toBe(false);
   });
 });

--- a/apps/dashboard/src/entities/agent.ts
+++ b/apps/dashboard/src/entities/agent.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import { ConfigSchema } from "./hermes-config";
 import { EnvVarSchema } from "./shared-env-set";
 
 export const ENV_SECRET_SENTINEL = "<secret>";
@@ -74,56 +75,6 @@ instructions (those belong elsewhere in the config).
   );
 
 export type Soul = z.infer<typeof SoulSchema>;
-
-// Only the fields the dashboard reads (server/infras/kubernetes/client.ts) are
-// typed here; everything else passes through as a loose field. Full field
-// semantics live in docs/hermes-config/ and are surfaced to the LLM via the
-// readDocument tool.
-const WebConfigSchema = z
-  .looseObject({
-    search_backend: z.string().optional(),
-    backend: z.string().optional(),
-  })
-  .optional();
-
-const BrowserConfigSchema = z
-  .looseObject({
-    cloud_provider: z.string().optional(),
-  })
-  .optional();
-
-const WebhookConfigSchema = z
-  .looseObject({
-    enabled: z.boolean().optional(),
-    extra: z
-      .looseObject({
-        port: z.number().int().optional(),
-      })
-      .optional(),
-  })
-  .optional();
-
-const PlatformsConfigSchema = z
-  .looseObject({
-    webhook: WebhookConfigSchema,
-  })
-  .optional();
-
-export const ConfigSchema = z
-  .looseObject({
-    web: WebConfigSchema,
-    browser: BrowserConfigSchema,
-    platforms: PlatformsConfigSchema,
-  })
-  .optional()
-  .describe(
-    "Hermes agent configuration. Only well-known fields used by the dashboard " +
-      "are typed here; any additional fields pass through unchanged. Use the " +
-      "`readDocument` tool to look up the semantics of any config field you " +
-      "are not fully sure about before writing it into the draft."
-  );
-
-export type Config = z.infer<typeof ConfigSchema>;
 
 // https://hermes-agent.nousresearch.com/docs/user-guide/features/skills#supported-hub-sources
 const SKILL_SOURCE_PREFIXES = [

--- a/apps/dashboard/src/entities/hermes-config/browser.ts
+++ b/apps/dashboard/src/entities/hermes-config/browser.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+// Only the fields the dashboard reads (server/infras/kubernetes/client.ts) are
+// typed here; everything else passes through as a loose field. Full field
+// semantics live in docs/hermes-config/browser.md and are surfaced to the LLM
+// via the readDocument tool.
+export const BrowserConfigSchema = z
+  .looseObject({
+    cloud_provider: z.string().optional(),
+  })
+  .optional()
+  .describe("Browser automation config. See docs/hermes-config/browser.md.");
+
+export type BrowserConfig = z.infer<typeof BrowserConfigSchema>;

--- a/apps/dashboard/src/entities/hermes-config/browser.ts
+++ b/apps/dashboard/src/entities/hermes-config/browser.ts
@@ -1,14 +1,18 @@
 import { z } from "zod";
 
-// Only the fields the dashboard reads (server/infras/kubernetes/client.ts) are
-// typed here; everything else passes through as a loose field. Full field
-// semantics live in docs/hermes-config/browser.md and are surfaced to the LLM
-// via the readDocument tool.
-export const BrowserConfigSchema = z
+// https://hermes-agent.nousresearch.com/docs/user-guide/features/browser
+// Full field semantics: docs/hermes-config/browser.md
+export const BrowserCloudProviderSchema = z
+  .enum(["browserbase", "browser-use", "firecrawl", "camofox"])
+  .describe("Browser automation provider.");
+
+export type BrowserCloudProvider = z.infer<typeof BrowserCloudProviderSchema>;
+
+export const BrowserSchema = z
   .looseObject({
-    cloud_provider: z.string().optional(),
+    cloud_provider: BrowserCloudProviderSchema.optional(),
   })
   .optional()
-  .describe("Browser automation config. See docs/hermes-config/browser.md.");
+  .describe("Browser automation configuration.");
 
-export type BrowserConfig = z.infer<typeof BrowserConfigSchema>;
+export type Browser = z.infer<typeof BrowserSchema>;

--- a/apps/dashboard/src/entities/hermes-config/index.ts
+++ b/apps/dashboard/src/entities/hermes-config/index.ts
@@ -1,0 +1,38 @@
+// Hermes agent config schema.
+//
+// Only well-known fields the dashboard reads are typed here (see the per-field
+// modules below); any additional fields pass through unchanged via looseObject.
+// Full field semantics live in docs/hermes-config/ and are surfaced to the LLM
+// via the readDocument tool, so .describe() texts are kept minimal — use the
+// `readDocument` tool to look up the semantics of any config field you are not
+// fully sure about before writing it into the draft.
+
+export { WebConfigSchema, type WebConfig } from "./web";
+export { BrowserConfigSchema, type BrowserConfig } from "./browser";
+export {
+  WebhookConfigSchema,
+  type WebhookConfig,
+  PlatformsConfigSchema,
+  type PlatformsConfig,
+} from "./webhook";
+
+import { z } from "zod";
+import { WebConfigSchema } from "./web";
+import { BrowserConfigSchema } from "./browser";
+import { PlatformsConfigSchema } from "./webhook";
+
+export const ConfigSchema = z
+  .looseObject({
+    web: WebConfigSchema,
+    browser: BrowserConfigSchema,
+    platforms: PlatformsConfigSchema,
+  })
+  .optional()
+  .describe(
+    "Hermes agent configuration. Only well-known fields used by the Hermeum " +
+      "are typed here; any additional fields pass through unchanged. Use the " +
+      "`readDocument` tool to look up the semantics of any config field you " +
+      "are not fully sure about before writing it into the draft."
+  );
+
+export type Config = z.infer<typeof ConfigSchema>;

--- a/apps/dashboard/src/entities/hermes-config/index.ts
+++ b/apps/dashboard/src/entities/hermes-config/index.ts
@@ -1,38 +1,55 @@
 // Hermes agent config schema.
 //
-// Only well-known fields the dashboard reads are typed here (see the per-field
-// modules below); any additional fields pass through unchanged via looseObject.
-// Full field semantics live in docs/hermes-config/ and are surfaced to the LLM
-// via the readDocument tool, so .describe() texts are kept minimal — use the
+// Only well-known fields are typed here (see the per-field modules below); any
+// additional fields pass through unchanged via looseObject. Full field
+// semantics live in docs/hermes-config/ and are surfaced to the LLM via the
+// readDocument tool, so .describe() texts are kept minimal — use the
 // `readDocument` tool to look up the semantics of any config field you are not
 // fully sure about before writing it into the draft.
 
-export { WebConfigSchema, type WebConfig } from "./web";
-export { BrowserConfigSchema, type BrowserConfig } from "./browser";
+export { ModelProviderSchema, ModelSchema, type ModelProvider, type Model } from "./model";
 export {
-  WebhookConfigSchema,
-  type WebhookConfig,
-  PlatformsConfigSchema,
-  type PlatformsConfig,
+  WebhookDeliverSchema,
+  DeliverExtraSchema,
+  WebhookRouteSchema,
+  WebhookSchema,
+  PlatformsSchema,
+  type WebhookDeliver,
+  type DeliverExtra,
+  type WebhookRoute,
+  type Webhook,
+  type Platforms,
 } from "./webhook";
+export { SlackSchema, type Slack } from "./slack";
+export {
+  WebSearchBackendSchema,
+  WebExtractBackendSchema,
+  WebSchema,
+  type WebSearchBackend,
+  type WebExtractBackend,
+  type Web,
+} from "./web";
+export { BrowserCloudProviderSchema, BrowserSchema, type BrowserCloudProvider, type Browser } from "./browser";
 
 import { z } from "zod";
-import { WebConfigSchema } from "./web";
-import { BrowserConfigSchema } from "./browser";
-import { PlatformsConfigSchema } from "./webhook";
+import { ModelSchema } from "./model";
+import { PlatformsSchema } from "./webhook";
+import { SlackSchema } from "./slack";
+import { WebSchema } from "./web";
+import { BrowserSchema } from "./browser";
 
 export const ConfigSchema = z
   .looseObject({
-    web: WebConfigSchema,
-    browser: BrowserConfigSchema,
-    platforms: PlatformsConfigSchema,
+    model: ModelSchema,
+    platforms: PlatformsSchema,
+    slack: SlackSchema,
+    web: WebSchema,
+    browser: BrowserSchema,
   })
   .optional()
   .describe(
-    "Hermes agent configuration. Only well-known fields used by the Hermeum " +
-      "are typed here; any additional fields pass through unchanged. Use the " +
-      "`readDocument` tool to look up the semantics of any config field you " +
-      "are not fully sure about before writing it into the draft."
+    "Hermes agent configuration. Use the `readDocument` tool to look up the " +
+      "semantics of any config field before writing it into the draft."
   );
 
 export type Config = z.infer<typeof ConfigSchema>;

--- a/apps/dashboard/src/entities/hermes-config/model.ts
+++ b/apps/dashboard/src/entities/hermes-config/model.ts
@@ -1,0 +1,61 @@
+import { z } from "zod";
+
+// https://hermes-agent.nousresearch.com/docs/integrations/providers
+// Full field semantics: docs/hermes-config/model.md
+export const ModelProviderSchema = z
+  .enum([
+    "nous",
+    "openai-codex",
+    "copilot",
+    "copilot-acp",
+    "anthropic",
+    "openrouter",
+    "novita",
+    "zai",
+    "kimi-coding",
+    "kimi-coding-cn",
+    "arcee",
+    "gmi",
+    "minimax",
+    "minimax-cn",
+    "xai",
+    "xai-oauth",
+    "alibaba",
+    "alibaba-coding-plan",
+    "kilocode",
+    "xiaomi",
+    "tencent-tokenhub",
+    "opencode-zen",
+    "opencode-go",
+    "deepseek",
+    "huggingface",
+    "gemini",
+    "vertex",
+    "openai-api",
+    "azure-foundry",
+    "bedrock",
+    "nvidia",
+    "ollama-cloud",
+    "qwen-oauth",
+    "minimax-oauth",
+    "stepfun",
+    "lmstudio",
+    "custom",
+  ])
+  .describe("LLM provider.");
+
+export type ModelProvider = z.infer<typeof ModelProviderSchema>;
+
+export const ModelSchema = z
+  .looseObject({
+    provider: ModelProviderSchema,
+    default: z.string().min(1).describe("Default model id."),
+    base_url: z
+      .url()
+      .optional()
+      .describe("Provider API endpoint URL."),
+  })
+  .optional()
+  .describe("LLM model configuration.");
+
+export type Model = z.infer<typeof ModelSchema>;

--- a/apps/dashboard/src/entities/hermes-config/slack.ts
+++ b/apps/dashboard/src/entities/hermes-config/slack.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+// https://hermes-agent.nousresearch.com/docs/user-guide/messaging/slack
+// Only the essential fields are validated here; the rest pass through via
+// looseObject so users can configure whatever the Hermes agent supports.
+// There is no docs/hermes-config/slack.md yet; field semantics are inline.
+export const SlackSchema = z
+  .looseObject({
+    allowed_channels: z
+      .array(z.string())
+      .optional()
+      .describe("Slack channel IDs the bot may respond in."),
+    unauthorized_dm_behavior: z
+      .literal("ignore")
+      .default("ignore")
+      .optional()
+      .describe('Behavior for unauthorized DMs. Always "ignore".'),
+  })
+  .optional()
+  .describe("Slack platform configuration. Requires SLACK_* env vars.");
+
+export type Slack = z.infer<typeof SlackSchema>;

--- a/apps/dashboard/src/entities/hermes-config/web.ts
+++ b/apps/dashboard/src/entities/hermes-config/web.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+// Only the fields the dashboard reads (server/infras/kubernetes/client.ts) are
+// typed here; everything else passes through as a loose field. Full field
+// semantics live in docs/hermes-config/web-search.md and are surfaced to the
+// LLM via the readDocument tool.
+export const WebConfigSchema = z
+  .looseObject({
+    search_backend: z.string().optional(),
+    backend: z.string().optional(),
+  })
+  .optional()
+  .describe("Web search & extract config. See docs/hermes-config/web-search.md.");
+
+export type WebConfig = z.infer<typeof WebConfigSchema>;

--- a/apps/dashboard/src/entities/hermes-config/web.ts
+++ b/apps/dashboard/src/entities/hermes-config/web.ts
@@ -1,15 +1,26 @@
 import { z } from "zod";
 
-// Only the fields the dashboard reads (server/infras/kubernetes/client.ts) are
-// typed here; everything else passes through as a loose field. Full field
-// semantics live in docs/hermes-config/web-search.md and are surfaced to the
-// LLM via the readDocument tool.
-export const WebConfigSchema = z
+// https://hermes-agent.nousresearch.com/docs/user-guide/features/web-search
+// Full field semantics: docs/hermes-config/web-search.md
+export const WebSearchBackendSchema = z
+  .enum(["firecrawl", "searxng", "brave-free", "ddgs", "tavily", "exa", "parallel", "xai"])
+  .describe("Web search backend.");
+
+export type WebSearchBackend = z.infer<typeof WebSearchBackendSchema>;
+
+export const WebExtractBackendSchema = z
+  .enum(["firecrawl", "tavily", "exa", "parallel"])
+  .describe("Web extract backend. Search-only backends are not allowed here.");
+
+export type WebExtractBackend = z.infer<typeof WebExtractBackendSchema>;
+
+export const WebSchema = z
   .looseObject({
-    search_backend: z.string().optional(),
-    backend: z.string().optional(),
+    backend: WebSearchBackendSchema.optional().describe("Shared backend for search and extract."),
+    search_backend: WebSearchBackendSchema.optional().describe("Backend for the web_search tool."),
+    extract_backend: WebExtractBackendSchema.optional().describe("Backend for the web_extract tool."),
   })
   .optional()
-  .describe("Web search & extract config. See docs/hermes-config/web-search.md.");
+  .describe("Web search & extract configuration.");
 
-export type WebConfig = z.infer<typeof WebConfigSchema>;
+export type Web = z.infer<typeof WebSchema>;

--- a/apps/dashboard/src/entities/hermes-config/webhook.ts
+++ b/apps/dashboard/src/entities/hermes-config/webhook.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+
+// Only the fields the dashboard reads (isWebhookEnabled / getWebhookPort in
+// entities/agent.ts) are typed here; everything else passes through as a loose
+// field. Full field semantics live in docs/hermes-config/webhooks.md and are
+// surfaced to the LLM via the readDocument tool.
+export const WebhookConfigSchema = z
+  .looseObject({
+    enabled: z.boolean().optional(),
+    extra: z
+      .looseObject({
+        port: z.number().int().optional(),
+      })
+      .optional(),
+  })
+  .optional();
+
+export type WebhookConfig = z.infer<typeof WebhookConfigSchema>;
+
+export const PlatformsConfigSchema = z
+  .looseObject({
+    webhook: WebhookConfigSchema,
+  })
+  .optional();
+
+export type PlatformsConfig = z.infer<typeof PlatformsConfigSchema>;

--- a/apps/dashboard/src/entities/hermes-config/webhook.ts
+++ b/apps/dashboard/src/entities/hermes-config/webhook.ts
@@ -1,26 +1,89 @@
 import { z } from "zod";
 
-// Only the fields the dashboard reads (isWebhookEnabled / getWebhookPort in
-// entities/agent.ts) are typed here; everything else passes through as a loose
-// field. Full field semantics live in docs/hermes-config/webhooks.md and are
-// surfaced to the LLM via the readDocument tool.
-export const WebhookConfigSchema = z
-  .looseObject({
-    enabled: z.boolean().optional(),
+// https://hermes-agent.nousresearch.com/docs/user-guide/messaging/webhooks
+// Full field semantics: docs/hermes-config/webhooks.md
+export const WebhookDeliverSchema = z
+  .enum([
+    "log",
+    "github_comment",
+    "telegram",
+    "discord",
+    "slack",
+    "signal",
+    "sms",
+    "whatsapp",
+    "matrix",
+    "mattermost",
+    "homeassistant",
+    "email",
+    "dingtalk",
+    "feishu",
+    "wecom",
+    "weixin",
+    "bluebubbles",
+    "qqbot",
+  ])
+  .optional()
+  .describe("Where to send the response.");
+
+export type WebhookDeliver = z.infer<typeof WebhookDeliverSchema>;
+
+export const DeliverExtraSchema = z
+  .object({
+    chat_id: z.string().optional().describe("Destination chat/channel id."),
+    repo: z.string().optional().describe('Repository in "owner/repo" form.'),
+    pr_number: z.string().optional().describe("PR/issue number to comment on."),
+  })
+  .optional()
+  .describe("Platform-specific delivery options.");
+
+export type DeliverExtra = z.infer<typeof DeliverExtraSchema>;
+
+export const WebhookRouteSchema = z
+  .object({
+    events: z.array(z.string()).optional().describe("Event types this route accepts."),
+    prompt: z
+      .string()
+      .optional()
+      .describe("Prompt template with {dot.notation} payload access."),
+    skills: z.array(z.string()).optional().describe("Skill names to load for this route."),
+    deliver: WebhookDeliverSchema,
+    deliver_extra: DeliverExtraSchema,
+    deliver_only: z
+      .boolean()
+      .optional()
+      .describe("Skip the agent and deliver the rendered prompt as a literal message."),
+  })
+  .describe("A named webhook route.");
+
+export type WebhookRoute = z.infer<typeof WebhookRouteSchema>;
+
+export const WebhookSchema = z
+  .object({
+    enabled: z.boolean().optional().describe("Whether the webhook server is enabled."),
     extra: z
-      .looseObject({
-        port: z.number().int().optional(),
+      .object({
+        port: z.number().int().optional().describe("Webhook server port."),
+        rate_limit: z.number().optional().describe("Max requests per minute."),
+        max_body_bytes: z.number().optional().describe("Max request body size in bytes."),
+        routes: z
+          .record(z.string(), WebhookRouteSchema)
+          .optional()
+          .describe("Named webhook routes keyed by route name."),
       })
-      .optional(),
+      .optional()
+      .describe("Webhook server settings."),
   })
-  .optional();
+  .optional()
+  .describe("Webhook platform configuration.");
 
-export type WebhookConfig = z.infer<typeof WebhookConfigSchema>;
+export type Webhook = z.infer<typeof WebhookSchema>;
 
-export const PlatformsConfigSchema = z
+export const PlatformsSchema = z
   .looseObject({
-    webhook: WebhookConfigSchema,
+    webhook: WebhookSchema,
   })
-  .optional();
+  .optional()
+  .describe("Messaging platform integrations.");
 
-export type PlatformsConfig = z.infer<typeof PlatformsConfigSchema>;
+export type Platforms = z.infer<typeof PlatformsSchema>;

--- a/apps/dashboard/src/entities/index.ts
+++ b/apps/dashboard/src/entities/index.ts
@@ -3,3 +3,4 @@ export * from "./agent";
 export * from "./template";
 export * from "./hermeum-config";
 export * from "./shared-env-set";
+export * from "./hermes-config";

--- a/apps/dashboard/src/server/infras/kubernetes/client.test.ts
+++ b/apps/dashboard/src/server/infras/kubernetes/client.test.ts
@@ -338,7 +338,7 @@ describe("mapHermesConfig", () => {
     const config = {
       model: { provider: "anthropic", default: "claude-sonnet-5" },
     };
-    const hermesAgent = agentToHermesAgent(makeAgent({ config }));
+    const hermesAgent = agentToHermesAgent(makeAgent({ config: config as Agent["config"] }));
     expect(mapHermesConfig(hermesAgent.spec.hermes?.config)).toEqual(config);
   });
 });


### PR DESCRIPTION
## Summary

Splits the inlined `ConfigSchema` in `entities/agent.ts` into an expandable `entities/hermes-config/` directory and revives the previously-inlined config schemas (model, webhook routes/delivery, slack, web, browser) with minimal `.describe()` text — full field semantics now live in `docs/hermes-config/` and are surfaced to the LLM via the `readDocument` tool.

## Changes

- **New structure** under `apps/dashboard/src/entities/hermes-config/`:
  - `model.ts` — `ModelProviderSchema`, `ModelSchema`
  - `webhook.ts` — `WebhookDeliverSchema`, `DeliverExtraSchema`, `WebhookRouteSchema`, `WebhookSchema`, `PlatformsSchema`
  - `slack.ts` — `SlackSchema`
  - `web.ts` — `WebSearchBackendSchema`, `WebExtractBackendSchema`, `WebSchema`
  - `browser.ts` — `BrowserCloudProviderSchema`, `BrowserSchema`
  - `index.ts` — composes them into `ConfigSchema`, re-exports
- **`entities/agent.ts`**: dropped the duplicated inline schemas; imports `ConfigSchema` from the new module. The `api_server` schema stays removed (driven via env vars per #63); `isApiServerEnabled`/`getApiServerPort` helpers remain.
- **`.describe()` texts** trimmed to single-line pointers; redundant `See docs/hermes-config/...` suffixes removed since docs are surfaced via `readDocument`.
- **Tests**: updated `agent.test.ts` and `client.test.ts` to reflect revived enum validation (unknown `search_backend`/`extract_backend`/`cloud_provider` values now rejected as expected).

## Verification

- `pnpm --filter dashboard typecheck` — clean
- `pnpm --filter dashboard test` — 197/197 passing
- `pnpm --filter dashboard lint` — no new warnings/errors