### PR TITLE
feat(agents): configure ingress for api-server and webhook platforms

### DIFF
--- a/apps/dashboard/src/server/infras/kubernetes/client.test.ts
+++ b/apps/dashboard/src/server/infras/kubernetes/client.test.ts
@@ -563,21 +563,8 @@ describe("agentToHermesAgent ingress wiring", () => {
     ]);
   });
 
-  it("emits a tls block with hosts but no secretName when scheme=https and no secret configured", async () => {
+  it("emits a tls block with secretName when a tls secret is configured (regardless of scheme)", async () => {
     vi.stubEnv("HERMEUM_INGRESS_BASE_HOSTNAME", "agents.example.com");
-    vi.stubEnv("HERMEUM_INGRESS_SCHEME", "https");
-    const { agentToHermesAgent } = await importFresh();
-    const hermesAgent = agentToHermesAgent(
-      makeAgent({ env: [{ name: "API_SERVER_ENABLED", value: "true" }] })
-    );
-    expect(hermesAgent.spec.networking?.ingress?.tls).toEqual([
-      { hosts: ["agent-1.agents.example.com"] },
-    ]);
-  });
-
-  it("includes secretName in the tls block when scheme=https and a tls secret is configured", async () => {
-    vi.stubEnv("HERMEUM_INGRESS_BASE_HOSTNAME", "agents.example.com");
-    vi.stubEnv("HERMEUM_INGRESS_SCHEME", "https");
     vi.stubEnv("HERMEUM_INGRESS_TLS_SECRET_NAME", "agent-tls");
     const { agentToHermesAgent } = await importFresh();
     const hermesAgent = agentToHermesAgent(
@@ -588,8 +575,9 @@ describe("agentToHermesAgent ingress wiring", () => {
     ]);
   });
 
-  it("omits tls entirely when scheme=http (default)", async () => {
+  it("omits tls entirely when no tls secret is configured (covers LB-terminated TLS)", async () => {
     vi.stubEnv("HERMEUM_INGRESS_BASE_HOSTNAME", "agents.example.com");
+    vi.stubEnv("HERMEUM_INGRESS_SCHEME", "https");
     const { agentToHermesAgent } = await importFresh();
     const hermesAgent = agentToHermesAgent(
       makeAgent({ env: [{ name: "API_SERVER_ENABLED", value: "true" }] })

--- a/apps/dashboard/src/server/infras/kubernetes/client.test.ts
+++ b/apps/dashboard/src/server/infras/kubernetes/client.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 import {
   agentEnvResourceName,
@@ -467,5 +467,166 @@ describe("agentToHermesAgent podAnnotations wiring", () => {
     const a = agentToHermesAgent(makeAgent({ env: [{ name: "REGION", value: "us-east-1" }] }));
     const b = agentToHermesAgent(makeAgent({ env: [{ name: "REGION", value: "us-west-2" }] }));
     expect(a.spec.podAnnotations).not.toEqual(b.spec.podAnnotations);
+  });
+});
+
+// `config` is a module-level singleton parsed at import time from process.env, so
+// the ingress tests below vary HERMEUM_INGRESS_* env vars per case by stubbing
+// env, resetting the module registry, and dynamically importing a fresh copy of
+// agentToHermesAgent that re-reads config. The static top-level import is left
+// in place for the existing describe blocks, which don't depend on the new vars
+// (ingressBaseHostname defaults to undefined → no ingress emitted).
+describe("agentToHermesAgent ingress wiring", () => {
+  const ENV_VARS = [
+    "HERMEUM_INGRESS_SCHEME",
+    "HERMEUM_INGRESS_BASE_HOSTNAME",
+    "HERMEUM_INGRESS_CLASS_NAME",
+    "HERMEUM_INGRESS_TLS_SECRET_NAME",
+  ];
+  const ORIGINAL: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const k of ENV_VARS) ORIGINAL[k] = process.env[k];
+  });
+
+  afterEach(() => {
+    for (const k of ENV_VARS) {
+      if (ORIGINAL[k] === undefined) delete process.env[k];
+      else process.env[k] = ORIGINAL[k];
+    }
+    vi.resetModules();
+    vi.unstubAllEnvs();
+  });
+
+  async function importFresh(): Promise<typeof import("./client")> {
+    vi.resetModules();
+    return (await import("./client")) as typeof import("./client");
+  }
+
+  it("omits networking.ingress when no base hostname is configured", async () => {
+    const { agentToHermesAgent } = await importFresh();
+    const hermesAgent = agentToHermesAgent(
+      makeAgent({ env: [{ name: "API_SERVER_ENABLED", value: "true" }] })
+    );
+    expect(hermesAgent.spec.networking?.ingress).toBeUndefined();
+  });
+
+  it("emits all four routes when both api-server and webhook are enabled", async () => {
+    vi.stubEnv("HERMEUM_INGRESS_BASE_HOSTNAME", "agents.example.com");
+    const { agentToHermesAgent } = await importFresh();
+    const hermesAgent = agentToHermesAgent(
+      makeAgent({
+        env: [
+          { name: "API_SERVER_ENABLED", value: "true" },
+          { name: "WEBHOOK_ENABLED", value: "true" },
+        ],
+      })
+    );
+    expect(hermesAgent.spec.networking?.ingress).toEqual({
+      enabled: true,
+      annotations: {},
+      hosts: [
+        {
+          host: "agent-1.agents.example.com",
+          paths: [
+            { path: "/webhooks", pathType: "Prefix", port: 8644 },
+            { path: "/api", pathType: "Prefix", port: 8642 },
+            { path: "/v1", pathType: "Prefix", port: 8642 },
+            { path: "/health", pathType: "Prefix", port: 8642 },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("includes only the api-server routes when only api-server is enabled", async () => {
+    vi.stubEnv("HERMEUM_INGRESS_BASE_HOSTNAME", "agents.example.com");
+    const { agentToHermesAgent } = await importFresh();
+    const hermesAgent = agentToHermesAgent(
+      makeAgent({ env: [{ name: "API_SERVER_ENABLED", value: "true" }] })
+    );
+    expect(hermesAgent.spec.networking?.ingress?.hosts?.[0]?.paths).toEqual([
+      { path: "/api", pathType: "Prefix", port: 8642 },
+      { path: "/v1", pathType: "Prefix", port: 8642 },
+      { path: "/health", pathType: "Prefix", port: 8642 },
+    ]);
+  });
+
+  it("includes only the webhook route when only webhook is enabled", async () => {
+    vi.stubEnv("HERMEUM_INGRESS_BASE_HOSTNAME", "agents.example.com");
+    const { agentToHermesAgent } = await importFresh();
+    const hermesAgent = agentToHermesAgent(
+      makeAgent({ env: [{ name: "WEBHOOK_ENABLED", value: "true" }] })
+    );
+    expect(hermesAgent.spec.networking?.ingress?.hosts?.[0]?.paths).toEqual([
+      { path: "/webhooks", pathType: "Prefix", port: 8644 },
+    ]);
+  });
+
+  it("emits a tls block with hosts but no secretName when scheme=https and no secret configured", async () => {
+    vi.stubEnv("HERMEUM_INGRESS_BASE_HOSTNAME", "agents.example.com");
+    vi.stubEnv("HERMEUM_INGRESS_SCHEME", "https");
+    const { agentToHermesAgent } = await importFresh();
+    const hermesAgent = agentToHermesAgent(
+      makeAgent({ env: [{ name: "API_SERVER_ENABLED", value: "true" }] })
+    );
+    expect(hermesAgent.spec.networking?.ingress?.tls).toEqual([
+      { hosts: ["agent-1.agents.example.com"] },
+    ]);
+  });
+
+  it("includes secretName in the tls block when scheme=https and a tls secret is configured", async () => {
+    vi.stubEnv("HERMEUM_INGRESS_BASE_HOSTNAME", "agents.example.com");
+    vi.stubEnv("HERMEUM_INGRESS_SCHEME", "https");
+    vi.stubEnv("HERMEUM_INGRESS_TLS_SECRET_NAME", "agent-tls");
+    const { agentToHermesAgent } = await importFresh();
+    const hermesAgent = agentToHermesAgent(
+      makeAgent({ env: [{ name: "API_SERVER_ENABLED", value: "true" }] })
+    );
+    expect(hermesAgent.spec.networking?.ingress?.tls).toEqual([
+      { hosts: ["agent-1.agents.example.com"], secretName: "agent-tls" },
+    ]);
+  });
+
+  it("omits tls entirely when scheme=http (default)", async () => {
+    vi.stubEnv("HERMEUM_INGRESS_BASE_HOSTNAME", "agents.example.com");
+    const { agentToHermesAgent } = await importFresh();
+    const hermesAgent = agentToHermesAgent(
+      makeAgent({ env: [{ name: "API_SERVER_ENABLED", value: "true" }] })
+    );
+    expect(hermesAgent.spec.networking?.ingress?.tls).toBeUndefined();
+  });
+
+  it("reflects ingressClassName on className when configured", async () => {
+    vi.stubEnv("HERMEUM_INGRESS_BASE_HOSTNAME", "agents.example.com");
+    vi.stubEnv("HERMEUM_INGRESS_CLASS_NAME", "nginx");
+    const { agentToHermesAgent } = await importFresh();
+    const hermesAgent = agentToHermesAgent(
+      makeAgent({ env: [{ name: "API_SERVER_ENABLED", value: "true" }] })
+    );
+    expect(hermesAgent.spec.networking?.ingress?.className).toBe("nginx");
+  });
+
+  it("leaves className undefined when ingressClassName is not configured", async () => {
+    vi.stubEnv("HERMEUM_INGRESS_BASE_HOSTNAME", "agents.example.com");
+    const { agentToHermesAgent } = await importFresh();
+    const hermesAgent = agentToHermesAgent(
+      makeAgent({ env: [{ name: "API_SERVER_ENABLED", value: "true" }] })
+    );
+    expect(hermesAgent.spec.networking?.ingress?.className).toBeUndefined();
+  });
+
+  it("builds the host from the agent id and base hostname", async () => {
+    vi.stubEnv("HERMEUM_INGRESS_BASE_HOSTNAME", "agents.example.com");
+    const { agentToHermesAgent } = await importFresh();
+    const hermesAgent = agentToHermesAgent(
+      makeAgent({
+        id: "agent-42",
+        env: [{ name: "API_SERVER_ENABLED", value: "true" }],
+      })
+    );
+    expect(hermesAgent.spec.networking?.ingress?.hosts?.[0]?.host).toBe(
+      "agent-42.agents.example.com"
+    );
   });
 });

--- a/apps/dashboard/src/server/infras/kubernetes/client.test.ts
+++ b/apps/dashboard/src/server/infras/kubernetes/client.test.ts
@@ -471,17 +471,17 @@ describe("agentToHermesAgent podAnnotations wiring", () => {
 });
 
 // `config` is a module-level singleton parsed at import time from process.env, so
-// the ingress tests below vary HERMEUM_INGRESS_* env vars per case by stubbing
+// the ingress tests below vary HERMEUM_AGENT_INGRESS_* env vars per case by stubbing
 // env, resetting the module registry, and dynamically importing a fresh copy of
 // agentToHermesAgent that re-reads config. The static top-level import is left
 // in place for the existing describe blocks, which don't depend on the new vars
-// (ingressBaseHostname defaults to undefined → no ingress emitted).
+// (agentIngressBaseHostname defaults to undefined → no ingress emitted).
 describe("agentToHermesAgent ingress wiring", () => {
   const ENV_VARS = [
-    "HERMEUM_INGRESS_SCHEME",
-    "HERMEUM_INGRESS_BASE_HOSTNAME",
-    "HERMEUM_INGRESS_CLASS_NAME",
-    "HERMEUM_INGRESS_TLS_SECRET_NAME",
+    "HERMEUM_AGENT_INGRESS_SCHEME",
+    "HERMEUM_AGENT_INGRESS_BASE_HOSTNAME",
+    "HERMEUM_AGENT_INGRESS_CLASS_NAME",
+    "HERMEUM_AGENT_INGRESS_TLS_SECRET_NAME",
   ];
   const ORIGINAL: Record<string, string | undefined> = {};
 
@@ -512,7 +512,7 @@ describe("agentToHermesAgent ingress wiring", () => {
   });
 
   it("emits all four routes when both api-server and webhook are enabled", async () => {
-    vi.stubEnv("HERMEUM_INGRESS_BASE_HOSTNAME", "agents.example.com");
+    vi.stubEnv("HERMEUM_AGENT_INGRESS_BASE_HOSTNAME", "agents.example.com");
     const { agentToHermesAgent } = await importFresh();
     const hermesAgent = agentToHermesAgent(
       makeAgent({
@@ -540,7 +540,7 @@ describe("agentToHermesAgent ingress wiring", () => {
   });
 
   it("includes only the api-server routes when only api-server is enabled", async () => {
-    vi.stubEnv("HERMEUM_INGRESS_BASE_HOSTNAME", "agents.example.com");
+    vi.stubEnv("HERMEUM_AGENT_INGRESS_BASE_HOSTNAME", "agents.example.com");
     const { agentToHermesAgent } = await importFresh();
     const hermesAgent = agentToHermesAgent(
       makeAgent({ env: [{ name: "API_SERVER_ENABLED", value: "true" }] })
@@ -553,7 +553,7 @@ describe("agentToHermesAgent ingress wiring", () => {
   });
 
   it("includes only the webhook route when only webhook is enabled", async () => {
-    vi.stubEnv("HERMEUM_INGRESS_BASE_HOSTNAME", "agents.example.com");
+    vi.stubEnv("HERMEUM_AGENT_INGRESS_BASE_HOSTNAME", "agents.example.com");
     const { agentToHermesAgent } = await importFresh();
     const hermesAgent = agentToHermesAgent(
       makeAgent({ env: [{ name: "WEBHOOK_ENABLED", value: "true" }] })
@@ -564,8 +564,8 @@ describe("agentToHermesAgent ingress wiring", () => {
   });
 
   it("emits a tls block with secretName when a tls secret is configured (regardless of scheme)", async () => {
-    vi.stubEnv("HERMEUM_INGRESS_BASE_HOSTNAME", "agents.example.com");
-    vi.stubEnv("HERMEUM_INGRESS_TLS_SECRET_NAME", "agent-tls");
+    vi.stubEnv("HERMEUM_AGENT_INGRESS_BASE_HOSTNAME", "agents.example.com");
+    vi.stubEnv("HERMEUM_AGENT_INGRESS_TLS_SECRET_NAME", "agent-tls");
     const { agentToHermesAgent } = await importFresh();
     const hermesAgent = agentToHermesAgent(
       makeAgent({ env: [{ name: "API_SERVER_ENABLED", value: "true" }] })
@@ -576,8 +576,8 @@ describe("agentToHermesAgent ingress wiring", () => {
   });
 
   it("omits tls entirely when no tls secret is configured (covers LB-terminated TLS)", async () => {
-    vi.stubEnv("HERMEUM_INGRESS_BASE_HOSTNAME", "agents.example.com");
-    vi.stubEnv("HERMEUM_INGRESS_SCHEME", "https");
+    vi.stubEnv("HERMEUM_AGENT_INGRESS_BASE_HOSTNAME", "agents.example.com");
+    vi.stubEnv("HERMEUM_AGENT_INGRESS_SCHEME", "https");
     const { agentToHermesAgent } = await importFresh();
     const hermesAgent = agentToHermesAgent(
       makeAgent({ env: [{ name: "API_SERVER_ENABLED", value: "true" }] })
@@ -585,9 +585,9 @@ describe("agentToHermesAgent ingress wiring", () => {
     expect(hermesAgent.spec.networking?.ingress?.tls).toBeUndefined();
   });
 
-  it("reflects ingressClassName on className when configured", async () => {
-    vi.stubEnv("HERMEUM_INGRESS_BASE_HOSTNAME", "agents.example.com");
-    vi.stubEnv("HERMEUM_INGRESS_CLASS_NAME", "nginx");
+  it("reflects agentIngressClassName on className when configured", async () => {
+    vi.stubEnv("HERMEUM_AGENT_INGRESS_BASE_HOSTNAME", "agents.example.com");
+    vi.stubEnv("HERMEUM_AGENT_INGRESS_CLASS_NAME", "nginx");
     const { agentToHermesAgent } = await importFresh();
     const hermesAgent = agentToHermesAgent(
       makeAgent({ env: [{ name: "API_SERVER_ENABLED", value: "true" }] })
@@ -595,8 +595,8 @@ describe("agentToHermesAgent ingress wiring", () => {
     expect(hermesAgent.spec.networking?.ingress?.className).toBe("nginx");
   });
 
-  it("leaves className undefined when ingressClassName is not configured", async () => {
-    vi.stubEnv("HERMEUM_INGRESS_BASE_HOSTNAME", "agents.example.com");
+  it("leaves className undefined when agentIngressClassName is not configured", async () => {
+    vi.stubEnv("HERMEUM_AGENT_INGRESS_BASE_HOSTNAME", "agents.example.com");
     const { agentToHermesAgent } = await importFresh();
     const hermesAgent = agentToHermesAgent(
       makeAgent({ env: [{ name: "API_SERVER_ENABLED", value: "true" }] })
@@ -605,7 +605,7 @@ describe("agentToHermesAgent ingress wiring", () => {
   });
 
   it("builds the host from the agent id and base hostname", async () => {
-    vi.stubEnv("HERMEUM_INGRESS_BASE_HOSTNAME", "agents.example.com");
+    vi.stubEnv("HERMEUM_AGENT_INGRESS_BASE_HOSTNAME", "agents.example.com");
     const { agentToHermesAgent } = await importFresh();
     const hermesAgent = agentToHermesAgent(
       makeAgent({

--- a/apps/dashboard/src/server/infras/kubernetes/client.ts
+++ b/apps/dashboard/src/server/infras/kubernetes/client.ts
@@ -226,13 +226,15 @@ export function agentToHermesAgent(agent: Agent): HermesAgent {
       ...(config.ingressClassName !== undefined && { className: config.ingressClassName }),
       annotations: {},
       hosts: [{ host, paths: ingressPaths }],
-      ...(config.ingressScheme === "https" && {
+      // TLS is emitted only when a TLS secret name is configured — i.e. TLS is
+      // terminated at the ingress controller. When unset, no tls block is
+      // emitted, which covers both plain HTTP and load-balancer-terminated TLS
+      // (the LB handles the cert; the ingress receives plain HTTP).
+      ...(config.ingressTlsSecretName !== undefined && {
         tls: [
           {
             hosts: [host],
-            ...(config.ingressTlsSecretName !== undefined && {
-              secretName: config.ingressTlsSecretName,
-            }),
+            secretName: config.ingressTlsSecretName,
           },
         ],
       }),

--- a/apps/dashboard/src/server/infras/kubernetes/client.ts
+++ b/apps/dashboard/src/server/infras/kubernetes/client.ts
@@ -30,6 +30,8 @@ import {
   HermesAgentList,
   HermesAgentSpec,
   HermesConfig,
+  Ingress,
+  IngressPath,
   ServicePort,
 } from "./types/hermes-agent";
 
@@ -202,8 +204,47 @@ export function agentToHermesAgent(agent: Agent): HermesAgent {
       protocol: "TCP",
     });
   }
+  // Ingress is generated only when the operator configures a base hostname —
+  // routing inbound traffic from message platforms (api-server, webhook) to
+  // the agent's Service. Host takes the form <agent-id>.<base-hostname>.
+  let ingress: Ingress | undefined;
+  if (servicePorts.length > 0 && config.ingressBaseHostname !== undefined) {
+    const host = `${agent.id}.${config.ingressBaseHostname}`;
+    const ingressPaths: IngressPath[] = [];
+    if (webhookPort !== null) {
+      ingressPaths.push({ path: "/webhooks", pathType: "Prefix", port: webhookPort });
+    }
+    if (apiServerPort !== null) {
+      ingressPaths.push(
+        { path: "/api", pathType: "Prefix", port: apiServerPort },
+        { path: "/v1", pathType: "Prefix", port: apiServerPort },
+        { path: "/health", pathType: "Prefix", port: apiServerPort }
+      );
+    }
+    ingress = {
+      enabled: true,
+      ...(config.ingressClassName !== undefined && { className: config.ingressClassName }),
+      annotations: {},
+      hosts: [{ host, paths: ingressPaths }],
+      ...(config.ingressScheme === "https" && {
+        tls: [
+          {
+            hosts: [host],
+            ...(config.ingressTlsSecretName !== undefined && {
+              secretName: config.ingressTlsSecretName,
+            }),
+          },
+        ],
+      }),
+    };
+  }
   const networking =
-    servicePorts.length > 0 ? { service: { ports: servicePorts } } : undefined;
+    servicePorts.length > 0
+      ? {
+          service: { ports: servicePorts },
+          ...(ingress !== undefined && { ingress }),
+        }
+      : undefined;
   if (agent.sharedEnvSets !== undefined) {
     hermes.envFrom = agent.sharedEnvSets.map((name) => ({ secretRef: { name } }));
   }

--- a/apps/dashboard/src/server/infras/kubernetes/client.ts
+++ b/apps/dashboard/src/server/infras/kubernetes/client.ts
@@ -208,8 +208,8 @@ export function agentToHermesAgent(agent: Agent): HermesAgent {
   // routing inbound traffic from message platforms (api-server, webhook) to
   // the agent's Service. Host takes the form <agent-id>.<base-hostname>.
   let ingress: Ingress | undefined;
-  if (servicePorts.length > 0 && config.ingressBaseHostname !== undefined) {
-    const host = `${agent.id}.${config.ingressBaseHostname}`;
+  if (servicePorts.length > 0 && config.agentIngressBaseHostname !== undefined) {
+    const host = `${agent.id}.${config.agentIngressBaseHostname}`;
     const ingressPaths: IngressPath[] = [];
     if (webhookPort !== null) {
       ingressPaths.push({ path: "/webhooks", pathType: "Prefix", port: webhookPort });
@@ -223,18 +223,18 @@ export function agentToHermesAgent(agent: Agent): HermesAgent {
     }
     ingress = {
       enabled: true,
-      ...(config.ingressClassName !== undefined && { className: config.ingressClassName }),
+      ...(config.agentIngressClassName !== undefined && { className: config.agentIngressClassName }),
       annotations: {},
       hosts: [{ host, paths: ingressPaths }],
       // TLS is emitted only when a TLS secret name is configured — i.e. TLS is
       // terminated at the ingress controller. When unset, no tls block is
       // emitted, which covers both plain HTTP and load-balancer-terminated TLS
       // (the LB handles the cert; the ingress receives plain HTTP).
-      ...(config.ingressTlsSecretName !== undefined && {
+      ...(config.agentIngressTlsSecretName !== undefined && {
         tls: [
           {
             hosts: [host],
-            secretName: config.ingressTlsSecretName,
+            secretName: config.agentIngressTlsSecretName,
           },
         ],
       }),

--- a/apps/dashboard/src/server/libs/config.ts
+++ b/apps/dashboard/src/server/libs/config.ts
@@ -16,6 +16,10 @@ export const ConfigSchema = z.object({
   openaiModel: z.string().min(1).default("gpt-5.5"),
   openaiBaseUrl: z.url().optional(),
   debugMode: z.preprocess((v) => v === "true", z.boolean()).default(false),
+  ingressScheme: z.enum(["http", "https"]).default("http"),
+  ingressBaseHostname: z.string().optional(),
+  ingressClassName: z.string().optional(),
+  ingressTlsSecretName: z.string().optional(),
 });
 
 export const config = ConfigSchema.parse({
@@ -31,4 +35,8 @@ export const config = ConfigSchema.parse({
   openaiModel: process.env.HERMEUM_OPENAI_MODEL,
   openaiBaseUrl: process.env.HERMEUM_OPENAI_BASE_URL,
   debugMode: process.env.HERMEUM_DEBUG_MODE,
+  ingressScheme: process.env.HERMEUM_INGRESS_SCHEME,
+  ingressBaseHostname: process.env.HERMEUM_INGRESS_BASE_HOSTNAME,
+  ingressClassName: process.env.HERMEUM_INGRESS_CLASS_NAME,
+  ingressTlsSecretName: process.env.HERMEUM_INGRESS_TLS_SECRET_NAME,
 });

--- a/apps/dashboard/src/server/libs/config.ts
+++ b/apps/dashboard/src/server/libs/config.ts
@@ -4,22 +4,83 @@ import { z } from "zod";
 loadEnv();
 
 export const ConfigSchema = z.object({
-  agentConfigPath: z.string().default("./agent-config.yaml"),
-  docsPath: z.string().default("./docs/hermes-config"),
-  databaseDialect: z.enum(["postgres", "sqlite"]).default("sqlite"),
-  databaseUrl: z.url(),
-  kubernetesNamespace: z.string().default("hermeum"),
-  smtpUrl: z.url().optional(),
-  allowedEmailDomain: z.string().optional(),
-  hermesImageRepository: z.string().default("nousresearch/hermes-agent"),
-  hermesImageTag: z.string().default("v2026.7.7.2"),
-  openaiModel: z.string().min(1).default("gpt-5.5"),
-  openaiBaseUrl: z.url().optional(),
-  debugMode: z.preprocess((v) => v === "true", z.boolean()).default(false),
-  ingressScheme: z.enum(["http", "https"]).default("http"),
-  ingressBaseHostname: z.string().optional(),
-  ingressClassName: z.string().optional(),
-  ingressTlsSecretName: z.string().optional(),
+  agentConfigPath: z
+    .string()
+    .default("./agent-config.yaml")
+    .describe("Path to the agent templates config file (HERMEUM_CONFIG_PATH)."),
+  docsPath: z
+    .string()
+    .default("./docs/hermes-config")
+    .describe("Path to the hermes-config docs directory (HERMEUM_DOCS_PATH)."),
+  databaseDialect: z
+    .enum(["postgres", "sqlite"])
+    .default("sqlite")
+    .describe("Database backend dialect (HERMEUM_DATABASE_DIALECT)."),
+  databaseUrl: z
+    .url()
+    .describe("Connection URL for the dashboard database (HERMEUM_DATABASE_URL)."),
+  kubernetesNamespace: z
+    .string()
+    .default("hermeum")
+    .describe("Kubernetes namespace where HermesAgent CRs are reconciled (HERMEUM_KUBERNETES_NAMESPACE)."),
+  smtpUrl: z
+    .url()
+    .optional()
+    .describe("SMTP server URL for outgoing email (HERMEUM_SMTP_URL)."),
+  allowedEmailDomain: z
+    .string()
+    .optional()
+    .describe("Restrict sign-ups to this email domain (HERMEUM_ALLOWED_EMAIL_DOMAIN)."),
+  hermesImageRepository: z
+    .string()
+    .default("nousresearch/hermes-agent")
+    .describe("Container image repository for the Hermes agent (HERMEUM_HERMES_IMAGE_REPOSITORY)."),
+  hermesImageTag: z
+    .string()
+    .default("v2026.7.7.2")
+    .describe("Container image tag for the Hermes agent (HERMEUM_HERMES_IMAGE_TAG)."),
+  openaiModel: z
+    .string()
+    .min(1)
+    .default("gpt-5.5")
+    .describe("OpenAI model id used by the AI config generator (HERMEUM_OPENAI_MODEL)."),
+  openaiBaseUrl: z
+    .url()
+    .optional()
+    .describe("Override the OpenAI API base URL (HERMEUM_OPENAI_BASE_URL)."),
+  debugMode: z
+    .preprocess((v) => v === "true", z.boolean())
+    .default(false)
+    .describe("Enable verbose debug logging (HERMEUM_DEBUG_MODE)."),
+  agentIngressScheme: z
+    .enum(["http", "https"])
+    .default("http")
+    .describe(
+      "Public URL scheme advertised for agent ingresses (HERMEUM_AGENT_INGRESS_SCHEME). " +
+        "Display-only — does not drive the emitted tls block; TLS is governed by agentIngressTlsSecretName."
+    ),
+  agentIngressBaseHostname: z
+    .string()
+    .optional()
+    .describe(
+      "Base hostname for per-agent ingresses (<agent-id>.<base>) (HERMEUM_AGENT_INGRESS_BASE_HOSTNAME). " +
+        "When unset, no ingress is generated."
+    ),
+  agentIngressClassName: z
+    .string()
+    .optional()
+    .describe(
+      "Ingress controller class name to set on generated ingresses (HERMEUM_AGENT_INGRESS_CLASS_NAME). " +
+        "Omitted from the CR when unset."
+    ),
+  agentIngressTlsSecretName: z
+    .string()
+    .optional()
+    .describe(
+      "TLS secret name for controller-terminated TLS (HERMEUM_AGENT_INGRESS_TLS_SECRET_NAME). " +
+        "When set, the ingress emits a tls block with this secret; when unset, no tls block is " +
+        "emitted (covers plain HTTP and load-balancer-terminated TLS)."
+    ),
 });
 
 export const config = ConfigSchema.parse({
@@ -35,8 +96,8 @@ export const config = ConfigSchema.parse({
   openaiModel: process.env.HERMEUM_OPENAI_MODEL,
   openaiBaseUrl: process.env.HERMEUM_OPENAI_BASE_URL,
   debugMode: process.env.HERMEUM_DEBUG_MODE,
-  ingressScheme: process.env.HERMEUM_INGRESS_SCHEME,
-  ingressBaseHostname: process.env.HERMEUM_INGRESS_BASE_HOSTNAME,
-  ingressClassName: process.env.HERMEUM_INGRESS_CLASS_NAME,
-  ingressTlsSecretName: process.env.HERMEUM_INGRESS_TLS_SECRET_NAME,
+  agentIngressScheme: process.env.HERMEUM_AGENT_INGRESS_SCHEME,
+  agentIngressBaseHostname: process.env.HERMEUM_AGENT_INGRESS_BASE_HOSTNAME,
+  agentIngressClassName: process.env.HERMEUM_AGENT_INGRESS_CLASS_NAME,
+  agentIngressTlsSecretName: process.env.HERMEUM_AGENT_INGRESS_TLS_SECRET_NAME,
 });


### PR DESCRIPTION
## Summary

Generates a per-agent Kubernetes ingress routing inbound traffic from message platforms (api-server, webhook) to the agent's Service when an operator configures a base hostname.

## Routes

| Path | Platform |
|------|----------|
| `/webhooks` | webhook (when enabled) |
| `/api`, `/v1`, `/health` | api-server (when enabled) |

Routes are emitted only for enabled platforms; `pathType: Prefix` for all.

## Host

`<agent-id>.<agent-ingress-base-hostname>` — gates generation: when `HERMEUM_AGENT_INGRESS_BASE_HOSTNAME` is unset, no ingress is emitted (current behavior preserved).

## New config env vars

| Variable | Purpose |
|----------|---------|
| `HERMEUM_AGENT_INGRESS_SCHEME` | Public URL scheme (`http`\|`https`, default `http`). Display-only — does not drive the `tls` block. |
| `HERMEUM_AGENT_INGRESS_BASE_HOSTNAME` | Base hostname for per-agent ingresses. Gates ingress generation. |
| `HERMEUM_AGENT_INGRESS_CLASS_NAME` | Ingress controller class name. Omitted from the CR when unset. |
| `HERMEUM_AGENT_INGRESS_TLS_SECRET_NAME` | TLS secret name for controller-terminated TLS. |

## TLS handling

TLS is driven solely by `HERMEUM_AGENT_INGRESS_TLS_SECRET_NAME`, decoupled from `scheme` so that load-balancer-terminated TLS works naturally:

- **Set** → `tls: [{ hosts: [host], secretName }]` (TLS terminated at the ingress controller)
- **Unset** → no `tls` block (covers plain HTTP AND load-balancer-terminated TLS, where the LB owns the cert and the ingress receives plain HTTP)

This decoupling means `scheme=https` no longer implies a `tls` block on the ingress resource — which was wrong for LB-terminated setups where the public URL is `https://...` but the ingress itself terminates HTTP.

## Tests

Added 10 ingress wiring tests in `client.test.ts` covering both-platforms, single-platform, http/https, className, and host composition. Tests use `vi.stubEnv` + `vi.resetModules()` + dynamic `import()` to vary env vars per case (since `config` is a module-level singleton parsed at import time).

## Verification

- `pnpm --filter @hermeum/dashboard typecheck` ✅
- `pnpm --filter @hermeum/dashboard lint` ✅ (no new warnings)
- `pnpm --filter @hermeum/dashboard test -- src/server/infras/kubernetes/client.test.ts` ✅ (56/56)