### PR TITLE
feat(chat): add searchSkills tool backed by Hermes Skills Index

### DIFF
--- a/apps/dashboard/src/server/infras/hermes-skill-index.test.ts
+++ b/apps/dashboard/src/server/infras/hermes-skill-index.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+
+import { HermesSkillIndexAdaptor } from "./hermes-skill-index";
+import type { SkillIndexEntry } from "../usecases/adaptors/skill-index";
+
+function makeEntry(overrides: Partial<SkillIndexEntry> = {}): SkillIndexEntry {
+  return {
+    name: "git-pr-review",
+    description: "Review GitHub pull requests.",
+    source: "github",
+    identifier: "openai/skills/skills/git-pr-review",
+    trust_level: "trusted",
+    repo: "openai/skills",
+    path: "skills/git-pr-review",
+    tags: ["code-review", "github"],
+    extra: {},
+    ...overrides,
+  };
+}
+
+function jsonResponse(skills: SkillIndexEntry[]) {
+  return { ok: true, json: async () => ({ skills }) } as Response;
+}
+
+const entries: SkillIndexEntry[] = [
+  makeEntry({ name: "kubernetes", description: "Manage K8s clusters.", identifier: "official/k8s/kubernetes", tags: ["k8s"], extra: { provider: "openai" } }),
+  makeEntry({ name: "kube-deploy", description: "Deploy to kubernetes.", identifier: "github/openai/kube-deploy", tags: [], extra: { provider: "openai" } }),
+  makeEntry({ name: "git-pr-review", description: "Review pull requests.", identifier: "github/openai/git-pr-review", tags: ["github"], extra: {} }),
+  makeEntry({ name: "apple-reminders", description: "Apple Reminders via remindctl.", identifier: "official/apple/apple-reminders", tags: ["macos"], extra: {} }),
+  makeEntry({ name: "web-search", description: "Search the web.", identifier: "skills.sh/web-search", tags: ["web"], extra: { provider: "openai" } }),
+];
+
+describe("HermesSkillIndexAdaptor", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  describe("searchSkills", () => {
+    it("returns the first N entries in index order for an empty query", async () => {
+      vi.mocked(fetch).mockResolvedValue(jsonResponse(entries));
+      const adaptor = new HermesSkillIndexAdaptor();
+
+      const results = await adaptor.searchSkills("", 3);
+
+      expect(results).toEqual([
+        { name: "kubernetes", identifier: "official/k8s/kubernetes", description: "Manage K8s clusters." },
+        { name: "kube-deploy", identifier: "github/openai/kube-deploy", description: "Deploy to kubernetes." },
+        { name: "git-pr-review", identifier: "github/openai/git-pr-review", description: "Review pull requests." },
+      ]);
+    });
+
+    it("matches a skill by name", async () => {
+      vi.mocked(fetch).mockResolvedValue(jsonResponse(entries));
+      const adaptor = new HermesSkillIndexAdaptor();
+
+      const results = await adaptor.searchSkills("kubernetes", 5);
+
+      expect(results.some((r) => r.name === "kubernetes")).toBe(true);
+    });
+
+    it("matches case-insensitively across name, description, tags, identifier, and provider", async () => {
+      vi.mocked(fetch).mockResolvedValue(jsonResponse(entries));
+      const adaptor = new HermesSkillIndexAdaptor();
+
+      const byTag = await adaptor.searchSkills("MACOS", 5);
+      expect(byTag.some((r) => r.name === "apple-reminders")).toBe(true);
+
+      const byProvider = await adaptor.searchSkills("OPENAI", 5);
+      expect(byProvider.some((r) => r.name === "kubernetes")).toBe(true);
+
+      const byIdentifier = await adaptor.searchSkills("skills.sh/web-search", 5);
+      expect(byIdentifier.some((r) => r.name === "web-search")).toBe(true);
+    });
+
+    it("returns an empty array when nothing matches", async () => {
+      vi.mocked(fetch).mockResolvedValue(jsonResponse(entries));
+      const adaptor = new HermesSkillIndexAdaptor();
+
+      const results = await adaptor.searchSkills("nonexistent-skill-xyz");
+
+      expect(results).toEqual([]);
+    });
+
+    it("truncates to the limit", async () => {
+      vi.mocked(fetch).mockResolvedValue(jsonResponse(entries));
+      const adaptor = new HermesSkillIndexAdaptor();
+
+      const results = await adaptor.searchSkills("", 2);
+
+      expect(results).toHaveLength(2);
+    });
+
+    it("only returns name, identifier, and description", async () => {
+      vi.mocked(fetch).mockResolvedValue(jsonResponse(entries));
+      const adaptor = new HermesSkillIndexAdaptor();
+
+      const [first] = await adaptor.searchSkills("kubernetes", 1);
+
+      expect(Object.keys(first ?? {}).sort()).toEqual(["description", "identifier", "name"]);
+    });
+  });
+
+  describe("caching", () => {
+    it("serves from cache within the TTL without refetching", async () => {
+      vi.mocked(fetch).mockResolvedValue(jsonResponse(entries));
+      const adaptor = new HermesSkillIndexAdaptor();
+
+      await adaptor.searchSkills("kubernetes");
+      await adaptor.searchSkills("git");
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns an empty array on cold-start fetch failure", async () => {
+      vi.mocked(fetch).mockRejectedValue(new Error("network down"));
+      const adaptor = new HermesSkillIndexAdaptor();
+
+      const results = await adaptor.searchSkills("kubernetes");
+
+      expect(results).toEqual([]);
+    });
+
+    it("falls back to the stale cache on fetch failure after a successful fetch", async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(jsonResponse(entries)).mockRejectedValueOnce(new Error("network down"));
+      const adaptor = new HermesSkillIndexAdaptor();
+
+      await adaptor.searchSkills("kubernetes");
+      // Force a reload by expiring the cache.
+      vi.useFakeTimers();
+      vi.advanceTimersByTime(7 * 3600 * 1000);
+      const results = await adaptor.searchSkills("kubernetes");
+      vi.useRealTimers();
+
+      expect(results.length).toBeGreaterThan(0);
+      expect(fetch).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/apps/dashboard/src/server/infras/hermes-skill-index.test.ts
+++ b/apps/dashboard/src/server/infras/hermes-skill-index.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 
-import { HermesSkillIndexAdaptor } from "./hermes-skill-index";
-import type { SkillIndexEntry } from "../usecases/adaptors/skill-index";
+import { HermesSkillIndex } from "./hermes-skill-index";
+import type { SkillIndexEntry } from "./hermes-skill-index";
 
 function makeEntry(overrides: Partial<SkillIndexEntry> = {}): SkillIndexEntry {
   return {
@@ -30,7 +30,7 @@ const entries: SkillIndexEntry[] = [
   makeEntry({ name: "web-search", description: "Search the web.", identifier: "skills.sh/web-search", tags: ["web"], extra: { provider: "openai" } }),
 ];
 
-describe("HermesSkillIndexAdaptor", () => {
+describe("HermesSkillIndex", () => {
   beforeEach(() => {
     vi.stubGlobal("fetch", vi.fn());
   });
@@ -43,7 +43,7 @@ describe("HermesSkillIndexAdaptor", () => {
   describe("searchSkills", () => {
     it("returns the first N entries in index order for an empty query", async () => {
       vi.mocked(fetch).mockResolvedValue(jsonResponse(entries));
-      const adaptor = new HermesSkillIndexAdaptor();
+      const adaptor = new HermesSkillIndex();
 
       const results = await adaptor.searchSkills("", 3);
 
@@ -56,7 +56,7 @@ describe("HermesSkillIndexAdaptor", () => {
 
     it("matches a skill by name", async () => {
       vi.mocked(fetch).mockResolvedValue(jsonResponse(entries));
-      const adaptor = new HermesSkillIndexAdaptor();
+      const adaptor = new HermesSkillIndex();
 
       const results = await adaptor.searchSkills("kubernetes", 5);
 
@@ -65,7 +65,7 @@ describe("HermesSkillIndexAdaptor", () => {
 
     it("matches case-insensitively across name, description, tags, identifier, and provider", async () => {
       vi.mocked(fetch).mockResolvedValue(jsonResponse(entries));
-      const adaptor = new HermesSkillIndexAdaptor();
+      const adaptor = new HermesSkillIndex();
 
       const byTag = await adaptor.searchSkills("MACOS", 5);
       expect(byTag.some((r) => r.name === "apple-reminders")).toBe(true);
@@ -79,7 +79,7 @@ describe("HermesSkillIndexAdaptor", () => {
 
     it("returns an empty array when nothing matches", async () => {
       vi.mocked(fetch).mockResolvedValue(jsonResponse(entries));
-      const adaptor = new HermesSkillIndexAdaptor();
+      const adaptor = new HermesSkillIndex();
 
       const results = await adaptor.searchSkills("nonexistent-skill-xyz");
 
@@ -88,7 +88,7 @@ describe("HermesSkillIndexAdaptor", () => {
 
     it("truncates to the limit", async () => {
       vi.mocked(fetch).mockResolvedValue(jsonResponse(entries));
-      const adaptor = new HermesSkillIndexAdaptor();
+      const adaptor = new HermesSkillIndex();
 
       const results = await adaptor.searchSkills("", 2);
 
@@ -97,7 +97,7 @@ describe("HermesSkillIndexAdaptor", () => {
 
     it("only returns name, identifier, and description", async () => {
       vi.mocked(fetch).mockResolvedValue(jsonResponse(entries));
-      const adaptor = new HermesSkillIndexAdaptor();
+      const adaptor = new HermesSkillIndex();
 
       const [first] = await adaptor.searchSkills("kubernetes", 1);
 
@@ -108,7 +108,7 @@ describe("HermesSkillIndexAdaptor", () => {
   describe("caching", () => {
     it("serves from cache within the TTL without refetching", async () => {
       vi.mocked(fetch).mockResolvedValue(jsonResponse(entries));
-      const adaptor = new HermesSkillIndexAdaptor();
+      const adaptor = new HermesSkillIndex();
 
       await adaptor.searchSkills("kubernetes");
       await adaptor.searchSkills("git");
@@ -118,7 +118,7 @@ describe("HermesSkillIndexAdaptor", () => {
 
     it("returns an empty array on cold-start fetch failure", async () => {
       vi.mocked(fetch).mockRejectedValue(new Error("network down"));
-      const adaptor = new HermesSkillIndexAdaptor();
+      const adaptor = new HermesSkillIndex();
 
       const results = await adaptor.searchSkills("kubernetes");
 
@@ -127,7 +127,7 @@ describe("HermesSkillIndexAdaptor", () => {
 
     it("falls back to the stale cache on fetch failure after a successful fetch", async () => {
       vi.mocked(fetch).mockResolvedValueOnce(jsonResponse(entries)).mockRejectedValueOnce(new Error("network down"));
-      const adaptor = new HermesSkillIndexAdaptor();
+      const adaptor = new HermesSkillIndex();
 
       await adaptor.searchSkills("kubernetes");
       // Force a reload by expiring the cache.

--- a/apps/dashboard/src/server/infras/hermes-skill-index.ts
+++ b/apps/dashboard/src/server/infras/hermes-skill-index.ts
@@ -1,0 +1,79 @@
+import {
+  SkillIndexAdaptor,
+  SkillIndexEntry,
+  SkillSearchResult,
+} from "../usecases/adaptors/skill-index";
+
+const INDEX_URL = "https://hermes-agent.nousresearch.com/docs/api/skills-index.json";
+const CACHE_TTL_MS = 6 * 3600 * 1000;
+
+export class HermesSkillIndexAdaptor implements SkillIndexAdaptor {
+  #cache: { fetchedAt: number; skills: SkillIndexEntry[] } | null = null;
+
+  async #loadIndex(): Promise<SkillIndexEntry[]> {
+    const now = Date.now();
+    if (this.#cache && now - this.#cache.fetchedAt < CACHE_TTL_MS) {
+      return this.#cache.skills;
+    }
+
+    let skills: SkillIndexEntry[] | null = null;
+    try {
+      const resp = await fetch(INDEX_URL, {
+        headers: { "Accept-Encoding": "gzip, deflate" },
+      });
+      if (resp.ok) {
+        const data = (await resp.json()) as { skills?: SkillIndexEntry[] };
+        if (Array.isArray(data.skills)) {
+          skills = data.skills;
+        }
+      }
+    } catch {
+      // network / parse failure — fall through to stale-or-empty below
+    }
+
+    if (skills === null) {
+      // Stale cache is better than nothing; cold-start failure → empty.
+      return this.#cache?.skills ?? [];
+    }
+
+    this.#cache = { fetchedAt: now, skills };
+    return skills;
+  }
+
+  async searchSkills(query: string, limit = 25): Promise<SkillSearchResult[]> {
+    const skills = await this.#loadIndex();
+    if (skills.length === 0) {
+      return [];
+    }
+
+    const toResult = (entry: SkillIndexEntry): SkillSearchResult => ({
+      name: entry.name,
+      identifier: entry.identifier,
+      description: entry.description,
+    });
+
+    const queryLower = query.trim().toLowerCase();
+    if (queryLower === "") {
+      return skills.slice(0, limit).map(toResult);
+    }
+
+    const results: SkillSearchResult[] = [];
+    for (const s of skills) {
+      const haystack = [
+        s.name,
+        s.description,
+        ...s.tags,
+        s.identifier,
+        s.extra?.provider ?? "",
+      ].join(" ").toLowerCase();
+
+      if (haystack.includes(queryLower)) {
+        results.push(toResult(s));
+      }
+      if (results.length >= limit) {
+        break;
+      }
+    }
+    return results;
+  }
+}

--- a/apps/dashboard/src/server/infras/hermes-skill-index.ts
+++ b/apps/dashboard/src/server/infras/hermes-skill-index.ts
@@ -1,13 +1,22 @@
-import {
-  SkillIndexAdaptor,
-  SkillIndexEntry,
-  SkillSearchResult,
-} from "../usecases/adaptors/skill-index";
+import { SkillIndexAdaptor, SkillSearchResult } from "../usecases/adaptors/skill-index";
 
 const INDEX_URL = "https://hermes-agent.nousresearch.com/docs/api/skills-index.json";
 const CACHE_TTL_MS = 6 * 3600 * 1000;
 
-export class HermesSkillIndexAdaptor implements SkillIndexAdaptor {
+export interface SkillIndexEntry {
+  name: string;
+  description: string;
+  source: string;
+  identifier: string;
+  trust_level: string;
+  repo?: string;
+  path?: string;
+  tags: string[];
+  extra?: { provider?: string; [k: string]: unknown };
+  resolved_github_id?: string;
+}
+
+export class HermesSkillIndex implements SkillIndexAdaptor {
   #cache: { fetchedAt: number; skills: SkillIndexEntry[] } | null = null;
 
   async #loadIndex(): Promise<SkillIndexEntry[]> {

--- a/apps/dashboard/src/server/usecases/adaptors/skill-index.ts
+++ b/apps/dashboard/src/server/usecases/adaptors/skill-index.ts
@@ -1,16 +1,3 @@
-export interface SkillIndexEntry {
-  name: string;
-  description: string;
-  source: string;
-  identifier: string;
-  trust_level: string;
-  repo?: string;
-  path?: string;
-  tags: string[];
-  extra?: { provider?: string; [k: string]: unknown };
-  resolved_github_id?: string;
-}
-
 export interface SkillSearchResult {
   name: string;
   identifier: string;

--- a/apps/dashboard/src/server/usecases/adaptors/skill-index.ts
+++ b/apps/dashboard/src/server/usecases/adaptors/skill-index.ts
@@ -1,0 +1,22 @@
+export interface SkillIndexEntry {
+  name: string;
+  description: string;
+  source: string;
+  identifier: string;
+  trust_level: string;
+  repo?: string;
+  path?: string;
+  tags: string[];
+  extra?: { provider?: string; [k: string]: unknown };
+  resolved_github_id?: string;
+}
+
+export interface SkillSearchResult {
+  name: string;
+  identifier: string;
+  description: string;
+}
+
+export interface SkillIndexAdaptor {
+  searchSkills(query: string, limit?: number): Promise<SkillSearchResult[]>;
+}

--- a/apps/dashboard/src/server/usecases/chat.test.ts
+++ b/apps/dashboard/src/server/usecases/chat.test.ts
@@ -4,7 +4,7 @@ import { stringify } from "yaml";
 
 vi.mock("../infras/local-files", () => ({ LocalFiles: vi.fn() }));
 vi.mock("../infras/kubernetes/client", () => ({ KubernetesClient: vi.fn() }));
-vi.mock("../infras/hermes-skill-index", () => ({ HermesSkillIndexAdaptor: vi.fn() }));
+vi.mock("../infras/hermes-skill-index", () => ({ HermesSkillIndex: vi.fn() }));
 vi.mock("@/server/libs/config", () => ({
   config: { agentConfigPath: "./agent-config.yaml", docsPath: "./docs/hermes-config" },
 }));

--- a/apps/dashboard/src/server/usecases/chat.test.ts
+++ b/apps/dashboard/src/server/usecases/chat.test.ts
@@ -4,6 +4,7 @@ import { stringify } from "yaml";
 
 vi.mock("../infras/local-files", () => ({ LocalFiles: vi.fn() }));
 vi.mock("../infras/kubernetes/client", () => ({ KubernetesClient: vi.fn() }));
+vi.mock("../infras/hermes-skill-index", () => ({ HermesSkillIndexAdaptor: vi.fn() }));
 vi.mock("@/server/libs/config", () => ({
   config: { agentConfigPath: "./agent-config.yaml", docsPath: "./docs/hermes-config" },
 }));
@@ -11,6 +12,7 @@ vi.mock("@/server/libs/config", () => ({
 import { ChatUseCase, AGENT_CONFIG_CHAT_SYSTEM_PROMPT } from "./chat";
 import type { File, FileAdaptor } from "./adaptors/file";
 import type { Runtime } from "./adaptors/runtime";
+import type { SkillIndexAdaptor, SkillSearchResult } from "./adaptors/skill-index";
 import type { HermeumConfig, SharedEnvSet } from "@/entities";
 
 type Doc = { content: string; data?: Record<string, unknown> };
@@ -80,6 +82,12 @@ function makeFiles(
 }
 
 const callOptions = {} as ToolExecutionOptions<never>;
+
+function makeSkillIndex(results: SkillSearchResult[] = []): SkillIndexAdaptor {
+  return {
+    searchSkills: vi.fn().mockResolvedValue(results),
+  } as unknown as SkillIndexAdaptor;
+}
 
 // Expected empty-list footer appended to the instructions when there are no
 // shared env sets (matches buildSharedEnvSetList's header-only emission).
@@ -181,6 +189,39 @@ describe("ChatUseCase.getAgentConfigContext", () => {
 
     expect(tools.listDocuments).toBeUndefined();
     expect(tools.readDocument?.execute).toBeDefined();
+  });
+
+  it("exposes a server-executed searchSkills tool", async () => {
+    const useCase = new ChatUseCase(makeRuntime(), makeFiles());
+
+    const { tools } = await useCase.getAgentConfigContext();
+
+    expect(tools.searchSkills).toBeDefined();
+    expect(tools.searchSkills?.execute).toBeDefined();
+  });
+
+  it("delegates searchSkills to the injected skill index adaptor", async () => {
+    const results: SkillSearchResult[] = [
+      { name: "git-pr-review", identifier: "openai/skills/skills/git-pr-review", description: "Review PRs." },
+    ];
+    const skillIndex = makeSkillIndex(results);
+    const useCase = new ChatUseCase(makeRuntime(), makeFiles(), skillIndex);
+
+    const { tools } = await useCase.getAgentConfigContext();
+    const result = await tools.searchSkills!.execute!({ query: "review", limit: 5 }, callOptions);
+
+    expect(result).toEqual({ results });
+    expect(skillIndex.searchSkills).toHaveBeenCalledWith("review", 5);
+  });
+
+  it("defaults the searchSkills limit to 25 when omitted", async () => {
+    const skillIndex = makeSkillIndex([]);
+    const useCase = new ChatUseCase(makeRuntime(), makeFiles(), skillIndex);
+
+    const { tools } = await useCase.getAgentConfigContext();
+    await tools.searchSkills!.execute!({ query: "kubernetes" }, callOptions);
+
+    expect(skillIndex.searchSkills).toHaveBeenCalledWith("kubernetes", 25);
   });
 
   it("embeds the available documents in the instructions with frontmatter descriptions", async () => {

--- a/apps/dashboard/src/server/usecases/chat.ts
+++ b/apps/dashboard/src/server/usecases/chat.ts
@@ -40,13 +40,9 @@ export class ChatUseCase extends HermeumConfigLoadable(BaseUseCase) {
         readSharedEnvSet: this.buildReadSharedEnvSetTool(),
         searchSkills: tool({
           description:
-            "Search the Hermes Skills Index — a catalog of installable " +
-            "agent skills aggregated from skills.sh, GitHub " +
-            "(OpenAI/Anthropics/HuggingFace/NVIDIA), ClawHub, LobeHub, " +
-            "browse.sh, and the Claude marketplace. Use this to find a " +
-            "skill for a task. Matches the query against the skill name, " +
-            "description, tags, identifier, and provider. Pass an empty " +
-            "query to list featured skills.",
+            "Search the Hermes Skills Index for an installable agent skill " +
+            "by name, keyword, or capability. Pass an empty query to list " +
+            "featured skills.",
           inputSchema: z.object({
             query: z.string().describe("Search query (skill name, capability, or keyword)."),
             limit: z

--- a/apps/dashboard/src/server/usecases/chat.ts
+++ b/apps/dashboard/src/server/usecases/chat.ts
@@ -38,6 +38,29 @@ export class ChatUseCase extends HermeumConfigLoadable(BaseUseCase) {
       tools: {
         readDocument: this.buildReadDocumentTool(),
         readSharedEnvSet: this.buildReadSharedEnvSetTool(),
+        searchSkills: tool({
+          description:
+            "Search the Hermes Skills Index — a catalog of installable " +
+            "agent skills aggregated from skills.sh, GitHub " +
+            "(OpenAI/Anthropics/HuggingFace/NVIDIA), ClawHub, LobeHub, " +
+            "browse.sh, and the Claude marketplace. Use this to find a " +
+            "skill for a task. Matches the query against the skill name, " +
+            "description, tags, identifier, and provider. Pass an empty " +
+            "query to list featured skills.",
+          inputSchema: z.object({
+            query: z.string().describe("Search query (skill name, capability, or keyword)."),
+            limit: z
+              .number()
+              .int()
+              .min(1)
+              .max(100)
+              .optional()
+              .describe("Max results (default 25)."),
+          }),
+          execute: async ({ query, limit }) => ({
+            results: await this.skillIndex.searchSkills(query, limit ?? 25),
+          }),
+        }),
         readAgentConfig: tool({
           description:
             "Read the current agent config draft straight from the user's " +

--- a/apps/dashboard/src/server/usecases/mixin.ts
+++ b/apps/dashboard/src/server/usecases/mixin.ts
@@ -4,16 +4,19 @@ import { Context, HermeumConfig, HermeumConfigSchema, User } from "@/entities";
 import { config } from "@/server/libs/config";
 
 import { KubernetesClient } from "../infras/kubernetes/client";
+import { HermesSkillIndexAdaptor } from "../infras/hermes-skill-index";
 import { LocalFiles } from "../infras/local-files";
 import { FileAdaptor } from "./adaptors/file";
 import { Runtime } from "./adaptors/runtime";
+import { SkillIndexAdaptor } from "./adaptors/skill-index";
 
-// Core base class for use cases backed by the file and runtime adaptors;
-// mixins like HermeumConfigLoadable build on the injected adaptors.
+// Core base class for use cases backed by the file, runtime, and skill index
+// adaptors; mixins like HermeumConfigLoadable build on the injected adaptors.
 export class BaseUseCase {
   constructor(
     readonly runtime: Runtime = new KubernetesClient(),
-    readonly files: FileAdaptor = new LocalFiles()
+    readonly files: FileAdaptor = new LocalFiles(),
+    readonly skillIndex: SkillIndexAdaptor = new HermesSkillIndexAdaptor()
   ) {}
 }
 

--- a/apps/dashboard/src/server/usecases/mixin.ts
+++ b/apps/dashboard/src/server/usecases/mixin.ts
@@ -4,7 +4,7 @@ import { Context, HermeumConfig, HermeumConfigSchema, User } from "@/entities";
 import { config } from "@/server/libs/config";
 
 import { KubernetesClient } from "../infras/kubernetes/client";
-import { HermesSkillIndexAdaptor } from "../infras/hermes-skill-index";
+import { HermesSkillIndex } from "../infras/hermes-skill-index";
 import { LocalFiles } from "../infras/local-files";
 import { FileAdaptor } from "./adaptors/file";
 import { Runtime } from "./adaptors/runtime";
@@ -16,7 +16,7 @@ export class BaseUseCase {
   constructor(
     readonly runtime: Runtime = new KubernetesClient(),
     readonly files: FileAdaptor = new LocalFiles(),
-    readonly skillIndex: SkillIndexAdaptor = new HermesSkillIndexAdaptor()
+    readonly skillIndex: SkillIndexAdaptor = new HermesSkillIndex()
   ) {}
 }
 


### PR DESCRIPTION
## What

Adds a server-executed `searchSkills(query, limit?)` ai-sdk tool to the agent-config chat so the model can discover installable agent skills from the [Hermes Skills Index](https://hermes-agent.nousresearch.com/docs/api/skills-index.json) — a centralized JSON catalog aggregating skills from skills.sh, GitHub (OpenAI/Anthropics/HuggingFace/NVIDIA), ClawHub, LobeHub, browse.sh, and the Claude marketplace.

## Why

The dashboard chat had no way for the model to look up skills by capability. Reusing Hermes' centralized index means zero per-query GitHub API calls (the index is rebuilt twice daily by Hermes' CI and pre-resolves paths for all upstream sources).

## How

- **New adaptor interface** `apps/dashboard/src/server/usecases/adaptors/skill-index.ts` — `SkillIndexAdaptor` + `SkillSearchResult` (source-agnostic, mirrors the existing `FileAdaptor`/`Runtime` pattern).
- **New implementation** `apps/dashboard/src/server/infras/hermes-skill-index.ts` — `HermesSkillIndex` class. Fetches the index JSON, caches in-memory for 6h (mirroring Hermes' `HERMES_INDEX_TTL`), falls back to stale cache on fetch failure. Search is case-insensitive substring match across `name + description + tags + identifier + provider`, returned in index order up to `limit`. `SkillIndexEntry` (Hermes JSON shape) lives here, not on the interface.
- **Wired into `BaseUseCase`** (`mixin.ts`) as a third injected constructor param alongside `runtime` and `files`, so any use case can use it and tests inject a mock.
- **New tool in `ChatUseCase.getAgentConfigContext`** (`chat.ts`) — `searchSkills` returns `{ name, identifier, description }` per result (progressive-disclosure tier 1, matching Hermes' `skills_list` precedent so the model can judge relevance in one round-trip).

## Scope (deliberately narrow)

- Search-only. No `inspect`, no `install`, no `fetch`.
- Hermes index URL is the only source (no other adapters, no bundled snapshot, no building our own index).
- Filters: just `query` + `limit` (no `--source`/`--provider`).
- Cache: in-memory, process-scoped. Cold-start fetch failure returns `[]` (no on-disk cache).

## Tests

- `hermes-skill-index.test.ts` — 9 tests: empty query, case-insensitive matching across all fields, no-match, limit truncation, result-shape whitelist, caching within TTL, cold-start failure, stale fallback.
- `chat.test.ts` — 4 new tests: tool is exposed with an `execute`, delegates to the injected adaptor, defaults `limit` to 25. `HermesSkillIndex` is mocked so no live network.

## Verification

```bash
pnpm --filter @hermeum/dashboard typecheck   # tsc --noEmit ✓
pnpm --filter @hermeum/dashboard lint        # 0 errors (2 pre-existing unrelated warnings)
pnpm --filter @hermeum/dashboard test        # 223 passed
```

## Reference

The Hermes index is documented in `vendor/hermes-agent/tools/skills_hub.py` (`HermesIndexSource`, line 3750) and rebuilt by `vendor/hermes-agent/scripts/build_skills_index.py`. This PR ports the search logic (without the scoring/ranking, per request — plain substring match only).