### PR TITLE
Fix scroll issue on agent detail page and refine section layout

### DIFF
--- a/apps/dashboard/src/client/ui/routes/__root.tsx
+++ b/apps/dashboard/src/client/ui/routes/__root.tsx
@@ -42,7 +42,7 @@ function RootLayout() {
   return (
     <SidebarProvider className="h-svh">
       <AppSidebar session={session} />
-      <SidebarInset className="min-h-0 overflow-hidden">
+      <SidebarInset className="min-h-0 overflow-y-auto">
         <Outlet />
       </SidebarInset>
       <Toaster />

--- a/apps/dashboard/src/client/ui/routes/agents/$id.tsx
+++ b/apps/dashboard/src/client/ui/routes/agents/$id.tsx
@@ -317,7 +317,7 @@ function AgentDetailPage() {
             {/* env */}
             {agent.env && agent.env.length > 0 && (
               <div className="py-8 flex flex-col gap-3">
-                <p className="text-sm font-bold">Environment Variables</p>
+                <p className="text-sm font-bold">Env Vars</p>
                 <div className="flex flex-wrap gap-2">
                   {agent.env.map((v) => (
                     <Button

--- a/apps/dashboard/src/client/ui/routes/agents/$id.tsx
+++ b/apps/dashboard/src/client/ui/routes/agents/$id.tsx
@@ -280,6 +280,9 @@ function AgentDetailPage() {
               </div>
             )}
 
+            {/* tools */}
+            <ToolsSection agent={agent} />
+
             {/* skills */}
             {agent.skills && agent.skills.length > 0 && (
               <div className="py-8 flex flex-col gap-3">
@@ -295,9 +298,6 @@ function AgentDetailPage() {
                 <ButtonList items={agent.plugins} max={10} />
               </div>
             )}
-
-            {/* tools */}
-            <ToolsSection agent={agent} />
 
             {/* packages */}
             {agent.packages?.pip && agent.packages.pip.length > 0 && (

--- a/apps/dashboard/src/client/ui/routes/agents/$id.tsx
+++ b/apps/dashboard/src/client/ui/routes/agents/$id.tsx
@@ -256,7 +256,7 @@ function AgentDetailPage() {
           <TabsTrigger value="connect">Connect</TabsTrigger>
         </TabsList>
 
-        <TabsContent value="agent" className="mt-4">
+        <TabsContent value="agent">
           <div className="flex flex-col divide-y">
             {/* soul */}
             {agent.soul && (
@@ -384,7 +384,7 @@ function AgentDetailPage() {
           </div>
         </TabsContent>
 
-        <TabsContent value="connect" className="mt-4">
+        <TabsContent value="connect">
           <div className="flex flex-col divide-y">
             {gatewayToken && (
               <div className="py-8 flex flex-col gap-3">


### PR DESCRIPTION
## Summary

Fixes the scrollbar disappearing on overflowing pages (e.g. `/agents/:id`) and refines the agent detail page section layout per design feedback.

## Changes

- **`__root.tsx`** — Replaced `overflow-hidden` with `overflow-y-auto` on the `SidebarInset` `<main>`. `<main>` is a `flex-1` child of the `h-svh` `SidebarProvider`, so it is bounded to viewport height; the previous `overflow-hidden` clipped any content taller than the viewport instead of scrolling it. Now it is the single scroll container for every route. `agents/new.tsx` (which uses `h-full min-h-0` + internal panes) is unaffected since its content fits within `<main>` and its panes scroll internally. Dropdown menus and tooltips render through `<Portal>` to `<body>`, so they are not clipped by `overflow-y-auto` on `<main>`.
- **`agents/$id.tsx`** — Removed the redundant `mt-4` top margin on the `TabsContent` panels.
- **`agents/$id.tsx`** — Shortened the "Environment Variables" section title to "Env Vars".
- **`agents/$id.tsx`** — Moved the Tools section to render right after Configuration (before Skills and Plugins). New order: Soul → Configuration → Tools → Skills → Plugins → Packages → Env Vars → Shared Env Sets.

## Verification

- `pnpm --filter @hermeum/dashboard typecheck` — clean
- `pnpm --filter @hermeum/dashboard lint` — 0 errors (2 pre-existing warnings in unrelated files)
- Manual check recommended: open `/agents/:id` with a long agent and confirm the page scrolls; open `/agents/new` and confirm internal panes still scroll without double-scroll; hover a Tool badge / open the actions dropdown and confirm they aren't clipped.