### PR TITLE
feat(agents): show agent endpoint on detail page

### DIFF
--- a/apps/dashboard/src/client/ui/routes/agents/$id/index.tsx
+++ b/apps/dashboard/src/client/ui/routes/agents/$id/index.tsx
@@ -1,14 +1,13 @@
 import { useState } from "react";
 import { useMutation, useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { Eye, EyeOff, Info, MoreHorizontal, RefreshCw } from "lucide-react";
+import { Info, MoreHorizontal, RefreshCw } from "lucide-react";
 import { stringify as stringifyYaml } from "yaml";
 import { toast } from "sonner";
 
 import { Badge } from "@hermeum/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@hermeum/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@hermeum/components/ui/tooltip";
-import { authClient } from "@/client/auth-client";
 import { useTRPC } from "@/router";
 import {
   TOOL_IDS,
@@ -223,12 +222,6 @@ function AgentDetailPage() {
     isFetching,
     error,
   } = useQuery(trpc.agent.get.queryOptions({ id }));
-  const { data: session } = authClient.useSession();
-  const isOwner = !!session?.user && session.user.id === agent?.userId;
-  const { data: gatewayToken } = useQuery({
-    ...trpc.agent.getGatewayToken.queryOptions({ id }),
-    enabled: isOwner,
-  });
   const envSetIds = agent?.sharedEnvSets ?? [];
   const envSetQueries = useQueries({
     queries: envSetIds.map((setId) => ({
@@ -241,7 +234,6 @@ function AgentDetailPage() {
     .filter((s): s is NonNullable<typeof s> => s != null);
   const [editOpen, setEditOpen] = useState(false);
   const [archiveOpen, setArchiveOpen] = useState(false);
-  const [tokenVisible, setTokenVisible] = useState(false);
 
   const invalidateDetail = () =>
     queryClient.invalidateQueries({ queryKey: trpc.agent.get.queryKey({ id }) });
@@ -283,7 +275,7 @@ function AgentDetailPage() {
     <div className="flex flex-col gap-6 p-6">
       {/* Header */}
       <div className="flex items-start justify-between gap-4">
-        <div className="flex flex-col gap-1">
+        <div className="flex flex-col gap-0.5">
           <div className="flex items-center gap-3">
             <h1 className="text-2xl font-bold">{agent.name ?? agent.id}</h1>
             {agent.archived ? (
@@ -298,6 +290,12 @@ function AgentDetailPage() {
           </div>
           {agent.description && (
             <p className="text-sm text-muted-foreground mt-1">{agent.description}</p>
+          )}
+          {agent.endpoint && (
+            <div className="group mt-1 flex items-center gap-1">
+              <span className="text-sm text-muted-foreground font-mono">{agent.endpoint}</span>
+              <CopyButton text={agent.endpoint} className="opacity-0 group-hover:opacity-100" />
+            </div>
           )}
           {agent.type && (
             <p className="text-sm text-muted-foreground mt-1">
@@ -349,7 +347,6 @@ function AgentDetailPage() {
       <Tabs defaultValue="agent">
         <TabsList variant="line">
           <TabsTrigger value="agent">Agent</TabsTrigger>
-          <TabsTrigger value="connect">Connect</TabsTrigger>
         </TabsList>
 
         <TabsContent value="agent">
@@ -378,7 +375,7 @@ function AgentDetailPage() {
 
             {/* tools */}
             <ToolsSection agent={agent} />
-            
+
             {/* message platforms */}
             <PlatformsSection agent={agent} />
 
@@ -409,7 +406,7 @@ function AgentDetailPage() {
 
             {agent.packages?.npm && agent.packages.npm.length > 0 && (
               <div className="py-8 flex flex-col gap-3">
-                <p className="text-sm font-bold">npm Packages</p>
+                <p className="text-sm font-bold">NPM Packages</p>
                 <ButtonList items={agent.packages.npm} max={10} />
               </div>
             )}
@@ -481,31 +478,6 @@ function AgentDetailPage() {
                 <p className="text-sm text-muted-foreground">No shared env sets attached.</p>
               )}
             </div>
-          </div>
-        </TabsContent>
-
-        <TabsContent value="connect">
-          <div className="flex flex-col divide-y">
-            {gatewayToken && (
-              <div className="py-8 flex flex-col gap-3">
-                <p className="text-sm font-bold">Gateway Token</p>
-                <div className="group flex items-center gap-2">
-                  <span className="font-mono text-sm text-muted-foreground">
-                    {tokenVisible ? gatewayToken : "•".repeat(32)}
-                  </span>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="size-6 opacity-0 group-hover:opacity-100"
-                    onClick={() => setTokenVisible((v) => !v)}
-                    aria-label={tokenVisible ? "Hide token" : "Show token"}
-                  >
-                    {tokenVisible ? <EyeOff className="size-3" /> : <Eye className="size-3" />}
-                  </Button>
-                  <CopyButton text={gatewayToken} className="opacity-0 group-hover:opacity-100" />
-                </div>
-              </div>
-            )}
           </div>
         </TabsContent>
       </Tabs>

--- a/apps/dashboard/src/entities/agent.ts
+++ b/apps/dashboard/src/entities/agent.ts
@@ -656,6 +656,8 @@ export const AgentSchema = AgentInputObjectSchema.extend({
   suspended: z.boolean().optional(),
   archived: z.boolean().optional(),
   phase: AgentPhaseSchema.optional(),
+  // Public base URL of the agent's ingress. Output-only; null when no ingress.
+  endpoint: z.string().url().nullable().optional(),
   createdAt: z.date().optional(),
 }).readonly();
 

--- a/apps/dashboard/src/server/infras/kubernetes/client.test.ts
+++ b/apps/dashboard/src/server/infras/kubernetes/client.test.ts
@@ -606,7 +606,7 @@ describe("agentToHermesAgent ingress wiring", () => {
 
   it("builds the host from the agent id and base hostname", async () => {
     vi.stubEnv("HERMEUM_AGENT_INGRESS_BASE_HOSTNAME", "agents.example.com");
-    const { agentToHermesAgent } = await importFresh();
+    const { agentToHermesAgent, mapHermesAgent } = await importFresh();
     const hermesAgent = agentToHermesAgent(
       makeAgent({
         id: "agent-42",
@@ -615,6 +615,77 @@ describe("agentToHermesAgent ingress wiring", () => {
     );
     expect(hermesAgent.spec.networking?.ingress?.hosts?.[0]?.host).toBe(
       "agent-42.agents.example.com"
+    );
+    expect(mapHermesAgent(hermesAgent).endpoint).toBe(
+      "http://agent-42.agents.example.com"
+    );
+  });
+});
+
+describe("buildAgentEndpoint", () => {
+  const ENV_VARS = [
+    "HERMEUM_AGENT_INGRESS_SCHEME",
+    "HERMEUM_AGENT_INGRESS_BASE_HOSTNAME",
+  ];
+  const ORIGINAL: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const k of ENV_VARS) ORIGINAL[k] = process.env[k];
+  });
+
+  afterEach(() => {
+    for (const k of ENV_VARS) {
+      if (ORIGINAL[k] === undefined) delete process.env[k];
+      else process.env[k] = ORIGINAL[k];
+    }
+    vi.resetModules();
+    vi.unstubAllEnvs();
+  });
+
+  async function importFresh(): Promise<typeof import("./client")> {
+    vi.resetModules();
+    return (await import("./client")) as typeof import("./client");
+  }
+
+  function makeHermesAgentWithIngress(host: string | undefined): HermesAgent {
+    return {
+      spec: {
+        networking: {
+          ingress: {
+            enabled: true,
+            hosts: host
+              ? [{ host, paths: [{ path: "/api", pathType: "Prefix", port: 8642 }] }]
+              : undefined,
+          },
+        },
+      },
+    } as unknown as HermesAgent;
+  }
+
+  it("returns the scheme + host URL when an ingress host is present", async () => {
+    vi.stubEnv("HERMEUM_AGENT_INGRESS_BASE_HOSTNAME", "agents.example.com");
+    const { buildAgentEndpoint } = await importFresh();
+    expect(buildAgentEndpoint(makeHermesAgentWithIngress("agent-1.agents.example.com"))).toBe(
+      "http://agent-1.agents.example.com"
+    );
+  });
+
+  it("returns null when the CR has no ingress host", async () => {
+    const { buildAgentEndpoint } = await importFresh();
+    expect(buildAgentEndpoint(makeHermesAgentWithIngress(undefined))).toBeNull();
+  });
+
+  it("returns null when the CR has no networking.ingress at all", async () => {
+    const { buildAgentEndpoint } = await importFresh();
+    expect(buildAgentEndpoint({ spec: {} } as unknown as HermesAgent)).toBeNull();
+  });
+
+  it("honours agentIngressScheme when set to https", async () => {
+    vi.stubEnv("HERMEUM_AGENT_INGRESS_BASE_HOSTNAME", "agents.example.com");
+    vi.stubEnv("HERMEUM_AGENT_INGRESS_SCHEME", "https");
+    const { buildAgentEndpoint } = await importFresh();
+    expect(buildAgentEndpoint(makeHermesAgentWithIngress("agent-1.agents.example.com"))).toBe(
+      "https://agent-1.agents.example.com"
     );
   });
 });

--- a/apps/dashboard/src/server/infras/kubernetes/client.ts
+++ b/apps/dashboard/src/server/infras/kubernetes/client.ts
@@ -303,6 +303,19 @@ export function mapHermesConfig(config: HermesConfig | undefined): Agent["config
   return config?.raw;
 }
 
+// Derive the agent's public endpoint URL from the reconciled ingress host.
+// The host is written into spec.networking.ingress by agentToHermesAgent only
+// when at least one HTTP platform (api-server / webhook) is enabled AND the
+// operator has configured agentIngressBaseHostname — so a null return here
+// exactly mirrors "no public endpoint exists for this agent / deployment".
+// The scheme comes from agentIngressScheme (display-only; TLS is governed
+// separately by agentIngressTlsSecretName).
+export function buildAgentEndpoint(raw: HermesAgent): string | null {
+  const host = raw.spec.networking?.ingress?.hosts?.[0]?.host;
+  if (!host) return null;
+  return `${config.agentIngressScheme}://${host}`;
+}
+
 export function mapHermesAgent(raw: HermesAgent): Agent {
   return {
     id: raw.metadata?.name ?? "",
@@ -311,6 +324,7 @@ export function mapHermesAgent(raw: HermesAgent): Agent {
     description: raw.metadata?.annotations?.[HermeumAnnotation.Description],
     type: raw.metadata?.annotations?.[HermeumAnnotation.Type],
     config: mapHermesConfig(raw.spec.hermes?.config),
+    endpoint: buildAgentEndpoint(raw),
     sharedEnvSets: raw.spec.hermes?.envFrom?.flatMap((e) =>
       e.secretRef?.name ? [e.secretRef.name] : []
     ),


### PR DESCRIPTION
## Summary

Surface the agent's public endpoint URL on the agent detail page so users know how to reach its API server and webhook.

## Changes

- **`entities/agent.ts`** — Add an output-only `endpoint: string | null` field to `AgentSchema` (not to `AgentInputObjectSchema`, so it can't be set via create/update). Null when no ingress is configured.
- **`server/infras/kubernetes/client.ts`** — Add `buildAgentEndpoint(raw)`, a pure helper that reads the reconciled ingress host off the `HermesAgent` CR and prepends `agentIngressScheme`. Wired into `mapHermesAgent` so every agent returned by the k8s runtime carries `endpoint`. No new tRPC procedure needed — it rides on the existing `agent.get` query.
- **`client/ui/routes/agents/$id/index.tsx`** — Display the endpoint in the agent detail header (below the description, with a hover-revealed copy button). Remove the **Connect** tab (and its gateway-token block) plus the now-unused state/imports (`tokenVisible`, gateway token query, `isOwner`/`session`, `Eye`/`EyeOff`, `authClient`). Tabs kept with the single **Agent** tab.

The endpoint is derived from the same host string that `agentToHermesAgent` already writes into `spec.networking.ingress` at `client.ts:212`, so the CR-emission path and the UI share one source of truth. It's `null` when no base hostname is configured (no ingress generated) or no HTTP platform is enabled — in which case the endpoint row is hidden.

## Test plan

- [x] `pnpm --filter @hermeum/dashboard typecheck`
- [x] `pnpm --filter @hermeum/dashboard lint`
- [x] `pnpm --filter @hermeum/dashboard test` (249 passing)
- New `buildAgentEndpoint` test block: scheme+host URL, null on no host, null on no networking, https scheme override
- Extended the existing host-building test to assert `mapHermesAgent(...).endpoint`