### PR TITLE
feat(config): add x_search configuration and docs

### DIFF
--- a/apps/dashboard/docs/hermes-config/x-search.md
+++ b/apps/dashboard/docs/hermes-config/x-search.md
@@ -1,0 +1,58 @@
+---
+name: x-search
+category: tools
+description: X (Twitter) search configuration (`config.x_search`) — xAI Responses-backed tool, model/timeout/retries, and XAI_API_KEY env var.
+---
+
+# X (Twitter) Search configuration (`config.x_search`)
+
+Configures the `x_search` tool, which lets the agent search X (Twitter)
+posts, profiles, and threads. It is backed by xAI's built-in `x_search`
+tool on the Responses API (`https://api.x.ai/v1/responses`) — Grok
+runs the search server-side and returns a synthesized answer with
+citations to the originating posts.
+
+**Use `x_search` instead of `web_search`** when you specifically want
+current discussion, reactions, or claims **on X**. For general web
+pages, keep `web_search` / `web_extract`.
+
+**Credential path:** only the `XAI_API_KEY` path is supported here.
+SuperGrok / X Premium+ OAuth (`hermes auth add xai-oauth`) is **not**
+wired up in this dashboard yet — set `XAI_API_KEY` instead.
+
+The tool auto-enables when `XAI_API_KEY` is present and the `x_search`
+toolset is on. Disable explicitly via `hermes tools` → Search →
+`x_search` if you don't want it.
+
+## Fields
+
+- `model` — xAI model id used for the Responses call. Default
+  `grok-4.20-reasoning`; any Grok model with `x_search` tool access
+  works. If the configured model lacks access, the call fails with
+  "`x_search` is not enabled for this model".
+- `timeout_seconds` — request timeout in seconds (minimum `30`,
+  default `180`). `x_search` can take 60–120s for complex queries, so
+  the default is generous.
+- `retries` — number of automatic retries on `5xx` / `ReadTimeout` /
+  `ConnectionError` (default `2`). Each retry backs off at `1.5 ×
+  attempt` seconds, capped at `5s`.
+
+## Environment variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `XAI_API_KEY` | Paid xAI API key — the only supported credential path in this dashboard (set in `~/.hermes/.env`). OAuth (SuperGrok / X Premium+) is not wired up here. Without it the `x_search` tool does not register. | _(required)_ |
+
+## Example
+
+```yaml
+config:
+  x_search:
+    model: grok-4.20-reasoning
+    timeout_seconds: 180
+    retries: 2
+env:
+  - name: XAI_API_KEY
+    value: xai-your-key-here
+    sensitive: true
+```

--- a/apps/dashboard/src/entities/hermes-config/index.ts
+++ b/apps/dashboard/src/entities/hermes-config/index.ts
@@ -30,6 +30,7 @@ export {
   type Web,
 } from "./web";
 export { BrowserCloudProviderSchema, BrowserSchema, type BrowserCloudProvider, type Browser } from "./browser";
+export { XSearchSchema, type XSearch } from "./x-search";
 
 import { z } from "zod";
 import { ModelSchema } from "./model";
@@ -37,6 +38,7 @@ import { PlatformsSchema } from "./webhook";
 import { SlackSchema } from "./slack";
 import { WebSchema } from "./web";
 import { BrowserSchema } from "./browser";
+import { XSearchSchema } from "./x-search";
 
 export const ConfigSchema = z
   .looseObject({
@@ -45,6 +47,7 @@ export const ConfigSchema = z
     slack: SlackSchema,
     web: WebSchema,
     browser: BrowserSchema,
+    x_search: XSearchSchema,
   })
   .optional()
   .describe(

--- a/apps/dashboard/src/entities/hermes-config/x-search.ts
+++ b/apps/dashboard/src/entities/hermes-config/x-search.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+
+// https://hermes-agent.nousresearch.com/docs/user-guide/features/x-search
+// Full field semantics: docs/hermes-config/x-search.md
+// NOTE: only the XAI_API_KEY credential path is supported here
+export const XSearchSchema = z
+  .looseObject({
+    model: z
+      .string()
+      .min(1)
+      .optional()
+      .describe("xAI model id for the Responses call (default grok-4.20-reasoning)."),
+    timeout_seconds: z
+      .number()
+      .int()
+      .min(30)
+      .optional()
+      .describe("Request timeout in seconds (minimum 30, default 180)."),
+    retries: z
+      .number()
+      .int()
+      .min(0)
+      .optional()
+      .describe("Auto-retries on 5xx / ReadTimeout / ConnectionError (default 2)."),
+  })
+  .optional()
+  .describe("X (Twitter) Search configuration. Requires XAI_API_KEY.");
+
+export type XSearch = z.infer<typeof XSearchSchema>;


### PR DESCRIPTION
Adds support for the `x_search` tool to the dashboard's Hermes config layer.

## Changes

- **`apps/dashboard/src/entities/hermes-config/x-search.ts`** — new Zod schema module exporting `XSearchSchema` / `XSearch` with `model`, `timeout_seconds` (min 30), and `retries` fields, all optional under a `looseObject`. Sourced from the hermes submodule (`vendor/hermes-agent/hermes_cli/config.py` + `tools/x_search_tool.py`).
- **`apps/dashboard/src/entities/hermes-config/index.ts`** — wired `x_search: XSearchSchema` into `ConfigSchema` alongside `model`, `web`, `browser`, etc.
- **`apps/dashboard/docs/hermes-config/x-search.md`** — new doc (frontmatter `name: x-search` / `category: tools`) auto-surfaced to the chat LLM via `buildDocumentList()` in `chat.ts`. Covers fields, the `XAI_API_KEY` env var, and an example.

## Notes

Only the `XAI_API_KEY` credential path is supported; SuperGrok / X Premium+ OAuth (`xai-oauth`) is not wired up in this dashboard yet. The doc marks `XAI_API_KEY` as `_(required)_` in the env-var table.

## Verification

- `pnpm --filter @hermeum/dashboard typecheck` — clean
- `pnpm --filter @hermeum/dashboard lint` — clean (only 2 pre-existing unrelated warnings)
- `pnpm --filter @hermeum/dashboard test` — 205/205 passing