### PR TITLE
feat(agents): add Tools section to agent detail page

### DIFF
--- a/apps/dashboard/src/client/ui/routes/agents/$id.tsx
+++ b/apps/dashboard/src/client/ui/routes/agents/$id.tsx
@@ -7,8 +7,17 @@ import { toast } from "sonner";
 
 import { Badge } from "@hermeum/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@hermeum/components/ui/tabs";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@hermeum/components/ui/tooltip";
 import { authClient } from "@/client/auth-client";
 import { useTRPC } from "@/router";
+import {
+  TOOL_IDS,
+  deriveToolAvailability,
+  getToolDescription,
+  getToolLabel,
+  type Agent,
+  type ToolId,
+} from "@/entities";
 import { PhaseBadge } from "@/client/ui/components/phase-badge";
 import { Button } from "@hermeum/components/ui/button";
 import { EditInstanceDialog } from "@/client/ui/components/edit-agent-dialog";
@@ -59,6 +68,54 @@ function ButtonList({ items, max = BADGE_MAX }: { items: string[]; max?: number 
         </Button>
       ))}
       {overflow > 0 && <span className="text-xs text-muted-foreground">+{overflow} more</span>}
+    </div>
+  );
+}
+
+function ToolBadge({ id, agent }: { id: ToolId; agent: Agent }) {
+  const { status, reason } = deriveToolAvailability(id, agent);
+  const label = getToolLabel(id);
+  const description = getToolDescription(id);
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <Button
+            variant="outline"
+            size="sm"
+            className={`h-auto px-2 py-1 font-mono text-xs ${
+              status === "unavailable" ? "text-muted-foreground opacity-60" : ""
+            }`}
+          />
+        }
+      >
+        {label}
+      </TooltipTrigger>
+      <TooltipContent>
+        <div className="flex flex-col gap-0.5">
+          <span>{description}</span>
+          {reason && (
+            <span className="capitalize opacity-80">
+              {status} — {reason}
+            </span>
+          )}
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+function ToolsSection({ agent }: { agent: Agent }) {
+  return (
+    <div className="py-8 flex flex-col gap-3">
+      <p className="text-sm font-bold">Tools</p>
+      <TooltipProvider>
+        <div className="flex flex-wrap gap-2">
+          {TOOL_IDS.map((id) => (
+            <ToolBadge key={id} id={id} agent={agent} />
+          ))}
+        </div>
+      </TooltipProvider>
     </div>
   );
 }
@@ -238,6 +295,9 @@ function AgentDetailPage() {
                 <ButtonList items={agent.plugins} max={10} />
               </div>
             )}
+
+            {/* tools */}
+            <ToolsSection agent={agent} />
 
             {/* packages */}
             {agent.packages?.pip && agent.packages.pip.length > 0 && (

--- a/apps/dashboard/src/entities/agent.test.ts
+++ b/apps/dashboard/src/entities/agent.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { z } from "zod";
 
-import { AgentInputObjectSchema, AgentInputSchema, SkillSchema, isApiServerEnabled, getApiServerPort, isWebhookEnabled, getWebhookPort } from "./agent";
+import { AgentInputObjectSchema, AgentInputSchema, SkillSchema, isApiServerEnabled, getApiServerPort, isWebhookEnabled, getWebhookPort, ToolId, deriveToolAvailability, type Agent } from "./agent";
 
 function makeInput(overrides: Record<string, unknown> = {}) {
   return {
@@ -600,5 +600,58 @@ describe("AgentInputSchema browser config validation", () => {
       config: { browser: { cloud_provider: "playwright" } },
     });
     expect(result.success).toBe(false);
+  });
+});
+
+describe("deriveToolAvailability", () => {
+  function makeAgent(overrides: Partial<Agent> = {}): Agent {
+    return { id: "a1", userId: "u1", ...overrides } as Agent;
+  }
+
+  it("marks core tools available with no config", () => {
+    const agent = makeAgent();
+    for (const id of [ToolId.Terminal, ToolId.File, ToolId.Memory, ToolId.Cron, ToolId.Mcp]) {
+      expect(deriveToolAvailability(id, agent).status).toBe("available");
+    }
+  });
+
+  it("marks web unavailable without a backend and available with one", () => {
+    expect(deriveToolAvailability(ToolId.Web, makeAgent()).status).toBe("unavailable");
+    expect(
+      deriveToolAvailability(ToolId.Web, makeAgent({ config: { web: { backend: "searxng" } } }))
+        .status
+    ).toBe("available");
+    expect(
+      deriveToolAvailability(
+        ToolId.Web,
+        makeAgent({ config: { web: { search_backend: "tavily" } } })
+      ).status
+    ).toBe("available");
+  });
+
+  it("marks x search unavailable by default and available with XAI_API_KEY or xai backend", () => {
+    expect(deriveToolAvailability(ToolId.XSearch, makeAgent()).status).toBe("unavailable");
+    expect(
+      deriveToolAvailability(
+        ToolId.XSearch,
+        makeAgent({ env: [{ name: "XAI_API_KEY", value: "xai-123", sensitive: true }] })
+      ).status
+    ).toBe("available");
+    expect(
+      deriveToolAvailability(
+        ToolId.XSearch,
+        makeAgent({ config: { web: { search_backend: "xai" } } })
+      ).status
+    ).toBe("available");
+  });
+
+  it("marks browser unavailable without a provider and available with one", () => {
+    expect(deriveToolAvailability(ToolId.Browser, makeAgent()).status).toBe("unavailable");
+    expect(
+      deriveToolAvailability(
+        ToolId.Browser,
+        makeAgent({ config: { browser: { cloud_provider: "camofox" } } })
+      ).status
+    ).toBe("available");
   });
 });

--- a/apps/dashboard/src/entities/agent.ts
+++ b/apps/dashboard/src/entities/agent.ts
@@ -563,3 +563,129 @@ export const AgentSchema = AgentInputObjectSchema.extend({
 }).readonly();
 
 export type Agent = z.infer<typeof AgentSchema>;
+
+// Tool availability — a derived, read-only view of which Hermes tools are
+// usable for an agent, computed from its config + env. Not persisted.
+// https://hermes-agent.nousresearch.com/docs/user-guide/features/tools
+
+export enum ToolId {
+  Web = "web",
+  XSearch = "x-search",
+  Terminal = "terminal",
+  File = "file",
+  Browser = "browser",
+  Memory = "memory",
+  Cron = "cron",
+  Mcp = "mcp",
+  // Media = "media", // TBD — media toolset shape not finalized yet.
+}
+
+export type ToolStatus = "available" | "unavailable";
+
+export interface ToolAvailability {
+  status: ToolStatus;
+  /** Short explanation shown when status is not "available". */
+  reason?: string;
+}
+
+interface ToolMeta {
+  label: string;
+  description: string;
+}
+
+const TOOL_META: Record<ToolId, ToolMeta> = {
+  [ToolId.Web]: {
+    label: "Web",
+    description: "Search the web and extract page content.",
+  },
+  [ToolId.XSearch]: {
+    label: "X Search",
+    description: "Search X (Twitter) posts via xAI.",
+  },
+  [ToolId.Terminal]: {
+    label: "Terminal",
+    description: "Execute shell commands.",
+  },
+  [ToolId.File]: {
+    label: "File",
+    description: "Read, edit, and search files.",
+  },
+  [ToolId.Browser]: {
+    label: "Browser",
+    description: "Interactive browser automation.",
+  },
+  [ToolId.Memory]: {
+    label: "Memory",
+    description: "Persistent memory and recall.",
+  },
+  [ToolId.Cron]: {
+    label: "Cron",
+    description: "Scheduled tasks.",
+  },
+  [ToolId.Mcp]: {
+    label: "MCP",
+    description: "MCP server integrations.",
+  },
+};
+
+export function getToolLabel(id: ToolId): string {
+  return TOOL_META[id].label;
+}
+
+export function getToolDescription(id: ToolId): string {
+  return TOOL_META[id].description;
+}
+
+/** Ordered tool list for UI rendering. */
+export const TOOL_IDS: readonly ToolId[] = [
+  ToolId.Web,
+  ToolId.XSearch,
+  ToolId.Terminal,
+  ToolId.File,
+  ToolId.Browser,
+  ToolId.Memory,
+  ToolId.Cron,
+  ToolId.Mcp,
+];
+
+export function deriveToolAvailability(id: ToolId, agent: Agent): ToolAvailability {
+  const config = agent.config;
+  const env = agent.env ?? [];
+
+  switch (id) {
+    case ToolId.Web: {
+      const hasBackend = !!(
+        config?.web?.backend ??
+        config?.web?.search_backend ??
+        config?.web?.extract_backend
+      );
+      return hasBackend
+        ? { status: "available" }
+        : { status: "unavailable", reason: "No web backend configured." };
+    }
+    case ToolId.XSearch: {
+      // Gated on xAI credentials; off by default.
+      const hasXaiKey = env.some((v) => v.name === "XAI_API_KEY" && v.value.trim() !== "");
+      const xaiBackend = config?.web?.search_backend === "xai";
+      return hasXaiKey || xaiBackend
+        ? { status: "available" }
+        : {
+            status: "unavailable",
+            reason: "Set XAI_API_KEY to opt in.",
+          };
+    }
+    case ToolId.Browser: {
+      return config?.browser?.cloud_provider
+        ? { status: "available" }
+        : { status: "unavailable", reason: "No browser provider configured." };
+    }
+    case ToolId.Terminal:
+    case ToolId.File:
+    case ToolId.Memory:
+    case ToolId.Cron:
+    case ToolId.Mcp:
+      // Core capabilities with no config gate. MCP servers themselves are
+      // opt-in via the catalog, which the dashboard cannot introspect.
+      return { status: "available" };
+  }
+}


### PR DESCRIPTION
## Summary

Add a read-only **Tools** section to the agent detail page that shows which tools are available/unavailable for an agent, derived from its config + env.

Each tool renders as an outline-button pill (matching the existing Skills/Plugins/Packages sections) with a tooltip showing the description and status/reason. Unavailable tools render dimmed.

### Tools

| Tool | Gating |
|------|--------|
| Web | needs a web backend in config |
| X Search | needs `XAI_API_KEY` env or `web.search_backend: xai` (off by default) |
| Browser | needs a browser `cloud_provider` in config |
| Terminal / File / Memory / Cron / MCP | available by default |

> `media` is omitted as TBD per request.

### Implementation

- Derivation logic lives in `apps/dashboard/src/entities/agent.ts` (colocated with the other agent-domain helpers like `isWebhookEnabled`):
  - `ToolId` enum
  - `TOOL_META` table with `getToolLabel` / `getToolDescription` accessors
  - `deriveToolAvailability(id, agent)` — pure function, reads `agent.config` + `agent.env`
  - Ordered `TOOL_IDS` list for rendering
- UI in `apps/dashboard/src/client/ui/routes/agents/$id.tsx`: `ToolBadge` + `ToolsSection` components, placed in the Agent tab after Plugins.

### Why no `toolset` / disabled-state

Toolset-key matching against Hermes' `agent.disabled_toolsets` was considered and removed to keep the dashboard's tool model independent of Hermes' internal toolset names (which don't map 1:1 — e.g. `cron` ↔ `cronjob`, `x-search` ↔ `x_search`). Availability is purely available/unavailable based on config/env gating.

### Verification

- `pnpm --filter @hermeum/dashboard typecheck` ✅
- `pnpm --filter @hermeum/dashboard lint` ✅ (no new warnings)
- `pnpm --filter @hermeum/dashboard test -- src/entities/agent.test.ts` ✅ (120 tests pass, incl. new `deriveToolAvailability` tests)