### PR TITLE
feat(chat): show transient readConfig indicator in agent-config chat

### DIFF
--- a/apps/dashboard/src/client/ui/components/agent-config-chat.tsx
+++ b/apps/dashboard/src/client/ui/components/agent-config-chat.tsx
@@ -171,6 +171,19 @@ export function AgentConfigChat({ getConfig, onConfigUpdate, templates }: AgentC
                               </Bubble>
                             );
                           }
+                          if (part.type === "tool-readAgentConfig") {
+                            if (part.state === "input-streaming" || part.state === "input-available") {
+                              return (
+                                <Marker key={index}>
+                                  <MarkerIcon>
+                                    <LoaderCircle className="animate-spin" />
+                                  </MarkerIcon>
+                                  <MarkerContent>Reading config…</MarkerContent>
+                                </Marker>
+                              );
+                            }
+                            return null;
+                          }
                           if (part.type === "tool-updateAgentConfig") {
                             return (
                               <Marker key={index}>


### PR DESCRIPTION
Render a spinner marker while the `readAgentConfig` tool is running (input-streaming/input-available states). The marker disappears once the tool completes, leaving no permanent trace — unlike `updateAgentConfig`, which keeps a permanent success/failure marker.

**Change:** Adds a `tool-readAgentConfig` branch in the `message.parts` renderer in `agent-config-chat.tsx`. No type changes needed (`readAgentConfig` was already declared in the message type).

Verified with typecheck and lint (both clean).