### PR TITLE
feat(agents): show phase reason on agent detail page

### DIFF
--- a/apps/dashboard/src/client/ui/components/phase-badge.tsx
+++ b/apps/dashboard/src/client/ui/components/phase-badge.tsx
@@ -18,10 +18,11 @@ function phaseClass(phase: AgentPhase | undefined): string {
 
 interface PhaseBadgeProps {
   phase: AgentPhase | undefined;
+  reason?: string | undefined;
   className?: string;
 }
 
-export function PhaseBadge({ phase, className }: PhaseBadgeProps) {
+export function PhaseBadge({ phase, reason, className }: PhaseBadgeProps) {
   if (!phase) return null;
   return (
     <span
@@ -32,6 +33,7 @@ export function PhaseBadge({ phase, className }: PhaseBadgeProps) {
       )}
     >
       {phase}
+      {reason && <span className="font-normal opacity-80">&nbsp;by&nbsp;{reason}</span>}
     </span>
   );
 }

--- a/apps/dashboard/src/client/ui/routes/agents/$id/index.tsx
+++ b/apps/dashboard/src/client/ui/routes/agents/$id/index.tsx
@@ -289,7 +289,7 @@ function AgentDetailPage() {
             {agent.archived ? (
               <Badge variant="secondary">Archived</Badge>
             ) : (
-              <PhaseBadge phase={agent.phase} />
+              <PhaseBadge phase={agent.phase} reason={agent.reason} />
             )}
           </div>
           <div className="group flex items-center gap-1">

--- a/apps/dashboard/src/entities/agent.ts
+++ b/apps/dashboard/src/entities/agent.ts
@@ -656,6 +656,7 @@ export const AgentSchema = AgentInputObjectSchema.extend({
   suspended: z.boolean().optional(),
   archived: z.boolean().optional(),
   phase: AgentPhaseSchema.optional(),
+  reason: z.string().optional(),
   createdAt: z.date().optional(),
 }).readonly();
 

--- a/apps/dashboard/src/server/infras/kubernetes/client.ts
+++ b/apps/dashboard/src/server/infras/kubernetes/client.ts
@@ -337,6 +337,7 @@ export function mapHermesAgent(raw: HermesAgent): Agent {
     suspended: raw.spec.suspend,
     archived: raw.metadata?.labels?.[HermeumLabel.Archived] === "true",
     phase: raw.status?.phase as AgentPhase | undefined,
+    reason: raw.status?.reason,
     createdAt: raw.metadata?.creationTimestamp,
   };
 }


### PR DESCRIPTION
## Summary

Surface the Kubernetes `status.reason` field on the agent detail page so users can see why an agent is in a given phase (e.g. `Pending by ImagePullBackOff`, `Failed by CrashLoopBackOff`).

## Changes

- **`entities/agent.ts`** — add `reason: z.string().optional()` to `AgentSchema`.
- **`server/infras/kubernetes/client.ts`** — `mapHermesAgent` maps `raw.status?.reason`.
- **`client/ui/components/phase-badge.tsx`** — add a `reason` prop rendered inline as `<phase> by <reason>`, keeping the phase-based color.
- **`client/ui/routes/agents/$id/index.tsx`** — pass `agent.reason` to `PhaseBadge`.

## Verification

- `pnpm --filter @hermeum/dashboard typecheck` ✅
- `pnpm --filter @hermeum/dashboard lint` ✅
- `pnpm --filter @hermeum/dashboard test` — 245 passed ✅