### PR TITLE
Make agent-config chat resizable on desktop

### DIFF
--- a/apps/dashboard/src/client/ui/components/agent-config-chat.tsx
+++ b/apps/dashboard/src/client/ui/components/agent-config-chat.tsx
@@ -111,7 +111,7 @@ export function AgentConfigChat({ getConfig, onConfigUpdate, templates }: AgentC
       {messages.length === 0 ? (
         <div className="flex min-h-0 flex-1 flex-col items-center justify-center">
           <div className="text-center">
-            <h2 className="text-lg font-semibold tracking-tight">What do you want to build?</h2>
+            <h2 className="text-lg font-semibold tracking-tight">What should your agent do?</h2>
             <p className="mt-1 text-sm text-muted-foreground">
               Describe your agent
               {hasTemplates ? (

--- a/apps/dashboard/src/client/ui/routes/agents/new.tsx
+++ b/apps/dashboard/src/client/ui/routes/agents/new.tsx
@@ -5,6 +5,11 @@ import { parse } from "yaml";
 import { toast } from "sonner";
 
 import { Button } from "@hermeum/components/ui/button";
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from "@hermeum/components/ui/resizable";
 import { useTRPC } from "@/router";
 import { AgentInputObjectSchema, AgentInputSchema } from "@/entities";
 import type { AgentInput } from "@/entities";
@@ -95,23 +100,16 @@ function NewAgentPage() {
     <div className="flex h-full min-h-0 flex-col gap-4 p-6">
       <h1 className="shrink-0 text-2xl font-semibold tracking-tight">Create agent</h1>
 
-      <div className="grid min-h-0 flex-1 grid-cols-1 gap-6 lg:grid-cols-2">
-        {/* Chat pane */}
-        <AgentConfigChat
-          getConfig={getConfig}
-          onConfigUpdate={handleConfigUpdate}
-          templates={templates}
-        />
-
-        {/* Config pane */}
-        <div className="flex min-h-0 flex-col gap-2">
+      {/* Mobile: static stacked layout (config on top, chat at bottom) */}
+      <div className="flex min-h-0 flex-1 flex-col gap-6 lg:hidden">
+        <div className="flex flex-col gap-2">
           <p className="shrink-0 text-sm font-medium">Agent config</p>
           <div className="min-h-0 flex-1">
             <CodeEditor
               value={editorValue}
               onChange={setEditorValue}
               invalid={!!validationError}
-              height="100%"
+              height="300px"
             />
           </div>
           {validationError && (
@@ -126,7 +124,61 @@ function NewAgentPage() {
             </Button>
           </div>
         </div>
+        <div className="flex min-h-0 flex-1 flex-col">
+          <AgentConfigChat
+            getConfig={getConfig}
+            onConfigUpdate={handleConfigUpdate}
+            templates={templates}
+          />
+        </div>
       </div>
+
+      {/* Desktop: resizable side-by-side layout */}
+      <ResizablePanelGroup
+        orientation="horizontal"
+        className="hidden min-h-0 flex-1 lg:flex"
+      >
+        {/* Chat pane */}
+        <ResizablePanel defaultSize="50%" minSize="25%" className="min-h-0">
+          <div className="flex h-full min-h-0 flex-col pr-3">
+            <AgentConfigChat
+              getConfig={getConfig}
+              onConfigUpdate={handleConfigUpdate}
+              templates={templates}
+            />
+          </div>
+        </ResizablePanel>
+        <ResizableHandle
+          withHandle
+          className="bg-transparent [&>div]:opacity-0 [&>div]:transition-opacity hover:[&>div]:opacity-100"
+        />
+
+        {/* Config pane */}
+        <ResizablePanel defaultSize="50%" minSize="25%" className="min-h-0">
+          <div className="flex h-full min-h-0 flex-col gap-2 pl-3">
+            <p className="shrink-0 text-sm font-medium">Agent config</p>
+            <div className="min-h-0 flex-1">
+              <CodeEditor
+                value={editorValue}
+                onChange={setEditorValue}
+                invalid={!!validationError}
+                height="100%"
+              />
+            </div>
+            {validationError && (
+              <p className="shrink-0 text-sm text-destructive">{validationError}</p>
+            )}
+            <div className="flex shrink-0 justify-end gap-2">
+              <Button variant="outline" onClick={() => navigate({ to: "/agents" })}>
+                Cancel
+              </Button>
+              <Button onClick={handleCreate} disabled={isCreating}>
+                {isCreating ? "Creating…" : "Create agent"}
+              </Button>
+            </div>
+          </div>
+        </ResizablePanel>
+      </ResizablePanelGroup>
     </div>
   );
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -25,6 +25,7 @@
     "clsx": "^2.1.1",
     "input-otp": "^1.4.2",
     "lucide-react": "^1.8.0",
+    "react-resizable-panels": "^4.0.0",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0"
   },

--- a/packages/components/ui/resizable.tsx
+++ b/packages/components/ui/resizable.tsx
@@ -1,0 +1,53 @@
+"use client"
+
+import { GripVerticalIcon } from "lucide-react"
+import * as ResizablePrimitive from "react-resizable-panels"
+
+import { cn } from "@hermeum/components/lib/utils"
+
+function ResizablePanelGroup({
+  className,
+  ...props
+}: ResizablePrimitive.GroupProps) {
+  return (
+    <ResizablePrimitive.Group
+      data-slot="resizable-panel-group"
+      className={cn(
+        "flex h-full w-full aria-[orientation=vertical]:flex-col",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ResizablePanel({ ...props }: ResizablePrimitive.PanelProps) {
+  return <ResizablePrimitive.Panel data-slot="resizable-panel" {...props} />
+}
+
+function ResizableHandle({
+  withHandle,
+  className,
+  ...props
+}: ResizablePrimitive.SeparatorProps & {
+  withHandle?: boolean
+}) {
+  return (
+    <ResizablePrimitive.Separator
+      data-slot="resizable-handle"
+      className={cn(
+        "relative flex w-px items-center justify-center bg-border after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:outline-hidden aria-[orientation=horizontal]:h-px aria-[orientation=horizontal]:w-full aria-[orientation=horizontal]:after:left-0 aria-[orientation=horizontal]:after:h-1 aria-[orientation=horizontal]:after:w-full aria-[orientation=horizontal]:after:translate-x-0 aria-[orientation=horizontal]:after:-translate-y-1/2 [&[aria-orientation=horizontal]>div]:rotate-90",
+        className
+      )}
+      {...props}
+    >
+      {withHandle && (
+        <div className="z-10 flex h-4 w-3 items-center justify-center rounded-xs border bg-border">
+          <GripVerticalIcon className="size-2.5" />
+        </div>
+      )}
+    </ResizablePrimitive.Separator>
+  )
+}
+
+export { ResizableHandle, ResizablePanel, ResizablePanelGroup }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,6 +204,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
+      react-resizable-panels:
+        specifier: ^4.0.0
+        version: 4.12.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
@@ -3883,6 +3886,12 @@ packages:
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
+
+  react-resizable-panels@4.12.2:
+    resolution: {integrity: sha512-NwY5LCo4WrxVvDh0xoMML6EMLPONP/8ckKcIdpnojxexoatZdjLiRqLJQjQK5CPkd4SYiB/2M5BVrjZBQtOO7Q==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
 
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
@@ -8258,6 +8267,11 @@ snapshots:
   react-is@16.13.1: {}
 
   react-refresh@0.17.0: {}
+
+  react-resizable-panels@4.12.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   react@19.2.4: {}
 


### PR DESCRIPTION
## Summary

Replaces the static two-column grid on the **Create agent** page with a resizable panel layout using the shadcn  component (built on `react-resizable-panels` v4).

## Changes

- **Add  shadcn component** () and the `react-resizable-panels` dependency to `@hermeum/components`.
- **Rewrite the Create agent page layout** (`apps/dashboard/src/client/ui/routes/agents/new.tsx`):
  - **Desktop (lg+):** `ResizablePanelGroup` with two 50% panels (25% min either side) split by a borderless, hover-revealed grip handle. Inner padding keeps content off the divider.
  - **Mobile (<lg):** static stacked layout — config editor on top, chat at the bottom. No resizable handle.
- **Update the empty-chat hero title** to "What should your agent do?".

## Verification

- `pnpm typecheck` ✅
- `pnpm lint` ✅ (only pre-existing warnings, no new issues)

## Screenshots

N/A (model does not support image input) — verified visually per user review during the session.