### PR TITLE
refactor(chat): decouple usecase from ai-sdk via neutral Tool entity

### DIFF
--- a/apps/dashboard/src/entities/chat.ts
+++ b/apps/dashboard/src/entities/chat.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+
+// Framework-neutral tool port consumed by use cases. Adapters at the router
+// boundary convert these into a specific AI library's tool representation; use
+// cases never import a framework directly. Zod remains the schema language
+// (project standard — field semantics live in `.describe()` texts).
+
+export interface ToolExecutionOptions {
+  signal?: AbortSignal;
+}
+
+// Defaults are `any` (not `unknown`) so a specific `Tool<SpecificInput, X>`
+// stays assignable to `ToolSet`'s element type: `any` makes the `execute`
+// parameter bivariant, sidestepping the contravariance that bites `unknown`.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export interface Tool<INPUT = any, OUTPUT = any> {
+  description?: string;
+  inputSchema: z.ZodType<INPUT>;
+  execute?: (
+    input: INPUT,
+    options: ToolExecutionOptions
+  ) => Promise<OUTPUT> | OUTPUT;
+}
+
+export type ToolSet = Record<string, Tool>;
+
+// Factory preserving inference ergonomics: INPUT is inferred from
+// `inputSchema`, OUTPUT from `execute`'s return type (defaulting to `never` for
+// client-side tools that omit `execute`).
+export function tool<INPUT, OUTPUT = never>(t: {
+  description?: string;
+  inputSchema: z.ZodType<INPUT>;
+  execute?: (
+    input: INPUT,
+    options: ToolExecutionOptions
+  ) => Promise<OUTPUT> | OUTPUT;
+}): Tool<INPUT, OUTPUT> {
+  return t;
+}

--- a/apps/dashboard/src/entities/index.ts
+++ b/apps/dashboard/src/entities/index.ts
@@ -4,3 +4,4 @@ export * from "./template";
 export * from "./hermeum-config";
 export * from "./shared-env-set";
 export * from "./hermes-config";
+export * from "./chat";

--- a/apps/dashboard/src/server/routers/ai-sdk/agent-config.ts
+++ b/apps/dashboard/src/server/routers/ai-sdk/agent-config.ts
@@ -1,13 +1,24 @@
 import { Router } from "express";
 import { createOpenAI } from "@ai-sdk/openai";
-import { convertToModelMessages, streamText, UIMessage } from "ai";
+import { convertToModelMessages, streamText, UIMessage, type ToolSet as AiToolSet } from "ai";
 import { fromNodeHeaders } from "better-auth/node";
 import { z } from "zod";
 
-import { AgentInputObjectSchema } from "@/entities";
+import { AgentInputObjectSchema, type ToolSet } from "@/entities";
 import { config } from "@/server/libs/config";
 import { auth } from "@/server/routers/better-auth/auth.js";
 import { ChatUseCase } from "@/server/usecases/chat";
+
+// Adapts the framework-neutral ToolSet (entity) into ai-sdk's ToolSet at the
+// framework boundary. ai-sdk's `tool()` is an identity at runtime; the entity
+// Tool's shape (description + inputSchema + optional execute) is structurally
+// compatible with ai-sdk's FunctionTool, so a cast is sufficient and avoids the
+// `tool()` factory's INPUT-inference overloads (which can't recover a specific
+// INPUT from a ToolSet element widened to `Tool<any>`). Use cases depend only
+// on the entity port; ai-sdk stays confined to this router.
+function toAiToolSet(tools: ToolSet): AiToolSet {
+  return tools as unknown as AiToolSet;
+}
 
 const ChatRequestSchema = z.object({
   messages: z.array(z.custom<UIMessage>()),
@@ -53,7 +64,7 @@ aiSdkRouter.post("/agent-config", async (req, res) => {
     model: model(),
     system: `${instructions}\n\n${prompt}`,
     messages: await convertToModelMessages(parsed.data.messages),
-    tools,
+    tools: toAiToolSet(tools),
     // AgentInputObjectSchema uses looseObject/record/optionals, which strict
     // JSON schema mode rejects; Responses API models default it to true.
     providerOptions: {

--- a/apps/dashboard/src/server/usecases/chat.test.ts
+++ b/apps/dashboard/src/server/usecases/chat.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import type { ToolExecutionOptions } from "ai";
+import type { ToolExecutionOptions } from "@/entities";
 import { stringify } from "yaml";
 
 vi.mock("../infras/local-files", () => ({ LocalFiles: vi.fn() }));
@@ -81,7 +81,7 @@ function makeFiles(
   };
 }
 
-const callOptions = {} as ToolExecutionOptions<never>;
+const callOptions = {} as ToolExecutionOptions;
 
 function makeSkillIndex(results: SkillSearchResult[] = []): SkillIndexAdaptor {
   return {

--- a/apps/dashboard/src/server/usecases/chat.ts
+++ b/apps/dashboard/src/server/usecases/chat.ts
@@ -1,7 +1,6 @@
-import { tool, ToolSet } from "ai";
 import { z } from "zod";
 
-import { AgentInput, AgentInputObjectSchema } from "@/entities";
+import { AgentInput, AgentInputObjectSchema, tool, ToolSet } from "@/entities";
 import { config } from "@/server/libs/config";
 
 import { BaseUseCase, HermeumConfigLoadable } from "./mixin";


### PR DESCRIPTION
## Summary

`ChatUseCase` imported `tool` and `ToolSet` directly from `ai` (ai-sdk), coupling the usecase to a specific framework. This introduces a framework-neutral tool port as an entity and pushes ai-sdk to the router boundary.

## Changes

- **New entity** `src/entities/chat.ts`: defines `Tool`, `ToolSet`, `ToolExecutionOptions`, and a `tool()` factory preserving INPUT/OUTPUT inference ergonomics. Zod stays the schema language (project standard; field semantics live in `.describe()` texts per AGENTS.md).
- **`src/server/usecases/chat.ts`**: imports `tool`/`ToolSet` from `@/entities` instead of `ai`. No logic changes.
- **`src/server/routers/ai-sdk/agent-config.ts`**: adds `toAiToolSet()` adapting the entity `ToolSet` into ai-sdk's `ToolSet` at the framework boundary. ai-sdk is now confined to this single router file.
- **`src/server/usecases/chat.test.ts`**: imports `ToolExecutionOptions` from `@/entities`.

## Design notes

- Defaults are `any` (not `unknown`) so a specific `Tool<SpecificInput, X>` stays assignable to `ToolSet`'s element type — `any` makes the `execute` parameter bivariant, sidestepping the contravariance that bites `unknown` under `exactOptionalPropertyTypes: true`. An eslint-disable follows the existing `mixin.ts:23` precedent.
- ai-sdk's `tool()` is an identity at runtime and the entity `Tool` shape is structurally compatible with ai-sdk's `FunctionTool`, so the adapter casts rather than re-running the factory (whose INPUT-inference overloads can't recover a specific INPUT from a `ToolSet` element widened to `Tool<any>`).
- ai-sdk's optional lifecycle hooks (`onInputStart`, `onInputDelta`, `needsApproval`, `toModelOutput`) are deliberately omitted; none are used by the chat tools today, and keeping them out holds the port minimal and truly framework-neutral.

## Verification

- `pnpm --filter @hermeum/dashboard typecheck` — clean
- `pnpm --filter @hermeum/dashboard lint` — clean (2 pre-existing unrelated warnings)
- `pnpm --filter @hermeum/dashboard test` — all 245 tests pass