### PR TITLE
docs(hermes-config): show examples in AgentInput shape

### DIFF
--- a/apps/dashboard/docs/hermes-config/api-server.md
+++ b/apps/dashboard/docs/hermes-config/api-server.md
@@ -29,11 +29,13 @@ The API server is configured entirely through environment variables —
 
 ## Example
 
-`~/.hermes/.env`:
+### Enabling the API server with an auth key
 
-```bash
-API_SERVER_ENABLED=true
-API_SERVER_KEY=change-me-local-dev
-# Optional: only if a browser must call Hermes directly
-# API_SERVER_CORS_ORIGINS=http://localhost:3000
+```yaml
+env:
+  - name: API_SERVER_ENABLED
+    value: "true"
+  - name: API_SERVER_KEY
+    value: change-me-local-dev
+    sensitive: true
 ```

--- a/apps/dashboard/docs/hermes-config/browser.md
+++ b/apps/dashboard/docs/hermes-config/browser.md
@@ -103,19 +103,16 @@ different backend when the user explicitly requests one.
 
 ## Example
 
-`~/.hermes/config.yaml`:
+### Camofox with managed persistence and loopback rewriting
 
 ```yaml
-browser:
-  dialog_policy: must_respond
-  camofox:
-    managed_persistence: true
-    rewrite_loopback_urls: true
+config:
+  browser:
+    dialog_policy: must_respond
+    camofox:
+      managed_persistence: true
+      rewrite_loopback_urls: true
 ```
 
-`~/.hermes/.env`:
-
-```bash
-# CAMOFOX_URL and CAMOFOX_API_KEY are set automatically by Hermeum —
-# no need to set them here.
-```
+`CAMOFOX_URL` and `CAMOFOX_API_KEY` are set automatically by Hermeum —
+no need to add them to `env`.

--- a/apps/dashboard/docs/hermes-config/model.md
+++ b/apps/dashboard/docs/hermes-config/model.md
@@ -33,8 +33,15 @@ Setting a model requires an env var holding the provider's API key, marked
 
 ## Example
 
+### OpenAI API provider with a required key
+
 ```yaml
-model:
-  provider: openai-api
-  default: gpt-5.5
+config:
+  model:
+    provider: openai-api
+    default: gpt-5.5
+env:
+  - name: OPENAI_API_KEY
+    value: sk-...
+    sensitive: true
 ```

--- a/apps/dashboard/docs/hermes-config/web-search.md
+++ b/apps/dashboard/docs/hermes-config/web-search.md
@@ -65,17 +65,17 @@ package, lazy-installed on first use).
 
 ## Example
 
-`~/.hermes/config.yaml`:
+### SearXNG search with Firecrawl extraction
 
 ```yaml
-web:
-  search_backend: "searxng"     # free, self-hosted, Hermeum default
-  extract_backend: "firecrawl" # paid, high-quality extraction
+config:
+  web:
+    search_backend: searxng
+    extract_backend: firecrawl
+env:
+  - name: FIRECRAWL_API_KEY
+    value: fc-your-key-here
+    sensitive: true
 ```
 
-`~/.hermes/.env`:
-
-```bash
-# SEARXNG_URL is set automatically by Hermeum — no need to set it here.
-FIRECRAWL_API_KEY=fc-your-key-here
-```
+`SEARXNG_URL` is set automatically by Hermeum — no need to add it to `env`.

--- a/apps/dashboard/docs/hermes-config/webhooks.md
+++ b/apps/dashboard/docs/hermes-config/webhooks.md
@@ -115,28 +115,35 @@ fallback for deployments that don't set `config.yaml`.
 
 ## Example
 
+### GitHub PR review webhook posting back as a comment
+
 ```yaml
-platforms:
-  webhook:
-    enabled: true
-    extra:
-      port: 8644
-      routes:
-        github-pr:
-          events: ["pull_request"]
-          prompt: |
-            Review this pull request:
-            Repository: {repository.full_name}
-            PR #{number}: {pull_request.title}
-            Author: {pull_request.user.login}
-            URL: {pull_request.html_url}
-            Diff URL: {pull_request.diff_url}
-            Action: {action}
-          skills: ["github-code-review"]
-          deliver: "github_comment"
-          deliver_extra:
-            repo: "{repository.full_name}"
-            pr_number: "{number}"
+config:
+  platforms:
+    webhook:
+      enabled: true
+      extra:
+        port: 8644
+        routes:
+          github-pr:
+            events: [pull_request]
+            prompt: |
+              Review this pull request:
+              Repository: {repository.full_name}
+              PR #{number}: {pull_request.title}
+              Author: {pull_request.user.login}
+              URL: {pull_request.html_url}
+              Diff URL: {pull_request.diff_url}
+              Action: {action}
+            skills: [github-code-review]
+            deliver: github_comment
+            deliver_extra:
+              repo: "{repository.full_name}"
+              pr_number: "{number}"
+env:
+  - name: WEBHOOK_SECRET
+    value: wh-secret-here
+    sensitive: true
 ```
 
-The HMAC secret is provided via the `WEBHOOK_SECRET` environment variable.
+The HMAC secret is provided via the `WEBHOOK_SECRET` env entry.


### PR DESCRIPTION
## Summary

The docs under `apps/dashboard/docs/hermes-config/` are surfaced to the LLM via the `readDocument` tool, and the model emits config changes through `updateAgentConfig` as an `AgentInput` JSON object (`AgentInputObjectSchema` in `apps/dashboard/src/entities/agent.ts`).

Previously the Example blocks framed configuration as two runtime files (`~/.hermes/config.yaml` + `~/.hermes/.env`), e.g.:

```bash
# ~/.hermes/.env
API_SERVER_ENABLED=true
API_SERVER_KEY=change-me-local-dev
```

The model then had to infer the translation into the `AgentInput` shape (config fields under `config`, env vars under `env` as `{name, value, sensitive}` entries). That inference gap was the source of the agent confusion called out in #issue.

## Changes

Only the **Example** sections of the 5 hermes-config docs are rewritten. Prose, field/env reference tables, and frontmatter are untouched.

- `api-server.md` — bash `.env` block → YAML `env` array with `API_SERVER_ENABLED` + `API_SERVER_KEY` (`sensitive: true`)
- `webhooks.md` — split `config.yaml`/`env` example → single YAML block with `config.platforms.webhook` + `env: WEBHOOK_SECRET`
- `web-search.md` — split `config.yaml`/`env` example → single YAML block with `config.web` + `env: FIRECRAWL_API_KEY`
- `browser.md` — `config.yaml`-only example → YAML `config.browser` block (auto-set `CAMOFOX_*` note preserved)
- `model.md` — bare `config.yaml` example → YAML with `config.model` + `env: OPENAI_API_KEY`

Each example keeps YAML for readability and gains a descriptive `###` title under the existing `## Example` section.

## Verification

- Confirmed each example YAML parses against `AgentInputObjectSchema` (ad-hoc vitest, since removed)
- `apps/dashboard/src/server/usecases/chat.test.ts` — 11/11 pass (readDocument/listing behavior unaffected; frontmatter unchanged)