### PR TITLE
feat(chat): add client-side readAgentConfig tool

### DIFF
--- a/apps/dashboard/src/client/ui/components/agent-config-chat.tsx
+++ b/apps/dashboard/src/client/ui/components/agent-config-chat.tsx
@@ -31,7 +31,10 @@ import { AgentInputObjectSchema } from "@/entities";
 type AgentConfigChatMessage = UIMessage<
   unknown,
   UIDataTypes,
-  { updateAgentConfig: { input: AgentInput; output: string } }
+  {
+    updateAgentConfig: { input: AgentInput; output: string };
+    readAgentConfig: { input: undefined; output: AgentInput | undefined };
+  }
 >;
 
 interface AgentConfigChatProps {
@@ -60,7 +63,17 @@ export function AgentConfigChat({ getConfig, onConfigUpdate, templates }: AgentC
       transport: new DefaultChatTransport({ api: "/chat/agent-config" }),
       sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
       async onToolCall({ toolCall }) {
-        if (toolCall.dynamic || toolCall.toolName !== "updateAgentConfig") return;
+        if (toolCall.dynamic) return;
+        if (toolCall.toolName === "readAgentConfig") {
+          const config = callbacksRef.current.getConfig();
+          addToolOutput({
+            tool: "readAgentConfig",
+            toolCallId: toolCall.toolCallId,
+            output: config,
+          });
+          return;
+        }
+        if (toolCall.toolName !== "updateAgentConfig") return;
         const parsed = AgentInputObjectSchema.safeParse(toolCall.input);
         if (!parsed.success) {
           const issue = parsed.error.issues[0]!;

--- a/apps/dashboard/src/server/usecases/chat.test.ts
+++ b/apps/dashboard/src/server/usecases/chat.test.ts
@@ -105,6 +105,26 @@ describe("ChatUseCase.getAgentConfigContext", () => {
     expect(tools.updateAgentConfig!.execute).toBeUndefined();
   });
 
+  it("exposes a client-side readAgentConfig tool", async () => {
+    const useCase = new ChatUseCase(undefined, makeFiles());
+
+    const { tools } = await useCase.getAgentConfigContext();
+
+    expect(tools.readAgentConfig).toBeDefined();
+    expect(tools.readAgentConfig!.inputSchema).toBeDefined();
+    // No execute: the tool runs on the client, which returns the latest
+    // editor draft and reports it back.
+    expect(tools.readAgentConfig!.execute).toBeUndefined();
+  });
+
+  it("instructs the model to call readAgentConfig when the draft may be stale", async () => {
+    const useCase = new ChatUseCase(undefined, makeFiles());
+
+    const { instructions } = await useCase.getAgentConfigContext();
+
+    expect(instructions).toContain("readAgentConfig");
+  });
+
   it("does not expose a listDocuments tool (the list is embedded in the prompt)", async () => {
     const useCase = new ChatUseCase(undefined, makeFiles());
 

--- a/apps/dashboard/src/server/usecases/chat.ts
+++ b/apps/dashboard/src/server/usecases/chat.ts
@@ -37,6 +37,16 @@ export class ChatUseCase extends HermeumConfigLoadable(BaseUseCase) {
           : "Current agent config draft as JSON:\n\n" + JSON.stringify(currentConfig, null, 2),
       tools: {
         readDocument: this.buildReadDocumentTool(),
+        readAgentConfig: tool({
+          description:
+            "Read the current agent config draft straight from the user's " +
+            "editor. Use this whenever you need to ground a change in the " +
+            "latest draft — the snapshot in the conversation may be stale " +
+            "because the user can hand-edit the config between messages.",
+          inputSchema: z.object({}),
+          // No `execute`: the client returns the latest editor draft and
+          // reports it back.
+        }),
         updateAgentConfig: tool({
           description:
             "Replace the agent config draft with a full updated definition. " +
@@ -167,6 +177,11 @@ Detailed documentation about the config fields is available through the
 Batch every document you need into a single call, and read up on any config
 section you are not fully sure about BEFORE writing it into the draft. Don't
 guess at field semantics that a document can settle.
+
+The draft shown in this conversation may be stale because the user can hand-edit
+the config in their editor between messages. Call \`readAgentConfig\` to fetch
+the latest draft before making any change that depends on the current state of
+fields you haven't just written yourself.
 
 Whenever the draft should change, call the \`updateAgentConfig\` tool with the
 FULL updated definition — keep every field not affected by the change


### PR DESCRIPTION
## Summary

The agent-config chat conversation carried the editor draft as a send-time snapshot, which goes stale when the user hand-edits the config between messages. Add a new client-side `readAgentConfig` tool so the model can fetch the latest draft on demand before making changes that depend on the current state.

## Changes

- `apps/dashboard/src/server/usecases/chat.ts`: expose `readAgentConfig` (no `execute`, client-side) alongside `updateAgentConfig`; extend the system prompt to instruct the model to call it before state-dependent changes.
- `apps/dashboard/src/client/ui/components/agent-config-chat.tsx`: handle `readAgentConfig` in `onToolCall` (returns current `getConfig()` draft via `addToolOutput`); no UI marker — the part renders nothing.
- `apps/dashboard/src/server/usecases/chat.test.ts`: tests covering tool exposure, missing `execute`, and prompt instruction.

## Verification

```
pnpm test --filter @hermeum/dashboard -- src/server/usecases/chat.test.ts
pnpm typecheck --filter @hermeum/dashboard
```
Both pass.