### PR TITLE
feat(chat): restrict searchSkills to builtin/trusted trust levels

### DIFF
--- a/apps/dashboard/scripts/test-hermes-skill-index.ts
+++ b/apps/dashboard/scripts/test-hermes-skill-index.ts
@@ -1,0 +1,13 @@
+import { HermesSkillIndex } from "../src/server/infras/hermes-skill-index";
+
+const query = process.argv[2] ?? "";
+const limit = Number(process.argv[3] ?? 25);
+
+const index = new HermesSkillIndex();
+
+const results = await index.searchSkills(query, limit);
+
+console.log(`query=${JSON.stringify(query)} limit=${limit} count=${results.length}`);
+for (const r of results) {
+  console.log(`\n- ${r.name}  [${r.identifier}]\n  ${r.description}`);
+}

--- a/apps/dashboard/src/server/infras/hermes-skill-index.ts
+++ b/apps/dashboard/src/server/infras/hermes-skill-index.ts
@@ -2,6 +2,7 @@ import { SkillIndexAdaptor, SkillSearchResult } from "../usecases/adaptors/skill
 
 const INDEX_URL = "https://hermes-agent.nousresearch.com/docs/api/skills-index.json";
 const CACHE_TTL_MS = 6 * 3600 * 1000;
+const ALLOWED_TRUST_LEVELS = new Set(["builtin", "trusted"]);
 
 export interface SkillIndexEntry {
   name: string;
@@ -45,8 +46,11 @@ export class HermesSkillIndex implements SkillIndexAdaptor {
       return this.#cache?.skills ?? [];
     }
 
-    this.#cache = { fetchedAt: now, skills };
-    return skills;
+    this.#cache = {
+      fetchedAt: now,
+      skills: skills.filter((s) => ALLOWED_TRUST_LEVELS.has(s.trust_level)),
+    };
+    return this.#cache.skills;
   }
 
   async searchSkills(query: string, limit = 25): Promise<SkillSearchResult[]> {


### PR DESCRIPTION
## What

Restricts the `searchSkills` tool to only surface skills with `trust_level` of `builtin` or `trusted` from the Hermes Skills Index.

## Why

The live index contains ~90,605 community entries vs only 582 builtin+trusted. The community skills are unvetted (and the `clawhub` source has malformed `name` fields), so exposing them in the chat agent tool risks surfacing low-quality/abusive prompts. Limiting to `builtin` + `trusted` keeps the agent's skill catalog curated.

## How

- Added `ALLOWED_TRUST_LEVELS = new Set([`builtin`, `trusted`])` at module scope.
- Filter is applied once at the cache-write site in `#loadIndex`, so the cached/stale fallback path stays consistent and `searchSkills` only sees the allowed subset.
- No change to the `SkillIndexAdaptor` interface.

## Debugging aid

Adds `apps/dashboard/scripts/test-hermes-skill-index.ts` — a standalone tsx script that runs `searchSkills` against the live index with an optional query/limit argument, for quick local verification.

Usage:
```
pnpm --filter @hermeum/dashboard exec tsx scripts/test-hermes-skill-index.ts "<query>" [limit]
```

## Verification

- Typecheck: no new errors (pre-existing `packages/components/ui` JSX/module errors are unrelated)
- Live run via the debug script: returns 582 skills (104 builtin + 478 trusted), matching the index breakdown

| trust_level | count  |
|-------------|--------|
| builtin     | 104    |
| trusted     | 478    |
| community   | 90,023 | (now excluded)
