### PR TITLE
fix(agents): restore template card top border by replacing ring with border

### DIFF
--- a/apps/dashboard/src/client/ui/routes/agents/new.tsx
+++ b/apps/dashboard/src/client/ui/routes/agents/new.tsx
@@ -109,7 +109,7 @@ function NewAgentPage() {
                 key={template.id}
                 size="sm"
                 onClick={() => setView({ mode: "preview", template })}
-                className="cursor-pointer ring-1 ring-border transition-all hover:ring-2 hover:ring-primary"
+                className="cursor-pointer ring-0 border border-border transition-colors hover:border-primary"
               >
                 <CardHeader>
                   <CardTitle className="text-sm font-medium tracking-normal normal-case">


### PR DESCRIPTION
Replaces the template card's `ring-1 ring-border` with `border border-border` so the top edge is no longer clipped by the card's overflow-hidden container.