### PR TITLE
feat(agents): show available message platforms on agent detail page

### DIFF
--- a/apps/dashboard/src/client/ui/routes/agents/$id.tsx
+++ b/apps/dashboard/src/client/ui/routes/agents/$id.tsx
@@ -12,11 +12,16 @@ import { authClient } from "@/client/auth-client";
 import { useTRPC } from "@/router";
 import {
   TOOL_IDS,
+  PLATFORM_IDS,
   deriveToolAvailability,
+  derivePlatformAvailability,
   getToolDescription,
   getToolLabel,
+  getPlatformDescription,
+  getPlatformLabel,
   type Agent,
   type ToolId,
+  type PlatformId,
 } from "@/entities";
 import { PhaseBadge } from "@/client/ui/components/phase-badge";
 import { Button } from "@hermeum/components/ui/button";
@@ -113,6 +118,62 @@ function ToolsSection({ agent }: { agent: Agent }) {
         <div className="flex flex-wrap gap-2">
           {TOOL_IDS.map((id) => (
             <ToolBadge key={id} id={id} agent={agent} />
+          ))}
+        </div>
+      </TooltipProvider>
+    </div>
+  );
+}
+
+function PlatformBadge({ id, agent }: { id: PlatformId; agent: Agent }) {
+  const { status, reason, port, home } = derivePlatformAvailability(id, agent);
+  const label = getPlatformLabel(id);
+  const description = getPlatformDescription(id);
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <Button
+            variant="outline"
+            size="sm"
+            className={`h-auto px-2 py-1 font-mono text-xs ${
+              status === "unavailable" ? "text-muted-foreground opacity-60" : ""
+            }`}
+          />
+        }
+      >
+        {label}
+        {status === "available" && port !== undefined && (
+          <span className="text-muted-foreground"> · port {port}</span>
+        )}
+        {status === "available" && home !== undefined && (
+          <span className="text-muted-foreground"> · home {home}</span>
+        )}
+      </TooltipTrigger>
+      <TooltipContent>
+        <div className="flex flex-col gap-0.5">
+          <span>{description}</span>
+          {port !== undefined && <span>Port: {port}</span>}
+          {home !== undefined && <span>Home channel: {home}</span>}
+          {reason && (
+            <span className="capitalize opacity-80">
+              {status} — {reason}
+            </span>
+          )}
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+function PlatformsSection({ agent }: { agent: Agent }) {
+  return (
+    <div className="py-8 flex flex-col gap-3">
+      <p className="text-sm font-bold">Message Platforms</p>
+      <TooltipProvider>
+        <div className="flex flex-wrap gap-2">
+          {PLATFORM_IDS.map((id) => (
+            <PlatformBadge key={id} id={id} agent={agent} />
           ))}
         </div>
       </TooltipProvider>
@@ -298,6 +359,9 @@ function AgentDetailPage() {
 
             {/* tools */}
             <ToolsSection agent={agent} />
+
+            {/* message platforms */}
+            <PlatformsSection agent={agent} />
 
             {/* packages */}
             {agent.packages?.pip && agent.packages.pip.length > 0 && (

--- a/apps/dashboard/src/entities/agent.test.ts
+++ b/apps/dashboard/src/entities/agent.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { z } from "zod";
 
-import { AgentInputObjectSchema, AgentInputSchema, SkillSchema, isApiServerEnabled, getApiServerPort, isWebhookEnabled, getWebhookPort, ToolId, deriveToolAvailability, type Agent } from "./agent";
+import { AgentInputObjectSchema, AgentInputSchema, SkillSchema, isApiServerEnabled, getApiServerPort, isWebhookEnabled, getWebhookPort, ToolId, deriveToolAvailability, PlatformId, derivePlatformAvailability, type Agent } from "./agent";
 
 function makeInput(overrides: Record<string, unknown> = {}) {
   return {
@@ -653,5 +653,165 @@ describe("deriveToolAvailability", () => {
         makeAgent({ config: { browser: { cloud_provider: "camofox" } } })
       ).status
     ).toBe("available");
+  });
+});
+
+describe("derivePlatformAvailability", () => {
+  function makeAgent(overrides: Partial<Agent> = {}): Agent {
+    return { id: "a1", userId: "u1", ...overrides } as Agent;
+  }
+
+  describe("api-server", () => {
+    it("is unavailable by default", () => {
+      const result = derivePlatformAvailability(PlatformId.ApiServer, makeAgent());
+      expect(result.status).toBe("unavailable");
+      expect(result.reason).toContain("API_SERVER_ENABLED");
+    });
+
+    it("is available with the default port when enabled", () => {
+      const result = derivePlatformAvailability(
+        PlatformId.ApiServer,
+        makeAgent({ env: [{ name: "API_SERVER_ENABLED", value: "true" }] })
+      );
+      expect(result).toEqual({ status: "available", port: 8642 });
+    });
+
+    it("uses API_SERVER_PORT when set", () => {
+      const result = derivePlatformAvailability(
+        PlatformId.ApiServer,
+        makeAgent({
+          env: [
+            { name: "API_SERVER_ENABLED", value: "true" },
+            { name: "API_SERVER_PORT", value: "9000" },
+          ],
+        })
+      );
+      expect(result).toEqual({ status: "available", port: 9000 });
+    });
+  });
+
+  describe("webhook", () => {
+    it("is unavailable by default", () => {
+      const result = derivePlatformAvailability(PlatformId.Webhook, makeAgent());
+      expect(result.status).toBe("unavailable");
+      expect(result.reason).toContain("WEBHOOK_ENABLED");
+    });
+
+    it("is available with the default port when enabled via config", () => {
+      const result = derivePlatformAvailability(
+        PlatformId.Webhook,
+        makeAgent({ config: { platforms: { webhook: { enabled: true } } } })
+      );
+      expect(result).toEqual({ status: "available", port: 8644 });
+    });
+
+    it("uses config.platforms.webhook.extra.port when set", () => {
+      const result = derivePlatformAvailability(
+        PlatformId.Webhook,
+        makeAgent({ config: { platforms: { webhook: { enabled: true, extra: { port: 9000 } } } } })
+      );
+      expect(result).toEqual({ status: "available", port: 9000 });
+    });
+
+    it("is available via WEBHOOK_ENABLED env var and respects WEBHOOK_PORT", () => {
+      const result = derivePlatformAvailability(
+        PlatformId.Webhook,
+        makeAgent({
+          env: [
+            { name: "WEBHOOK_ENABLED", value: "true" },
+            { name: "WEBHOOK_PORT", value: "9001" },
+          ],
+        })
+      );
+      expect(result).toEqual({ status: "available", port: 9001 });
+    });
+
+    it("is unavailable via config even when the WEBHOOK_ENABLED env var is set", () => {
+      const result = derivePlatformAvailability(
+        PlatformId.Webhook,
+        makeAgent({
+          config: { platforms: { webhook: { enabled: false } } },
+          env: [{ name: "WEBHOOK_ENABLED", value: "true" }],
+        })
+      );
+      expect(result.status).toBe("unavailable");
+    });
+  });
+
+  describe("slack", () => {
+    const slackEnv = [
+      { name: "SLACK_BOT_TOKEN", value: "xoxb-1", sensitive: true },
+      { name: "SLACK_APP_TOKEN", value: "xapp-1", sensitive: true },
+      { name: "SLACK_ALLOWED_USERS", value: "U01" },
+    ];
+
+    const slackSecretSentinelEnv = [
+      { name: "SLACK_BOT_TOKEN", value: "<secret>", sensitive: true },
+      { name: "SLACK_APP_TOKEN", value: "<secret>", sensitive: true },
+      { name: "SLACK_ALLOWED_USERS", value: "U01" },
+    ];
+
+    it("is unavailable when all three required env vars are missing", () => {
+      const result = derivePlatformAvailability(PlatformId.Slack, makeAgent());
+      expect(result.status).toBe("unavailable");
+      expect(result.reason).toContain("SLACK_BOT_TOKEN");
+      expect(result.reason).toContain("SLACK_APP_TOKEN");
+      expect(result.reason).toContain("SLACK_ALLOWED_USERS");
+    });
+
+    it("names only the missing env vars when some are set", () => {
+      const result = derivePlatformAvailability(
+        PlatformId.Slack,
+        makeAgent({ env: [{ name: "SLACK_BOT_TOKEN", value: "xoxb-1", sensitive: true }] })
+      );
+      expect(result.status).toBe("unavailable");
+      expect(result.reason).not.toContain("SLACK_BOT_TOKEN");
+      expect(result.reason).toContain("SLACK_APP_TOKEN");
+      expect(result.reason).toContain("SLACK_ALLOWED_USERS");
+    });
+
+    it("is available with no home when all three required env vars are set", () => {
+      const result = derivePlatformAvailability(PlatformId.Slack, makeAgent({ env: slackEnv }));
+      expect(result).toEqual({ status: "available" });
+    });
+
+    it("treats the <secret> sentinel for sensitive tokens as set", () => {
+      const result = derivePlatformAvailability(
+        PlatformId.Slack,
+        makeAgent({ env: slackSecretSentinelEnv })
+      );
+      expect(result.status).toBe("available");
+    });
+
+    it("reports SLACK_HOME_CHANNEL as home when set", () => {
+      const result = derivePlatformAvailability(
+        PlatformId.Slack,
+        makeAgent({ env: [...slackEnv, { name: "SLACK_HOME_CHANNEL", value: "C0123" }] })
+      );
+      expect(result).toEqual({ status: "available", home: "C0123" });
+    });
+
+    it("appends SLACK_HOME_CHANNEL_NAME when set", () => {
+      const result = derivePlatformAvailability(
+        PlatformId.Slack,
+        makeAgent({
+          env: [
+            ...slackEnv,
+            { name: "SLACK_HOME_CHANNEL", value: "C0123" },
+            { name: "SLACK_HOME_CHANNEL_NAME", value: "ops" },
+          ],
+        })
+      );
+      expect(result).toEqual({ status: "available", home: "C0123 (ops)" });
+    });
+
+    it("is available even when config.slack is present but no env credentials", () => {
+      // config.slack holds behavior knobs only; credentials come from env.
+      const result = derivePlatformAvailability(
+        PlatformId.Slack,
+        makeAgent({ config: { slack: { allowed_channels: ["C01"] } } })
+      );
+      expect(result.status).toBe("unavailable");
+    });
   });
 });

--- a/apps/dashboard/src/entities/agent.ts
+++ b/apps/dashboard/src/entities/agent.ts
@@ -543,6 +543,103 @@ export function getWebhookPort(input: AgentInput): number {
   return WEBHOOK_DEFAULT_PORT;
 }
 
+// Message-platform availability — a derived, read-only view of which inbound
+// message platforms are wired up for an agent, computed from its config + env.
+// Not persisted.
+// https://hermes-agent.nousresearch.com/docs/user-guide/messaging
+
+export enum PlatformId {
+  ApiServer = "api-server",
+  Webhook = "webhook",
+  Slack = "slack",
+}
+
+export interface PlatformAvailability {
+  status: "available" | "unavailable";
+  /** Short explanation shown when status is not "available". */
+  reason?: string;
+  /** Listening port for HTTP platforms (api-server, webhook). */
+  port?: number;
+  /** Home channel for chat platforms (slack only), if configured. */
+  home?: string;
+}
+
+interface PlatformMeta {
+  label: string;
+  description: string;
+}
+
+const PLATFORM_META: Record<PlatformId, PlatformMeta> = {
+  [PlatformId.ApiServer]: {
+    label: "API Server",
+    description: "OpenAI-compatible HTTP endpoint for frontends like Open WebUI.",
+  },
+  [PlatformId.Webhook]: {
+    label: "Webhook",
+    description: "HTTP server that accepts signed webhooks and routes them to the agent.",
+  },
+  [PlatformId.Slack]: {
+    label: "Slack",
+    description: "Slack bot relayed through the gateway (Socket Mode).",
+  },
+};
+
+export function getPlatformLabel(id: PlatformId): string {
+  return PLATFORM_META[id].label;
+}
+
+export function getPlatformDescription(id: PlatformId): string {
+  return PLATFORM_META[id].description;
+}
+
+/** Ordered platform list for UI rendering. */
+export const PLATFORM_IDS: readonly PlatformId[] = [
+  PlatformId.ApiServer,
+  PlatformId.Webhook,
+  PlatformId.Slack,
+];
+
+const SLACK_REQUIRED_ENV_VARS = ["SLACK_BOT_TOKEN", "SLACK_APP_TOKEN", "SLACK_ALLOWED_USERS"];
+
+export function derivePlatformAvailability(id: PlatformId, agent: Agent): PlatformAvailability {
+  const env = agent.env ?? [];
+
+  switch (id) {
+    case PlatformId.ApiServer: {
+      if (!isApiServerEnabled(agent)) {
+        return { status: "unavailable", reason: "Set API_SERVER_ENABLED=true to enable." };
+      }
+      return { status: "available", port: getApiServerPort(agent) };
+    }
+    case PlatformId.Webhook: {
+      if (!isWebhookEnabled(agent)) {
+        return {
+          status: "unavailable",
+          reason: "Set WEBHOOK_ENABLED=true (or config.platforms.webhook.enabled).",
+        };
+      }
+      return { status: "available", port: getWebhookPort(agent) };
+    }
+    case PlatformId.Slack: {
+      const isSet = (name: string) =>
+        env.some((v) => v.name === name && v.value.trim() !== "");
+      const missing = SLACK_REQUIRED_ENV_VARS.filter((name) => !isSet(name));
+      if (missing.length > 0) {
+        return {
+          status: "unavailable",
+          reason: `Missing env var${missing.length > 1 ? "s" : ""}: ${missing.join(", ")}.`,
+        };
+      }
+      const home = env.find((v) => v.name === "SLACK_HOME_CHANNEL")?.value;
+      const homeName = env.find((v) => v.name === "SLACK_HOME_CHANNEL_NAME")?.value;
+      if (home) {
+        return { status: "available", home: homeName ? `${home} (${homeName})` : home };
+      }
+      return { status: "available" };
+    }
+  }
+}
+
 export const AgentPhaseSchema = z.enum([
   "Pending",
   "Running",


### PR DESCRIPTION
## Summary

Adds a **Message Platforms** section to the Agent tab on the agent detail page, placed directly after **Tools** and styled to match the existing tools UI.

## Platforms shown

Each badge renders inline with a `· port N` / `· home <id>` suffix when available, greys out when unavailable, and surfaces full details + reason in a tooltip.

- **API Server** — OpenAI-compatible HTTP endpoint. Available when `API_SERVER_ENABLED=true`; port from `API_SERVER_PORT` (default 8642).
- **Webhook** — signed-webhook HTTP server. Available via `config.platforms.webhook.enabled` (preferred) or `WEBHOOK_ENABLED=true`; port from `config.platforms.webhook.extra.port` or `WEBHOOK_PORT` (default 8644).
- **Slack** — Socket Mode bot. Available when `SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`, and `SLACK_ALLOWED_USERS` env vars are all set (the `<secret>` sentinel counts as set); home channel surfaced from `SLACK_HOME_CHANNEL` (+ optional `SLACK_HOME_CHANNEL_NAME`).

## Changes

- `src/entities/agent.ts` — new `PlatformId` enum, `PlatformAvailability` interface, `PLATFORM_META`, `getPlatformLabel` / `getPlatformDescription`, ordered `PLATFORM_IDS`, and `derivePlatformAvailability(id, agent)`. Derived and read-only — no schema, router, or persistence changes.
- `src/entities/agent.test.ts` — 14 new tests under `describe("derivePlatformAvailability")` covering defaults, custom ports, env-vs-config precedence, sentinel handling, home channel rendering, and missing-var messaging.
- `src/client/ui/routes/agents/$id.tsx` — new `PlatformBadge` + `PlatformsSection` components, rendered after `<ToolsSection />` in the Agent tab.

## Verification

```
pnpm --filter @hermeum/dashboard test -- src/entities/agent.test.ts   # 135/135 pass
pnpm --filter @hermeum/dashboard typecheck                            # clean
pnpm --filter @hermeum/dashboard lint                                 # 0 errors (2 pre-existing warnings in unrelated files)
```