### PR TITLE
feat(chat): add debug mode env var for ai-sdk logging

### DIFF
--- a/apps/dashboard/src/server/libs/config.ts
+++ b/apps/dashboard/src/server/libs/config.ts
@@ -15,6 +15,7 @@ export const ConfigSchema = z.object({
   hermesImageTag: z.string().default("v2026.7.7.2"),
   openaiModel: z.string().min(1).default("gpt-5.5"),
   openaiBaseUrl: z.url().optional(),
+  debugMode: z.preprocess((v) => v === "true", z.boolean()).default(false),
 });
 
 export const config = ConfigSchema.parse({
@@ -29,4 +30,5 @@ export const config = ConfigSchema.parse({
   hermesImageTag: process.env.HERMEUM_HERMES_IMAGE_TAG,
   openaiModel: process.env.HERMEUM_OPENAI_MODEL,
   openaiBaseUrl: process.env.HERMEUM_OPENAI_BASE_URL,
+  debugMode: process.env.HERMEUM_DEBUG_MODE,
 });

--- a/apps/dashboard/src/server/routers/ai-sdk/agent-config.ts
+++ b/apps/dashboard/src/server/routers/ai-sdk/agent-config.ts
@@ -59,6 +59,17 @@ aiSdkRouter.post("/agent-config", async (req, res) => {
     providerOptions: {
       openai: { strictJsonSchema: false },
     },
+    ...(config.debugMode && {
+      onStepFinish: ({ stepNumber, finishReason, toolCalls, text, usage }) => {
+        const toolsCalled = toolCalls.map((c) => c.toolName).join(",") || "-";
+        const preview = text.slice(0, 80).replace(/\n/g, " ");
+        console.info(
+          `[ai-sdk] step ${stepNumber} finish=${finishReason} ` +
+            `tools=[${toolsCalled}] tokens=${usage.totalTokens ?? "?"} ` +
+            `text="${preview}${text.length > 80 ? "…" : ""}"`
+        );
+      },
+    }),
   });
   result.pipeUIMessageStreamToResponse(res);
 });


### PR DESCRIPTION
## Summary

The `apps/dashboard/src/server/routers/ai-sdk/` route logged nothing, making the agent-config chat impossible to debug. This adds a `HERMEUM_DEBUG_MODE` env var that, when enabled, emits minimal per-step console logs so you can follow what is happening in the chat.

## Changes

- **`apps/dashboard/src/server/libs/config.ts`** — added `debugMode` to `ConfigSchema`, parsed from `HERMEUM_DEBUG_MODE`. Accepts only the string `"true"`; everything else (including unset/empty) falls back to `false`.
- **`apps/dashboard/src/server/routers/ai-sdk/agent-config.ts`** — added an `onStepFinish` callback to the `streamText` call, gated on `config.debugMode`. Each LLM step logs one line:

```
[ai-sdk] step 0 finish=tool-calls tools=[readDocument] tokens=1234 text=""
[ai-sdk] step 1 finish=stop tools=- tokens=890 text="Updated the system prompt to be more concise…"
```

Each line shows the step index, finish reason, which tools fired (or `-` for none), token usage for the step, and an 80-char text preview. No prompt/draft/tool-arg payloads are logged, keeping it minimal.

## Notes

- The `onFinish` callback was intentionally not used: the UI-stream `onEnd` event shape (`UIMessageStreamOnEndCallback`) does not expose `steps`/`usage`. The final step's `finish=stop` line already marks completion.
- Defaults to off — no `.env` edit required to keep current behavior.

## Verification

- `typecheck`: no errors in changed files (pre-existing errors in `packages/components/ui/*` are unrelated).
- `lint`: blocked by a pre-existing missing `eslint-plugin-react` dep in the shared eslint config — unrelated.
- `test`: 209/209 pass.

To enable: set `HERMEUM_DEBUG_MODE=true` in `.env`.