### PR TITLE
feat(chat): surface shared env sets to the agent-config chat

### DIFF
--- a/apps/dashboard/AGENTS.md
+++ b/apps/dashboard/AGENTS.md
@@ -1,0 +1,20 @@
+# AGENTS.md
+
+Notes for agents working in the `@hermeum/dashboard` package.
+
+## Commands
+
+Run from the repo root via pnpm filter, or from this directory directly.
+
+- **Typecheck:** `pnpm --filter @hermeum/dashboard typecheck` (runs `tsc --noEmit`)
+- **Lint:** `pnpm --filter @hermeum/dashboard lint` (runs `eslint .`)
+- **Tests (all):** `pnpm --filter @hermeum/dashboard test` (runs `vitest run`)
+- **Tests (single file):** `pnpm --filter @hermeum/dashboard test -- <path>` (e.g. `... test -- src/server/usecases/chat.test.ts`)
+- **Tests (watch):** `pnpm --filter @hermeum/dashboard test:watch`
+- **Dev server:** `pnpm --filter @hermeum/dashboard dev`
+
+## Conventions
+
+- Use case classes compose mixins from `src/server/usecases/mixin.ts` (`BaseUseCase`, `HermeumConfigLoadable`, `OwnershipGuarded`) over injected `Runtime` (persistence) and `FileAdaptor` (docs) interfaces; concrete adaptors live in `src/server/infras/`. Inject mock adaptors in tests rather than relying on the defaults.
+- Field semantics for the chat agent live in tool input-schema `.describe()` texts (Zod), not in the system prompt — see the header comment on `AGENT_CONFIG_CHAT_SYSTEM_PROMPT` in `src/server/usecases/chat.ts`.
+- New chat tools follow the `readDocument` precedent: embed a lightweight list (names/ids + descriptions) in the system prompt up front via a `build*List()` method, and add a `read*` server-executed tool for fetching richer per-item detail on demand. Keep the prompt lean — batch lists into the prompt, batch detail calls into one tool invocation.

--- a/apps/dashboard/src/server/usecases/chat.test.ts
+++ b/apps/dashboard/src/server/usecases/chat.test.ts
@@ -3,15 +3,50 @@ import type { ToolExecutionOptions } from "ai";
 import { stringify } from "yaml";
 
 vi.mock("../infras/local-files", () => ({ LocalFiles: vi.fn() }));
+vi.mock("../infras/kubernetes/client", () => ({ KubernetesClient: vi.fn() }));
 vi.mock("@/server/libs/config", () => ({
   config: { agentConfigPath: "./agent-config.yaml", docsPath: "./docs/hermes-config" },
 }));
 
 import { ChatUseCase, AGENT_CONFIG_CHAT_SYSTEM_PROMPT } from "./chat";
 import type { File, FileAdaptor } from "./adaptors/file";
-import type { HermeumConfig } from "@/entities";
+import type { Runtime } from "./adaptors/runtime";
+import type { HermeumConfig, SharedEnvSet } from "@/entities";
 
 type Doc = { content: string; data?: Record<string, unknown> };
+
+// Runtime with no shared env sets by default. Individual tests override
+// `listSharedEnvSets` / `getSharedEnvSet` to feed sets to the chat context.
+function makeRuntime(sets: SharedEnvSet[] = []): Runtime {
+  return {
+    listSharedEnvSets: vi.fn().mockResolvedValue(sets),
+    getSharedEnvSet: vi
+      .fn()
+      .mockImplementation(async (id: string) => sets.find((s) => s.id === id) ?? null),
+    listHermesAgents: vi.fn(),
+    getHermesAgent: vi.fn(),
+    createHermesAgent: vi.fn(),
+    patchHermesAgent: vi.fn(),
+    archiveHermesAgent: vi.fn(),
+    getGatewayToken: vi.fn(),
+    createSharedEnvSet: vi.fn(),
+    archiveSharedEnvSet: vi.fn(),
+    patchSharedEnvSet: vi.fn(),
+    addEnvVar: vi.fn(),
+    updateEnvVar: vi.fn(),
+    removeEnvVar: vi.fn(),
+  } as unknown as Runtime;
+}
+
+function makeSharedEnvSet(overrides: Partial<SharedEnvSet> = {}): SharedEnvSet {
+  return {
+    id: "set-1",
+    userId: "user-1",
+    name: "Set One",
+    envVars: [],
+    ...overrides,
+  } as SharedEnvSet;
+}
 
 function makeFiles(
   docs: Record<string, Doc> = {},
@@ -46,21 +81,35 @@ function makeFiles(
 
 const callOptions = {} as ToolExecutionOptions<never>;
 
+// Expected empty-list footer appended to the instructions when there are no
+// shared env sets (matches buildSharedEnvSetList's header-only emission).
+const EMPTY_SHARED_ENV_SET_BLOCK =
+  "Available shared env sets (attach via the `sharedEnvSets` field with " +
+  "these ids; read env var names with `readSharedEnvSet` before attaching " +
+  "to avoid collisions with the agent's own `env`):\n";
+
 describe("ChatUseCase.getAgentConfigContext", () => {
   it("uses the base system prompt when no agent types are configured", async () => {
-    const useCase = new ChatUseCase(undefined, makeFiles({}, undefined));
+    const useCase = new ChatUseCase(makeRuntime(), makeFiles({}, undefined));
 
     const { instructions } = await useCase.getAgentConfigContext();
 
-    // The base prompt is always followed by the available-documents block,
-    // even when there are no docs and no agent types.
+    // The base prompt is always followed by the available-documents block and
+    // the available-shared-env-sets block, even when there are no docs, no
+    // sets, and no agent types.
     expect(instructions).toContain(AGENT_CONFIG_CHAT_SYSTEM_PROMPT);
-    expect(instructions).toBe(AGENT_CONFIG_CHAT_SYSTEM_PROMPT + "\n\n" + "Available documents (read with `readDocument` before writing any config section you're not fully sure about):\n");
+    expect(instructions).toBe(
+      AGENT_CONFIG_CHAT_SYSTEM_PROMPT +
+        "\n\n" +
+        "Available documents (read with `readDocument` before writing any config section you're not fully sure about):\n" +
+        "\n\n" +
+        EMPTY_SHARED_ENV_SET_BLOCK
+    );
   });
 
   it("appends the configured agent types to the instructions", async () => {
     const useCase = new ChatUseCase(
-      undefined,
+      makeRuntime(),
       makeFiles(
         {},
         {
@@ -78,7 +127,7 @@ describe("ChatUseCase.getAgentConfigContext", () => {
   });
 
   it("notes the missing draft when no current config is given", async () => {
-    const useCase = new ChatUseCase(undefined, makeFiles());
+    const useCase = new ChatUseCase(makeRuntime(), makeFiles());
 
     const { prompt } = await useCase.getAgentConfigContext();
 
@@ -86,7 +135,7 @@ describe("ChatUseCase.getAgentConfigContext", () => {
   });
 
   it("embeds the current config as JSON in the prompt", async () => {
-    const useCase = new ChatUseCase(undefined, makeFiles());
+    const useCase = new ChatUseCase(makeRuntime(), makeFiles());
 
     const { prompt } = await useCase.getAgentConfigContext({ name: "pr-reviewer" });
 
@@ -94,7 +143,7 @@ describe("ChatUseCase.getAgentConfigContext", () => {
   });
 
   it("exposes a client-side updateAgentConfig tool", async () => {
-    const useCase = new ChatUseCase(undefined, makeFiles());
+    const useCase = new ChatUseCase(makeRuntime(), makeFiles());
 
     const { tools } = await useCase.getAgentConfigContext();
 
@@ -106,7 +155,7 @@ describe("ChatUseCase.getAgentConfigContext", () => {
   });
 
   it("exposes a client-side readAgentConfig tool", async () => {
-    const useCase = new ChatUseCase(undefined, makeFiles());
+    const useCase = new ChatUseCase(makeRuntime(), makeFiles());
 
     const { tools } = await useCase.getAgentConfigContext();
 
@@ -118,7 +167,7 @@ describe("ChatUseCase.getAgentConfigContext", () => {
   });
 
   it("instructs the model to call readAgentConfig when the draft may be stale", async () => {
-    const useCase = new ChatUseCase(undefined, makeFiles());
+    const useCase = new ChatUseCase(makeRuntime(), makeFiles());
 
     const { instructions } = await useCase.getAgentConfigContext();
 
@@ -126,7 +175,7 @@ describe("ChatUseCase.getAgentConfigContext", () => {
   });
 
   it("does not expose a listDocuments tool (the list is embedded in the prompt)", async () => {
-    const useCase = new ChatUseCase(undefined, makeFiles());
+    const useCase = new ChatUseCase(makeRuntime(), makeFiles());
 
     const { tools } = await useCase.getAgentConfigContext();
 
@@ -136,7 +185,7 @@ describe("ChatUseCase.getAgentConfigContext", () => {
 
   it("embeds the available documents in the instructions with frontmatter descriptions", async () => {
     const useCase = new ChatUseCase(
-      undefined,
+      makeRuntime(),
       makeFiles({
         model: { content: "# Model", data: { description: "Model configuration" } },
         webhook: { content: "# Webhook" },
@@ -152,7 +201,7 @@ describe("ChatUseCase.getAgentConfigContext", () => {
 
   it("groups documents by category alphabetically, then uncategorized last", async () => {
     const useCase = new ChatUseCase(
-      undefined,
+      makeRuntime(),
       makeFiles({
         // core
         model: { content: "# Model", data: { category: "core", description: "Model configuration" } },
@@ -192,7 +241,7 @@ describe("ChatUseCase.getAgentConfigContext", () => {
 
   it("reads multiple documents in one call", async () => {
     const useCase = new ChatUseCase(
-      undefined,
+      makeRuntime(),
       makeFiles({
         model: { content: "# Model doc" },
         webhook: { content: "# Webhook doc" },
@@ -211,7 +260,7 @@ describe("ChatUseCase.getAgentConfigContext", () => {
   });
 
   it("returns a per-entry error for unknown names without failing the batch", async () => {
-    const useCase = new ChatUseCase(undefined, makeFiles({ model: { content: "# Model doc" } }));
+    const useCase = new ChatUseCase(makeRuntime(), makeFiles({ model: { content: "# Model doc" } }));
 
     const { tools } = await useCase.getAgentConfigContext();
     const result = await tools.readDocument!.execute!({ names: ["model", "nope"] }, callOptions);
@@ -226,7 +275,7 @@ describe("ChatUseCase.getAgentConfigContext", () => {
 
   it("rejects path-traversal document names without touching the adaptor", async () => {
     const files = makeFiles({ model: { content: "# Model doc" } });
-    const useCase = new ChatUseCase(undefined, files);
+    const useCase = new ChatUseCase(makeRuntime(), files);
 
     const { tools } = await useCase.getAgentConfigContext();
     vi.mocked(files.readFile).mockClear();
@@ -243,5 +292,114 @@ describe("ChatUseCase.getAgentConfigContext", () => {
       ],
     });
     expect(files.readFile).not.toHaveBeenCalled();
+  });
+
+  it("emits only the shared-env-sets header when none exist", async () => {
+    const useCase = new ChatUseCase(makeRuntime(), makeFiles());
+
+    const { instructions } = await useCase.getAgentConfigContext();
+
+    expect(instructions).toContain(EMPTY_SHARED_ENV_SET_BLOCK);
+    expect(instructions).not.toContain("- set-1");
+  });
+
+  it("embeds the available shared env sets in the instructions by id", async () => {
+    const runtime = makeRuntime([
+      makeSharedEnvSet({
+        id: "db-creds",
+        name: "Database Credentials",
+        description: "Postgres connection vars",
+        envVars: [{ name: "DATABASE_URL" }, { name: "DB_PASSWORD" }],
+      }),
+      makeSharedEnvSet({ id: "api-keys", name: "API Keys", envVars: [] }),
+    ]);
+    const useCase = new ChatUseCase(runtime, makeFiles());
+
+    const { instructions } = await useCase.getAgentConfigContext();
+
+    // Lines lead with the id (the draft's `sharedEnvSets` field wants ids),
+    // carry the human name, and append the description when present.
+    expect(instructions).toContain("- db-creds: Database Credentials — Postgres connection vars");
+    expect(instructions).toContain("- api-keys: API Keys");
+    // The db-creds ordering must come before api-keys (runtime returns them
+    // in the given order, which is preserved).
+    expect(instructions.indexOf("db-creds")).toBeLessThan(instructions.indexOf("api-keys"));
+  });
+
+  it("filters out archived shared env sets before listing them", async () => {
+    const runtime = makeRuntime([
+      makeSharedEnvSet({ id: "live", name: "Live" }),
+      makeSharedEnvSet({ id: "gone", name: "Gone", archived: true }),
+    ]);
+    const useCase = new ChatUseCase(runtime, makeFiles());
+
+    const { instructions } = await useCase.getAgentConfigContext();
+
+    expect(instructions).toContain("- live: Live");
+    expect(instructions).not.toContain("- gone");
+    // listSharedEnvSets is asked for non-archived sets only.
+    expect(runtime.listSharedEnvSets).toHaveBeenCalledWith({ archived: false });
+  });
+
+  it("exposes a server-side readSharedEnvSet tool that returns env var names", async () => {
+    const runtime = makeRuntime([
+      makeSharedEnvSet({
+        id: "db-creds",
+        name: "Database Credentials",
+        envVars: [{ name: "DATABASE_URL" }, { name: "DB_PASSWORD" }],
+      }),
+    ]);
+    const useCase = new ChatUseCase(runtime, makeFiles());
+
+    const { tools } = await useCase.getAgentConfigContext();
+    expect(tools.readSharedEnvSet).toBeDefined();
+    expect(tools.readSharedEnvSet?.execute).toBeDefined();
+
+    const result = await tools.readSharedEnvSet!.execute!({ ids: ["db-creds"] }, callOptions);
+
+    // Values are never surfaced — only env var names.
+    expect(result).toEqual({
+      sharedEnvSets: [{ id: "db-creds", envVars: [{ name: "DATABASE_URL" }, { name: "DB_PASSWORD" }] }],
+    });
+  });
+
+  it("reads multiple shared env sets in one call", async () => {
+    const runtime = makeRuntime([
+      makeSharedEnvSet({ id: "db-creds", name: "DB", envVars: [{ name: "DATABASE_URL" }] }),
+      makeSharedEnvSet({ id: "api-keys", name: "API", envVars: [{ name: "OPENAI_API_KEY" }] }),
+    ]);
+    const useCase = new ChatUseCase(runtime, makeFiles());
+
+    const { tools } = await useCase.getAgentConfigContext();
+    const result = await tools.readSharedEnvSet!.execute!({ ids: ["db-creds", "api-keys"] }, callOptions);
+
+    expect(result).toEqual({
+      sharedEnvSets: [
+        { id: "db-creds", envVars: [{ name: "DATABASE_URL" }] },
+        { id: "api-keys", envVars: [{ name: "OPENAI_API_KEY" }] },
+      ],
+    });
+  });
+
+  it("returns a per-entry error for unknown or archived shared env set ids", async () => {
+    const runtime = makeRuntime([
+      makeSharedEnvSet({ id: "db-creds", name: "DB", envVars: [{ name: "DATABASE_URL" }] }),
+      makeSharedEnvSet({ id: "archived-set", name: "Old", archived: true, envVars: [] }),
+    ]);
+    const useCase = new ChatUseCase(runtime, makeFiles());
+
+    const { tools } = await useCase.getAgentConfigContext();
+    const result = await tools.readSharedEnvSet!.execute!(
+      { ids: ["db-creds", "nope", "archived-set"] },
+      callOptions
+    );
+
+    expect(result).toEqual({
+      sharedEnvSets: [
+        { id: "db-creds", envVars: [{ name: "DATABASE_URL" }] },
+        { id: "nope", error: expect.stringContaining('"nope" not found') },
+        { id: "archived-set", error: expect.stringContaining('"archived-set" not found') },
+      ],
+    });
   });
 });

--- a/apps/dashboard/src/server/usecases/chat.ts
+++ b/apps/dashboard/src/server/usecases/chat.ts
@@ -37,6 +37,7 @@ export class ChatUseCase extends HermeumConfigLoadable(BaseUseCase) {
           : "Current agent config draft as JSON:\n\n" + JSON.stringify(currentConfig, null, 2),
       tools: {
         readDocument: this.buildReadDocumentTool(),
+        readSharedEnvSet: this.buildReadSharedEnvSetTool(),
         readAgentConfig: tool({
           description:
             "Read the current agent config draft straight from the user's " +
@@ -91,13 +92,47 @@ export class ChatUseCase extends HermeumConfigLoadable(BaseUseCase) {
     });
   }
 
+  // Server-executed tool that lets the model inspect the env var names inside
+  // one or more shared env sets (ids are listed in the system prompt). The
+  // values are never surfaced — shared env sets only carry env var names; the
+  // values live in Kubernetes Secrets the agent loads via `envFrom`. Batch
+  // every id you need into a single call to minimize round-trips.
+  private buildReadSharedEnvSetTool(): ToolSet[string] {
+    return tool({
+      description:
+        "Read the env var names inside one or more shared env sets by id " +
+        "(ids are listed in the system prompt). Use this before attaching a " +
+        "set to avoid name collisions with the agent's own `env`, or to " +
+        "confirm a needed var is present. Pass every id you need in a single " +
+        "call to minimize round-trips.",
+      inputSchema: z.object({
+        ids: z.array(z.string()).min(1).describe("Shared env set ids listed in the system prompt."),
+      }),
+      execute: async ({ ids }) => ({
+        sharedEnvSets: await Promise.all(
+          ids.map(async (id) => {
+            const set = await this.runtime.getSharedEnvSet(id);
+            if (set === null || set.archived) {
+              return {
+                id,
+                error: `Shared env set "${id}" not found. Use the ids listed in the system prompt.`,
+              };
+            }
+            return { id, envVars: set.envVars.map(({ name }) => ({ name })) };
+          })
+        ),
+      }),
+    });
+  }
+
   private async buildInstructions(): Promise<string> {
-    const [docList, { agentTypes }] = await Promise.all([
+    const [docList, sharedEnvSetList, { agentTypes }] = await Promise.all([
       this.buildDocumentList(),
+      this.buildSharedEnvSetList(),
       this.loadHermeumConfig(),
     ]);
 
-    let instructions = AGENT_CONFIG_CHAT_SYSTEM_PROMPT + "\n\n" + docList;
+    let instructions = AGENT_CONFIG_CHAT_SYSTEM_PROMPT + "\n\n" + docList + "\n\n" + sharedEnvSetList;
 
     if (agentTypes) {
       const lines = Object.entries(agentTypes).map(
@@ -162,6 +197,31 @@ export class ChatUseCase extends HermeumConfigLoadable(BaseUseCase) {
       "config section you're not fully sure about):\n" +
       blocks.join("\n\n");
   }
+
+  // Build the "Available shared env sets:" block listing every non-archived
+  // shared env set the model can attach via the `sharedEnvSets` field. The id
+  // (not the human name) is what the draft's `sharedEnvSets` array expects, so
+  // each line leads with the id. Embedded up front so the model can attach a
+  // set without first calling a list tool; env var names inside a set are
+  // fetched on demand via `readSharedEnvSet` to keep the prompt lean. When no
+  // sets exist, only the header is emitted.
+  private async buildSharedEnvSetList(): Promise<string> {
+    const sets = (await this.runtime.listSharedEnvSets({ archived: false })).filter(
+      (set) => !set.archived
+    );
+    const header =
+      "Available shared env sets (attach via the `sharedEnvSets` field with " +
+      "these ids; read env var names with `readSharedEnvSet` before attaching " +
+      "to avoid collisions with the agent's own `env`):";
+    if (sets.length === 0) {
+      return header + "\n";
+    }
+    const lines = sets.map((set) => {
+      const tail = set.description ? ` — ${set.description}` : "";
+      return `- ${set.id}: ${set.name}${tail}`;
+    });
+    return header + "\n" + lines.join("\n");
+  }
 }
 
 // Field semantics live in the tool input schema's .describe() texts; this
@@ -177,6 +237,12 @@ Detailed documentation about the config fields is available through the
 Batch every document you need into a single call, and read up on any config
 section you are not fully sure about BEFORE writing it into the draft. Don't
 guess at field semantics that a document can settle.
+
+The available shared env sets are listed below by id. To attach one, add its
+id to the draft's \`sharedEnvSets\` array. If you need to see the env var names
+inside a set (e.g. to avoid collisions with the agent's own \`env\` or to
+confirm a needed var is present), call \`readSharedEnvSet\` with the ids
+first. Don't attach a set blindly when its contents matter.
 
 The draft shown in this conversation may be stale because the user can hand-edit
 the config in their editor between messages. Call \`readAgentConfig\` to fetch


### PR DESCRIPTION
## Summary

Lets the agent-config chat agent attach shared env sets to a draft agent by making it aware of them, following the existing `readDocument` precedent exactly: a lightweight list embedded in the system prompt + a server-executed tool for richer per-item detail.

## Changes

**`apps/dashboard/src/server/usecases/chat.ts`**
- `buildSharedEnvSetList()` — fetches non-archived sets via `runtime.listSharedEnvSets({ archived: false })` and embeds `- {id}: {name}{ — description}` lines in the system prompt. The id leads (not the human name) because the draft's `sharedEnvSets` field takes ids. Header-only emission when no sets exist.
- `readSharedEnvSet` tool — server-executed, mirrors `readDocument`: takes `{ ids }`, returns each set's env var **names** (never values — shared sets only carry names; values live in K8s Secrets loaded via `envFrom`). Per-entry error for unknown or archived ids; batchable in one call.
- `buildInstructions()` parallel-fetches the env-set list alongside docs + config.
- `AGENT_CONFIG_CHAT_SYSTEM_PROMPT` gains a clause directing the model to attach via `sharedEnvSets` and to call `readSharedEnvSet` when contents matter.

**`apps/dashboard/src/server/usecases/chat.test.ts`**
- Added `makeRuntime` / `makeSharedEnvSet` helpers (a mock `Runtime` is now required since `buildInstructions` calls `runtime.listSharedEnvSets`).
- Updated existing `ChatUseCase` instantiations to inject the mock runtime.
- Fixed the exact-string assertion to account for the appended shared-env-sets block.
- 6 new tests: empty-list header-only emission, embedding by id with description, archived filtering, tool happy path, batched multi-id reads, unknown/archived per-entry errors.

**`apps/dashboard/AGENTS.md`** (new) — records the verified `typecheck` / `lint` / `test` commands.

## Why both prompt-list and tool?

- **Prompt list (Option 1)** — to *attach* a set, the model only needs id+name+description; that's lightweight and static, so it mirrors `buildDocumentList`. No round-trip needed to learn what sets exist.
- **`readSharedEnvSet` tool (Option 2 complement)** — to *reason about* the env vars inside a set (avoid collisions with the agent's own `env`, confirm a needed var is present), the model fetches per-set env var names on demand, mirroring `readDocument`.

The attach target (`AgentInputObjectSchema.sharedEnvSets`) and validation (`checkAgentInputAllowed`) already existed end-to-end, so this is purely an LLM-awareness change — no data-model or plumbing work.

## Verification

- `pnpm --filter @hermeum/dashboard typecheck` ✓
- `pnpm --filter @hermeum/dashboard lint` ✓ (0 new issues)
- `pnpm --filter @hermeum/dashboard test` ✓ — 205/205 passing (19 in `chat.test.ts`)

## Manual check

In the new-agent chat, ask the model to attach a shared env set → it should emit the id into the `sharedEnvSets` array; when asked about collisions it should call `readSharedEnvSet` first.