### PR TITLE
feat(agents): move templates from chat to editor pane

### DIFF
--- a/apps/dashboard/src/client/ui/components/agent-config-chat.tsx
+++ b/apps/dashboard/src/client/ui/components/agent-config-chat.tsx
@@ -6,14 +6,6 @@ import { ArrowUp, Check, LoaderCircle } from "lucide-react";
 
 import { Button } from "@hermeum/components/ui/button";
 import { Bubble, BubbleContent } from "@hermeum/components/ui/bubble";
-import { Card, CardDescription, CardHeader, CardTitle } from "@hermeum/components/ui/card";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from "@hermeum/components/ui/dialog";
 import { Marker, MarkerContent, MarkerIcon } from "@hermeum/components/ui/marker";
 import { Message, MessageContent } from "@hermeum/components/ui/message";
 import {
@@ -25,7 +17,7 @@ import {
   MessageScrollerViewport,
 } from "@hermeum/components/ui/message-scroller";
 import { Textarea } from "@hermeum/components/ui/textarea";
-import type { AgentInput, Template } from "@/entities";
+import type { AgentInput } from "@/entities";
 import { AgentInputObjectSchema } from "@/entities";
 
 type AgentConfigChatMessage = UIMessage<
@@ -41,17 +33,12 @@ interface AgentConfigChatProps {
   // Called at send time so each turn carries the latest editor draft,
   // including hand edits made between messages.
   getConfig: () => AgentInput | undefined;
-  // Receives config from both AI tool calls and template picks.
+  // Receives config from AI tool calls.
   onConfigUpdate: (config: AgentInput) => void;
-  // When non-empty, the empty-chat hero offers a "start with a template"
-  // link that opens the template dialog.
-  templates?: Template[] | undefined;
 }
 
-export function AgentConfigChat({ getConfig, onConfigUpdate, templates }: AgentConfigChatProps) {
+export function AgentConfigChat({ getConfig, onConfigUpdate }: AgentConfigChatProps) {
   const [input, setInput] = useState("");
-  const [templatesOpen, setTemplatesOpen] = useState(false);
-  const hasTemplates = templates !== undefined && templates.length > 0;
 
   // Latest-ref so the onToolCall closure (captured once by the Chat
   // instance) never applies updates through a stale callback.
@@ -106,41 +93,13 @@ export function AgentConfigChat({ getConfig, onConfigUpdate, templates }: AgentC
 
   const isBusy = status === "submitted" || status === "streaming";
 
-  function handleSelectTemplate(template: Template) {
-    onConfigUpdate(template.agentInput);
-    setTemplatesOpen(false);
-  }
-
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      {hasTemplates && (
-        <TemplateDialog
-          templates={templates}
-          open={templatesOpen}
-          onOpenChange={setTemplatesOpen}
-          onSelect={handleSelectTemplate}
-        />
-      )}
       {messages.length === 0 ? (
         <div className="flex min-h-0 flex-1 flex-col items-center justify-center">
           <div className="text-center">
             <h2 className="text-lg font-semibold tracking-tight">What should your agent do?</h2>
-            <p className="mt-1 text-sm text-muted-foreground">
-              Describe your agent
-              {hasTemplates ? (
-                <>
-                  {" or "}
-                  <button
-                    type="button"
-                    onClick={() => setTemplatesOpen(true)}
-                    className="cursor-pointer underline underline-offset-4 hover:text-foreground"
-                  >
-                    start with a template
-                  </button>
-                </>
-              ) : null}
-              .
-            </p>
+            <p className="mt-1 text-sm text-muted-foreground">Describe your agent.</p>
           </div>
         </div>
       ) : (
@@ -237,43 +196,5 @@ export function AgentConfigChat({ getConfig, onConfigUpdate, templates }: AgentC
         </div>
       </div>
     </div>
-  );
-}
-
-function TemplateDialog({
-  templates,
-  open,
-  onOpenChange,
-  onSelect,
-}: {
-  templates: Template[];
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  onSelect: (template: Template) => void;
-}) {
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-2xl">
-        <DialogHeader>
-          <DialogTitle>Templates</DialogTitle>
-          <DialogDescription>Pick a starting point for the agent config.</DialogDescription>
-        </DialogHeader>
-        <div className="grid max-h-[60vh] grid-cols-2 gap-3 overflow-y-auto p-px">
-          {templates.map((template) => (
-            <Card
-              key={template.id}
-              size="sm"
-              onClick={() => onSelect(template)}
-              className="cursor-pointer ring-1 ring-border transition-all hover:ring-2 hover:ring-primary"
-            >
-              <CardHeader>
-                <CardTitle className="text-base">{template.name}</CardTitle>
-                <CardDescription>{template.description}</CardDescription>
-              </CardHeader>
-            </Card>
-          ))}
-        </div>
-      </DialogContent>
-    </Dialog>
   );
 }

--- a/apps/dashboard/src/client/ui/routes/agents/new.tsx
+++ b/apps/dashboard/src/client/ui/routes/agents/new.tsx
@@ -1,13 +1,12 @@
 import { useState, type ReactNode } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { ArrowLeft, Search } from "lucide-react";
+import { ArrowLeft } from "lucide-react";
 import { parse, stringify } from "yaml";
 import { toast } from "sonner";
 
 import { Button } from "@hermeum/components/ui/button";
 import { Card, CardDescription, CardHeader, CardTitle } from "@hermeum/components/ui/card";
-import { Input } from "@hermeum/components/ui/input";
 import {
   ResizableHandle,
   ResizablePanel,
@@ -24,8 +23,8 @@ const YAML_OPTIONS = { blockQuote: "literal", lineWidth: 0 } as const;
 // The editor pane doubles as the template picker: users browse and preview
 // templates there, and only start editing after picking one as the draft.
 type EditorView =
-  | { mode: "browse"; search: string }
-  | { mode: "preview"; template: Template; search: string }
+  | { mode: "browse" }
+  | { mode: "preview"; template: Template }
   | { mode: "edit" };
 
 export const Route = createFileRoute("/agents/new")({
@@ -36,7 +35,7 @@ function NewAgentPage() {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
-  const [view, setView] = useState<EditorView>({ mode: "browse", search: "" });
+  const [view, setView] = useState<EditorView>({ mode: "browse" });
   const [editorValue, setEditorValue] = useState("");
   const [validationError, setValidationError] = useState<string | null>(null);
 
@@ -100,53 +99,33 @@ function NewAgentPage() {
 
   const configPane: ReactNode = (() => {
     if (view.mode === "browse") {
-      const query = view.search.trim().toLowerCase();
-      const visible = (templates ?? []).filter(
-        (t) =>
-          query.length === 0 ||
-          t.name.toLowerCase().includes(query) ||
-          (t.description ?? "").toLowerCase().includes(query)
-      );
+      const visible = templates ?? [];
       return (
         <div className="flex min-h-0 flex-1 flex-col gap-3">
-          <h2 className="shrink-0 text-lg font-semibold tracking-tight">Browse templates</h2>
-          <div className="relative shrink-0">
-            <Search className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-            <Input
-              value={view.search}
-              onChange={(e) => setView({ mode: "browse", search: e.target.value })}
-              placeholder="Search templates"
-              className="h-9 rounded-[0.25rem] border-border pl-9"
-            />
-          </div>
+          <h2 className="shrink-0 text-base font-medium">Start with templates</h2>
           <div className="grid min-h-0 flex-1 auto-rows-min grid-cols-1 gap-3 overflow-y-auto p-px sm:grid-cols-2">
             {visible.map((template) => (
               <Card
                 key={template.id}
                 size="sm"
-                onClick={() =>
-                  setView({ mode: "preview", template, search: view.search })
-                }
+                onClick={() => setView({ mode: "preview", template })}
                 className="cursor-pointer ring-1 ring-border transition-all hover:ring-2 hover:ring-primary"
               >
                 <CardHeader>
-                  <CardTitle className="text-base">{template.name}</CardTitle>
+                  <CardTitle className="text-sm font-medium tracking-normal normal-case">
+                    {template.name}
+                  </CardTitle>
                   <CardDescription>{template.description}</CardDescription>
                 </CardHeader>
               </Card>
             ))}
-            {templates !== undefined && visible.length === 0 && (
-              <p className="col-span-full text-sm text-muted-foreground">
-                No templates match your search.
-              </p>
-            )}
           </div>
         </div>
       );
     }
 
     if (view.mode === "preview") {
-      const { template, search } = view;
+      const { template } = view;
       return (
         <div className="flex min-h-0 flex-1 flex-col gap-2">
           <div className="flex shrink-0 items-center justify-between gap-2">
@@ -155,7 +134,7 @@ function NewAgentPage() {
                 variant="ghost"
                 size="icon-xs"
                 aria-label="Back to templates"
-                onClick={() => setView({ mode: "browse", search })}
+                onClick={() => setView({ mode: "browse" })}
               >
                 <ArrowLeft />
               </Button>
@@ -164,12 +143,9 @@ function NewAgentPage() {
                 <span className="text-muted-foreground"> · Template</span>
               </p>
             </div>
-            <div className="flex shrink-0 items-center gap-3">
-              <span className="text-sm text-muted-foreground">YAML</span>
-              <Button size="sm" onClick={() => handleUseTemplate(template)}>
-                Use template
-              </Button>
-            </div>
+            <Button size="sm" onClick={() => handleUseTemplate(template)}>
+              Use template
+            </Button>
           </div>
           <div className="min-h-0 flex-1">
             <CodeEditor

--- a/apps/dashboard/src/client/ui/routes/agents/new.tsx
+++ b/apps/dashboard/src/client/ui/routes/agents/new.tsx
@@ -1,10 +1,13 @@
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { ArrowLeft, Search } from "lucide-react";
 import { parse, stringify } from "yaml";
 import { toast } from "sonner";
 
 import { Button } from "@hermeum/components/ui/button";
+import { Card, CardDescription, CardHeader, CardTitle } from "@hermeum/components/ui/card";
+import { Input } from "@hermeum/components/ui/input";
 import {
   ResizableHandle,
   ResizablePanel,
@@ -12,30 +15,18 @@ import {
 } from "@hermeum/components/ui/resizable";
 import { useTRPC } from "@/router";
 import { AgentInputObjectSchema, AgentInputSchema } from "@/entities";
-import type { AgentInput } from "@/entities";
+import type { AgentInput, Template } from "@/entities";
 import { AgentConfigChat } from "@/client/ui/components/agent-config-chat";
 import { CodeEditor } from "@/client/ui/components/code-editor";
 
 const YAML_OPTIONS = { blockQuote: "literal", lineWidth: 0 } as const;
 
-const DEFAULT_YAML = stringify(
-  {
-    name: "Untitled agent",
-    description: "A blank starting point with the core toolset.",
-    soul: `You are a team agent that can research, write code, run commands, and use tools to help the team end to end.`,
-    config: {
-      model: {
-        provider: "anthropic",
-        default: "claude-sonnet-5",
-      },
-    },
-    env: [],
-    skills: [],
-    plugins: [],
-    sharedEnvSets: [],
-  },
-  YAML_OPTIONS
-).trim();
+// The editor pane doubles as the template picker: users browse and preview
+// templates there, and only start editing after picking one as the draft.
+type EditorView =
+  | { mode: "browse"; search: string }
+  | { mode: "preview"; template: Template; search: string }
+  | { mode: "edit" };
 
 export const Route = createFileRoute("/agents/new")({
   component: NewAgentPage,
@@ -45,7 +36,8 @@ function NewAgentPage() {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
-  const [editorValue, setEditorValue] = useState(DEFAULT_YAML);
+  const [view, setView] = useState<EditorView>({ mode: "browse", search: "" });
+  const [editorValue, setEditorValue] = useState("");
   const [validationError, setValidationError] = useState<string | null>(null);
 
   const { data: templates } = useQuery(trpc.template.list.queryOptions());
@@ -64,6 +56,7 @@ function NewAgentPage() {
   );
 
   function getConfig(): AgentInput | undefined {
+    if (view.mode !== "edit") return undefined;
     let parsed: unknown;
     try {
       parsed = parse(editorValue) ?? {};
@@ -77,6 +70,11 @@ function NewAgentPage() {
   function handleConfigUpdate(config: AgentInput) {
     setEditorValue(stringify(config, YAML_OPTIONS).trim());
     setValidationError(null);
+    setView({ mode: "edit" });
+  }
+
+  function handleUseTemplate(template: Template) {
+    handleConfigUpdate(template.agentInput);
   }
 
   function handleCreate() {
@@ -100,40 +98,125 @@ function NewAgentPage() {
     createAgent(parsed);
   }
 
+  const configPane: ReactNode = (() => {
+    if (view.mode === "browse") {
+      const query = view.search.trim().toLowerCase();
+      const visible = (templates ?? []).filter(
+        (t) =>
+          query.length === 0 ||
+          t.name.toLowerCase().includes(query) ||
+          (t.description ?? "").toLowerCase().includes(query)
+      );
+      return (
+        <div className="flex min-h-0 flex-1 flex-col gap-3">
+          <h2 className="shrink-0 text-lg font-semibold tracking-tight">Browse templates</h2>
+          <div className="relative shrink-0">
+            <Search className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              value={view.search}
+              onChange={(e) => setView({ mode: "browse", search: e.target.value })}
+              placeholder="Search templates"
+              className="h-9 rounded-[0.25rem] border-border pl-9"
+            />
+          </div>
+          <div className="grid min-h-0 flex-1 auto-rows-min grid-cols-1 gap-3 overflow-y-auto p-px sm:grid-cols-2">
+            {visible.map((template) => (
+              <Card
+                key={template.id}
+                size="sm"
+                onClick={() =>
+                  setView({ mode: "preview", template, search: view.search })
+                }
+                className="cursor-pointer ring-1 ring-border transition-all hover:ring-2 hover:ring-primary"
+              >
+                <CardHeader>
+                  <CardTitle className="text-base">{template.name}</CardTitle>
+                  <CardDescription>{template.description}</CardDescription>
+                </CardHeader>
+              </Card>
+            ))}
+            {templates !== undefined && visible.length === 0 && (
+              <p className="col-span-full text-sm text-muted-foreground">
+                No templates match your search.
+              </p>
+            )}
+          </div>
+        </div>
+      );
+    }
+
+    if (view.mode === "preview") {
+      const { template, search } = view;
+      return (
+        <div className="flex min-h-0 flex-1 flex-col gap-2">
+          <div className="flex shrink-0 items-center justify-between gap-2">
+            <div className="flex min-w-0 items-center gap-1">
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                aria-label="Back to templates"
+                onClick={() => setView({ mode: "browse", search })}
+              >
+                <ArrowLeft />
+              </Button>
+              <p className="min-w-0 truncate text-sm font-medium">
+                {template.name}
+                <span className="text-muted-foreground"> · Template</span>
+              </p>
+            </div>
+            <div className="flex shrink-0 items-center gap-3">
+              <span className="text-sm text-muted-foreground">YAML</span>
+              <Button size="sm" onClick={() => handleUseTemplate(template)}>
+                Use template
+              </Button>
+            </div>
+          </div>
+          <div className="min-h-0 flex-1">
+            <CodeEditor
+              value={stringify(template.agentInput, YAML_OPTIONS).trim()}
+              readOnly
+              height="100%"
+            />
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div className="flex min-h-0 flex-1 flex-col gap-2">
+        <p className="shrink-0 text-sm font-medium">Agent config</p>
+        <div className="min-h-0 flex-1">
+          <CodeEditor
+            value={editorValue}
+            onChange={setEditorValue}
+            invalid={!!validationError}
+            height="100%"
+          />
+        </div>
+        {validationError && (
+          <p className="shrink-0 text-sm text-destructive">{validationError}</p>
+        )}
+        <div className="flex shrink-0 justify-end gap-2">
+          <Button variant="outline" onClick={() => navigate({ to: "/agents" })}>
+            Cancel
+          </Button>
+          <Button onClick={handleCreate} disabled={isCreating}>
+            {isCreating ? "Creating…" : "Create agent"}
+          </Button>
+        </div>
+      </div>
+    );
+  })();
+
   return (
     <div className="flex h-full min-h-0 flex-col gap-4 p-6">
       <h1 className="shrink-0 text-2xl font-semibold tracking-tight">Create agent</h1>
 
       {/* Mobile: static stacked layout (config on top, chat at bottom) */}
       <div className="flex min-h-0 flex-1 flex-col gap-6 lg:hidden">
-        <div className="flex flex-col gap-2">
-          <p className="shrink-0 text-sm font-medium">Agent config</p>
-          <div className="min-h-0 flex-1">
-            <CodeEditor
-              value={editorValue}
-              onChange={setEditorValue}
-              invalid={!!validationError}
-              height="300px"
-            />
-          </div>
-          {validationError && (
-            <p className="shrink-0 text-sm text-destructive">{validationError}</p>
-          )}
-          <div className="flex shrink-0 justify-end gap-2">
-            <Button variant="outline" onClick={() => navigate({ to: "/agents" })}>
-              Cancel
-            </Button>
-            <Button onClick={handleCreate} disabled={isCreating}>
-              {isCreating ? "Creating…" : "Create agent"}
-            </Button>
-          </div>
-        </div>
+        <div className="flex min-h-0 flex-1 flex-col">{configPane}</div>
         <div className="flex min-h-0 flex-1 flex-col">
-          <AgentConfigChat
-            getConfig={getConfig}
-            onConfigUpdate={handleConfigUpdate}
-            templates={templates}
-          />
+          <AgentConfigChat getConfig={getConfig} onConfigUpdate={handleConfigUpdate} />
         </div>
       </div>
 
@@ -145,11 +228,7 @@ function NewAgentPage() {
         {/* Chat pane */}
         <ResizablePanel defaultSize="50%" minSize="25%" className="min-h-0">
           <div className="flex h-full min-h-0 flex-col pr-3">
-            <AgentConfigChat
-              getConfig={getConfig}
-              onConfigUpdate={handleConfigUpdate}
-              templates={templates}
-            />
+            <AgentConfigChat getConfig={getConfig} onConfigUpdate={handleConfigUpdate} />
           </div>
         </ResizablePanel>
         <ResizableHandle
@@ -159,28 +238,7 @@ function NewAgentPage() {
 
         {/* Config pane */}
         <ResizablePanel defaultSize="50%" minSize="25%" className="min-h-0">
-          <div className="flex h-full min-h-0 flex-col gap-2 pl-3">
-            <p className="shrink-0 text-sm font-medium">Agent config</p>
-            <div className="min-h-0 flex-1">
-              <CodeEditor
-                value={editorValue}
-                onChange={setEditorValue}
-                invalid={!!validationError}
-                height="100%"
-              />
-            </div>
-            {validationError && (
-              <p className="shrink-0 text-sm text-destructive">{validationError}</p>
-            )}
-            <div className="flex shrink-0 justify-end gap-2">
-              <Button variant="outline" onClick={() => navigate({ to: "/agents" })}>
-                Cancel
-              </Button>
-              <Button onClick={handleCreate} disabled={isCreating}>
-                {isCreating ? "Creating…" : "Create agent"}
-              </Button>
-            </div>
-          </div>
+          <div className="flex h-full min-h-0 flex-col pl-3">{configPane}</div>
         </ResizablePanel>
       </ResizablePanelGroup>
     </div>


### PR DESCRIPTION
## Summary

Moves the template picker out of the agent-config chat and into the editor pane on the new-agent page, so users pick a template as the starting draft rather than a hardcoded default.

## Changes

**`agent-config-chat.tsx`** — Templates fully removed from the chat component:
- Deleted the `templates` prop, `TemplateDialog` component (~35 lines), `templatesOpen`/`hasTemplates`/`handleSelectTemplate` state + handler
- Removed unused `Dialog*`/`Card*`/`Template` imports
- Empty-chat hero simplified to plain copy: *\"What should your agent do?\" / \"Describe your agent.\"*

**`routes/agents/new.tsx`** — The editor pane now hosts a browse → preview → edit state machine:
- Deleted the hardcoded `DEFAULT_YAML`
- **browse:** \"Start with templates\" heading + scrollable 2-column card grid (search bar dropped as unnecessary)
- **preview:** \`← Name · Template\` header (ghost back button, muted suffix) + primary **Use template** button above a read-only \`CodeEditor\`
- **edit:** unchanged (label, editable \`CodeEditor\`, validation error, Cancel/Create row)
- Single \`NewAgentPage\` component (no \`ConfigPane\` extraction); the three-mode render is inlined as an IIFE and reused at both mobile and desktop sites
- \`Use template\` runs the existing \`handleConfigUpdate\` path; chat tool-calls also flip view → edit; \`getConfig()\` returns \`undefined\` until a template is chosen

## Notes

- \`apps/dashboard/agent-config.yaml\` is gitignored (per-environment config), so the local \`blank\` template added there is not part of this commit — it lives in the working tree as a local-dev default.
- Typecheck, lint, and tests all pass.

## Test plan

- [x] \`pnpm --filter @hermeum/dashboard typecheck\`
- [x] \`pnpm --filter @hermeum/dashboard lint\`
- [x] \`pnpm --filter @hermeum/dashboard test\`
- [x] Manual: open \`/agents/new\`, confirm browse → preview → edit flow works on both mobile and desktop layouts
- [x] Manual: confirm chat still works without picking a template (AI \`updateAgentConfig\` flips pane to edit)