### PR TITLE
Refactor: show per-platform endpoints on badge click, support internal Service DNS

### DIFF
--- a/apps/dashboard/src/client/ui/routes/agents/$id/index.tsx
+++ b/apps/dashboard/src/client/ui/routes/agents/$id/index.tsx
@@ -141,7 +141,7 @@ function ToolsSection({ agent }: { agent: Agent }) {
 }
 
 function PlatformBadge({ id, agent }: { id: PlatformId; agent: Agent }) {
-  const { status, reason, port, home, endpoints } = derivePlatformAvailability(id, agent);
+  const { status, reason, home, endpoints } = derivePlatformAvailability(id, agent);
   const label = getPlatformLabel(id);
   const description = getPlatformDescription(id);
   return (
@@ -158,12 +158,6 @@ function PlatformBadge({ id, agent }: { id: PlatformId; agent: Agent }) {
         }
       >
         {label}
-        {status === "available" && port !== undefined && (
-          <span className="text-muted-foreground"> · port {port}</span>
-        )}
-        {status === "available" && home !== undefined && (
-          <span className="text-muted-foreground"> · home {home}</span>
-        )}
       </PopoverTrigger>
       <PopoverContent>
         <div className="flex flex-col gap-0.5">
@@ -181,7 +175,6 @@ function PlatformBadge({ id, agent }: { id: PlatformId; agent: Agent }) {
           {status === "available" && id === "slack" && endpoints === undefined && (
             <span className="opacity-80">Socket Mode — no public endpoint.</span>
           )}
-          {port !== undefined && <span>Port: {port}</span>}
           {home !== undefined && <span>Home channel: {home}</span>}
           {reason && (
             <span className="capitalize opacity-80">

--- a/apps/dashboard/src/client/ui/routes/agents/$id/index.tsx
+++ b/apps/dashboard/src/client/ui/routes/agents/$id/index.tsx
@@ -8,6 +8,7 @@ import { toast } from "sonner";
 import { Badge } from "@hermeum/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@hermeum/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@hermeum/components/ui/tooltip";
+import { Popover, PopoverContent, PopoverTrigger } from "@hermeum/components/ui/popover";
 import { useTRPC } from "@/router";
 import {
   TOOL_IDS,
@@ -140,12 +141,12 @@ function ToolsSection({ agent }: { agent: Agent }) {
 }
 
 function PlatformBadge({ id, agent }: { id: PlatformId; agent: Agent }) {
-  const { status, reason, port, home } = derivePlatformAvailability(id, agent);
+  const { status, reason, port, home, endpoints } = derivePlatformAvailability(id, agent);
   const label = getPlatformLabel(id);
   const description = getPlatformDescription(id);
   return (
-    <Tooltip>
-      <TooltipTrigger
+    <Popover>
+      <PopoverTrigger
         render={
           <Button
             variant="outline"
@@ -163,10 +164,23 @@ function PlatformBadge({ id, agent }: { id: PlatformId; agent: Agent }) {
         {status === "available" && home !== undefined && (
           <span className="text-muted-foreground"> · home {home}</span>
         )}
-      </TooltipTrigger>
-      <TooltipContent>
+      </PopoverTrigger>
+      <PopoverContent>
         <div className="flex flex-col gap-0.5">
           <span>{description}</span>
+          {endpoints !== undefined && endpoints.length > 0 && (
+            <div className="mt-1 flex flex-col gap-1">
+              {endpoints.map((url) => (
+                <div key={url} className="group flex items-center gap-1">
+                  <span className="font-mono">{url}</span>
+                  <CopyButton text={url} className="opacity-0 group-hover:opacity-100" />
+                </div>
+              ))}
+            </div>
+          )}
+          {status === "available" && id === "slack" && endpoints === undefined && (
+            <span className="opacity-80">Socket Mode — no public endpoint.</span>
+          )}
           {port !== undefined && <span>Port: {port}</span>}
           {home !== undefined && <span>Home channel: {home}</span>}
           {reason && (
@@ -175,8 +189,8 @@ function PlatformBadge({ id, agent }: { id: PlatformId; agent: Agent }) {
             </span>
           )}
         </div>
-      </TooltipContent>
-    </Tooltip>
+      </PopoverContent>
+    </Popover>
   );
 }
 
@@ -200,13 +214,11 @@ function PlatformsSection({ agent }: { agent: Agent }) {
           </TooltipContent>
         </Tooltip>
       </div>
-      <TooltipProvider>
-        <div className="flex flex-wrap gap-2">
-          {PLATFORM_IDS.map((id) => (
-            <PlatformBadge key={id} id={id} agent={agent} />
-          ))}
-        </div>
-      </TooltipProvider>
+      <div className="flex flex-wrap gap-2">
+        {PLATFORM_IDS.map((id) => (
+          <PlatformBadge key={id} id={id} agent={agent} />
+        ))}
+      </div>
     </div>
   );
 }
@@ -290,12 +302,6 @@ function AgentDetailPage() {
           </div>
           {agent.description && (
             <p className="text-sm text-muted-foreground mt-1">{agent.description}</p>
-          )}
-          {agent.endpoint && (
-            <div className="group mt-1 flex items-center gap-1">
-              <span className="text-sm text-muted-foreground font-mono">{agent.endpoint}</span>
-              <CopyButton text={agent.endpoint} className="opacity-0 group-hover:opacity-100" />
-            </div>
           )}
           {agent.type && (
             <p className="text-sm text-muted-foreground mt-1">

--- a/apps/dashboard/src/client/ui/routes/agents/$id/index.tsx
+++ b/apps/dashboard/src/client/ui/routes/agents/$id/index.tsx
@@ -159,15 +159,15 @@ function PlatformBadge({ id, agent }: { id: PlatformId; agent: Agent }) {
       >
         {label}
       </PopoverTrigger>
-      <PopoverContent>
+      <PopoverContent className="max-w-sm">
         <div className="flex flex-col gap-0.5">
           <span>{description}</span>
           {endpoints !== undefined && endpoints.length > 0 && (
             <div className="mt-1 flex flex-col gap-1">
               {endpoints.map((url) => (
-                <div key={url} className="group flex items-center gap-1">
-                  <span className="font-mono">{url}</span>
-                  <CopyButton text={url} className="opacity-0 group-hover:opacity-100" />
+                <div key={url} className="group flex min-w-0 items-center gap-1">
+                  <span className="min-w-0 break-all font-mono">{url}</span>
+                  <CopyButton text={url} className="shrink-0 opacity-0 group-hover:opacity-100" />
                 </div>
               ))}
             </div>

--- a/apps/dashboard/src/entities/agent.test.ts
+++ b/apps/dashboard/src/entities/agent.test.ts
@@ -703,6 +703,37 @@ describe("derivePlatformAvailability", () => {
       ]);
     });
 
+    it("inserts the per-platform port into internal (.svc.cluster.local) endpoints", () => {
+      const result = derivePlatformAvailability(
+        PlatformId.ApiServer,
+        makeAgent({
+          endpoint: "http://a1.hermeum.svc.cluster.local",
+          env: [{ name: "API_SERVER_ENABLED", value: "true" }],
+        })
+      );
+      expect(result.endpoints).toEqual([
+        "http://a1.hermeum.svc.cluster.local:8642/v1",
+        "http://a1.hermeum.svc.cluster.local:8642/api",
+      ]);
+    });
+
+    it("inserts a custom API_SERVER_PORT into internal endpoints", () => {
+      const result = derivePlatformAvailability(
+        PlatformId.ApiServer,
+        makeAgent({
+          endpoint: "http://a1.hermeum.svc.cluster.local",
+          env: [
+            { name: "API_SERVER_ENABLED", value: "true" },
+            { name: "API_SERVER_PORT", value: "9000" },
+          ],
+        })
+      );
+      expect(result.endpoints).toEqual([
+        "http://a1.hermeum.svc.cluster.local:9000/v1",
+        "http://a1.hermeum.svc.cluster.local:9000/api",
+      ]);
+    });
+
     it("omits endpoints when agent.endpoint is null", () => {
       const result = derivePlatformAvailability(
         PlatformId.ApiServer,
@@ -762,6 +793,19 @@ describe("derivePlatformAvailability", () => {
         })
       );
       expect(result.endpoints).toEqual(["https://a1.example.com/webhooks"]);
+    });
+
+    it("inserts the webhook port into internal (.svc.cluster.local) endpoints", () => {
+      const result = derivePlatformAvailability(
+        PlatformId.Webhook,
+        makeAgent({
+          endpoint: "http://a1.hermeum.svc.cluster.local",
+          config: { platforms: { webhook: { enabled: true } } },
+        })
+      );
+      expect(result.endpoints).toEqual([
+        "http://a1.hermeum.svc.cluster.local:8644/webhooks",
+      ]);
     });
 
     it("omits endpoints when agent.endpoint is null even when enabled", () => {

--- a/apps/dashboard/src/entities/agent.test.ts
+++ b/apps/dashboard/src/entities/agent.test.ts
@@ -688,6 +688,33 @@ describe("derivePlatformAvailability", () => {
       );
       expect(result).toEqual({ status: "available", port: 9000 });
     });
+
+    it("derives endpoints with /v1 first then /api when agent.endpoint is set", () => {
+      const result = derivePlatformAvailability(
+        PlatformId.ApiServer,
+        makeAgent({
+          endpoint: "https://a1.example.com",
+          env: [{ name: "API_SERVER_ENABLED", value: "true" }],
+        })
+      );
+      expect(result.endpoints).toEqual([
+        "https://a1.example.com/v1",
+        "https://a1.example.com/api",
+      ]);
+    });
+
+    it("omits endpoints when agent.endpoint is null", () => {
+      const result = derivePlatformAvailability(
+        PlatformId.ApiServer,
+        makeAgent({ env: [{ name: "API_SERVER_ENABLED", value: "true" }] })
+      );
+      expect(result.endpoints).toBeUndefined();
+    });
+
+    it("omits endpoints when unavailable", () => {
+      const result = derivePlatformAvailability(PlatformId.ApiServer, makeAgent());
+      expect(result.endpoints).toBeUndefined();
+    });
   });
 
   describe("webhook", () => {
@@ -724,6 +751,25 @@ describe("derivePlatformAvailability", () => {
         })
       );
       expect(result).toEqual({ status: "available", port: 9001 });
+    });
+
+    it("derives the /webhooks endpoint when agent.endpoint is set", () => {
+      const result = derivePlatformAvailability(
+        PlatformId.Webhook,
+        makeAgent({
+          endpoint: "https://a1.example.com",
+          config: { platforms: { webhook: { enabled: true } } },
+        })
+      );
+      expect(result.endpoints).toEqual(["https://a1.example.com/webhooks"]);
+    });
+
+    it("omits endpoints when agent.endpoint is null even when enabled", () => {
+      const result = derivePlatformAvailability(
+        PlatformId.Webhook,
+        makeAgent({ config: { platforms: { webhook: { enabled: true } } } })
+      );
+      expect(result.endpoints).toBeUndefined();
     });
 
     it("is unavailable via config even when the WEBHOOK_ENABLED env var is set", () => {
@@ -773,6 +819,14 @@ describe("derivePlatformAvailability", () => {
     it("is available with no home when all three required env vars are set", () => {
       const result = derivePlatformAvailability(PlatformId.Slack, makeAgent({ env: slackEnv }));
       expect(result).toEqual({ status: "available" });
+    });
+
+    it("never exposes endpoints — Slack uses Socket Mode", () => {
+      const result = derivePlatformAvailability(
+        PlatformId.Slack,
+        makeAgent({ endpoint: "https://a1.example.com", env: slackEnv })
+      );
+      expect(result.endpoints).toBeUndefined();
     });
 
     it("treats the <secret> sentinel for sensitive tokens as set", () => {

--- a/apps/dashboard/src/entities/agent.ts
+++ b/apps/dashboard/src/entities/agent.ts
@@ -563,10 +563,11 @@ export interface PlatformAvailability {
   /** Home channel for chat platforms (slack only), if configured. */
   home?: string;
   /**
-   * Fully-qualified public endpoint URLs for platforms exposed via ingress.
-   * Each entry is `${agent.endpoint}${subpath}`. Absent when the platform
-   * has no inbound HTTP surface (e.g. Slack Socket Mode) or when no ingress
-   * is configured (`agent.endpoint` is null).
+   * Fully-qualified endpoint URLs for this platform (base + subpath).
+   * For ingress endpoints the base carries no port (routing is by path).
+   * For internal (`*.svc.cluster.local`) endpoints the per-platform port is
+   * inserted before the subpath. Absent when the platform has no inbound HTTP
+   * surface (e.g. Slack Socket Mode) or when `agent.endpoint` is null.
    */
   endpoints?: string[];
 }
@@ -631,10 +632,11 @@ export function derivePlatformAvailability(id: PlatformId, agent: Agent): Platfo
       if (!isApiServerEnabled(agent)) {
         return { status: "unavailable", reason: "Set API_SERVER_ENABLED=true to enable." };
       }
+      const port = getApiServerPort(agent);
       return {
         status: "available",
-        port: getApiServerPort(agent),
-        ...endpointsFor(agent.endpoint, subpaths),
+        port,
+        ...endpointsFor(agent.endpoint, subpaths, port),
       };
     }
     case PlatformId.Webhook: {
@@ -644,10 +646,11 @@ export function derivePlatformAvailability(id: PlatformId, agent: Agent): Platfo
           reason: "Set WEBHOOK_ENABLED=true (or config.platforms.webhook.enabled).",
         };
       }
+      const port = getWebhookPort(agent);
       return {
         status: "available",
-        port: getWebhookPort(agent),
-        ...endpointsFor(agent.endpoint, subpaths),
+        port,
+        ...endpointsFor(agent.endpoint, subpaths, port),
       };
     }
     case PlatformId.Slack: {
@@ -673,12 +676,22 @@ export function derivePlatformAvailability(id: PlatformId, agent: Agent): Platfo
 /**
  * Spread helper: returns `{ endpoints }` when both a base endpoint and at
  * least one subpath are present, otherwise `{}` (so the field stays absent).
+ *
+ * Internal endpoints (base containing `.svc.cluster.local`) need the
+ * per-platform port inserted before the subpath, since each platform listens
+ * on its own port. Ingress endpoints route by path on a single host, so no
+ * port is inserted.
  */
 function endpointsFor(
   endpoint: string | null | undefined,
   subpaths: readonly string[] | undefined,
+  port: number | undefined,
 ): { endpoints?: string[] } {
   if (!endpoint || !subpaths || subpaths.length === 0) return {};
+  if (endpoint.includes(".svc.cluster.local")) {
+    if (port === undefined) return {};
+    return { endpoints: subpaths.map((p) => `${endpoint}:${port}${p}`) };
+  }
   return { endpoints: subpaths.map((p) => `${endpoint}${p}`) };
 }
 

--- a/apps/dashboard/src/entities/agent.ts
+++ b/apps/dashboard/src/entities/agent.ts
@@ -562,7 +562,28 @@ export interface PlatformAvailability {
   port?: number;
   /** Home channel for chat platforms (slack only), if configured. */
   home?: string;
+  /**
+   * Fully-qualified public endpoint URLs for platforms exposed via ingress.
+   * Each entry is `${agent.endpoint}${subpath}`. Absent when the platform
+   * has no inbound HTTP surface (e.g. Slack Socket Mode) or when no ingress
+   * is configured (`agent.endpoint` is null).
+   */
+  endpoints?: string[];
 }
+
+/**
+ * Ingress subpaths per platform, ordered by display priority.
+ * `/health` is intentionally excluded — it is an infra health probe, not a
+ * messaging endpoint users interact with. Single source of truth for both
+ * the UI (`derivePlatformAvailability`) and the ingress builder
+ * (`server/infras/kubernetes/client.ts`).
+ */
+export const PLATFORM_INGRESS_SUBPATHS: Partial<Record<PlatformId, string[]>> = {
+  // /v1 is the main OpenAI-compatible path; /api is the generic alias.
+  [PlatformId.ApiServer]: ["/v1", "/api"],
+  [PlatformId.Webhook]: ["/webhooks"],
+  // Slack uses Socket Mode — no inbound HTTP subpath.
+};
 
 interface PlatformMeta {
   label: string;
@@ -603,13 +624,18 @@ const SLACK_REQUIRED_ENV_VARS = ["SLACK_BOT_TOKEN", "SLACK_APP_TOKEN", "SLACK_AL
 
 export function derivePlatformAvailability(id: PlatformId, agent: Agent): PlatformAvailability {
   const env = agent.env ?? [];
+  const subpaths = PLATFORM_INGRESS_SUBPATHS[id];
 
   switch (id) {
     case PlatformId.ApiServer: {
       if (!isApiServerEnabled(agent)) {
         return { status: "unavailable", reason: "Set API_SERVER_ENABLED=true to enable." };
       }
-      return { status: "available", port: getApiServerPort(agent) };
+      return {
+        status: "available",
+        port: getApiServerPort(agent),
+        ...endpointsFor(agent.endpoint, subpaths),
+      };
     }
     case PlatformId.Webhook: {
       if (!isWebhookEnabled(agent)) {
@@ -618,7 +644,11 @@ export function derivePlatformAvailability(id: PlatformId, agent: Agent): Platfo
           reason: "Set WEBHOOK_ENABLED=true (or config.platforms.webhook.enabled).",
         };
       }
-      return { status: "available", port: getWebhookPort(agent) };
+      return {
+        status: "available",
+        port: getWebhookPort(agent),
+        ...endpointsFor(agent.endpoint, subpaths),
+      };
     }
     case PlatformId.Slack: {
       const isSet = (name: string) =>
@@ -638,6 +668,18 @@ export function derivePlatformAvailability(id: PlatformId, agent: Agent): Platfo
       return { status: "available" };
     }
   }
+}
+
+/**
+ * Spread helper: returns `{ endpoints }` when both a base endpoint and at
+ * least one subpath are present, otherwise `{}` (so the field stays absent).
+ */
+function endpointsFor(
+  endpoint: string | null | undefined,
+  subpaths: readonly string[] | undefined,
+): { endpoints?: string[] } {
+  if (!endpoint || !subpaths || subpaths.length === 0) return {};
+  return { endpoints: subpaths.map((p) => `${endpoint}${p}`) };
 }
 
 export const AgentPhaseSchema = z.enum([

--- a/apps/dashboard/src/server/infras/kubernetes/client.test.ts
+++ b/apps/dashboard/src/server/infras/kubernetes/client.test.ts
@@ -530,8 +530,8 @@ describe("agentToHermesAgent ingress wiring", () => {
           host: "agent-1.agents.example.com",
           paths: [
             { path: "/webhooks", pathType: "Prefix", port: 8644 },
-            { path: "/api", pathType: "Prefix", port: 8642 },
             { path: "/v1", pathType: "Prefix", port: 8642 },
+            { path: "/api", pathType: "Prefix", port: 8642 },
             { path: "/health", pathType: "Prefix", port: 8642 },
           ],
         },
@@ -546,8 +546,8 @@ describe("agentToHermesAgent ingress wiring", () => {
       makeAgent({ env: [{ name: "API_SERVER_ENABLED", value: "true" }] })
     );
     expect(hermesAgent.spec.networking?.ingress?.hosts?.[0]?.paths).toEqual([
-      { path: "/api", pathType: "Prefix", port: 8642 },
       { path: "/v1", pathType: "Prefix", port: 8642 },
+      { path: "/api", pathType: "Prefix", port: 8642 },
       { path: "/health", pathType: "Prefix", port: 8642 },
     ]);
   });

--- a/apps/dashboard/src/server/infras/kubernetes/client.test.ts
+++ b/apps/dashboard/src/server/infras/kubernetes/client.test.ts
@@ -626,6 +626,7 @@ describe("buildAgentEndpoint", () => {
   const ENV_VARS = [
     "HERMEUM_AGENT_INGRESS_SCHEME",
     "HERMEUM_AGENT_INGRESS_BASE_HOSTNAME",
+    "HERMEUM_KUBERNETES_NAMESPACE",
   ];
   const ORIGINAL: Record<string, string | undefined> = {};
 
@@ -649,6 +650,7 @@ describe("buildAgentEndpoint", () => {
 
   function makeHermesAgentWithIngress(host: string | undefined): HermesAgent {
     return {
+      metadata: { name: "agent-1" },
       spec: {
         networking: {
           ingress: {
@@ -656,6 +658,19 @@ describe("buildAgentEndpoint", () => {
             hosts: host
               ? [{ host, paths: [{ path: "/api", pathType: "Prefix", port: 8642 }] }]
               : undefined,
+          },
+        },
+      },
+    } as unknown as HermesAgent;
+  }
+
+  function makeHermesAgentWithServicePorts(portNames: string[]): HermesAgent {
+    return {
+      metadata: { name: "agent-1" },
+      spec: {
+        networking: {
+          service: {
+            ports: portNames.map((name) => ({ name, port: 8642, targetPort: 8642, protocol: "TCP" })),
           },
         },
       },
@@ -670,12 +685,12 @@ describe("buildAgentEndpoint", () => {
     );
   });
 
-  it("returns null when the CR has no ingress host", async () => {
+  it("returns null when the CR has no ingress host and no HTTP service ports", async () => {
     const { buildAgentEndpoint } = await importFresh();
     expect(buildAgentEndpoint(makeHermesAgentWithIngress(undefined))).toBeNull();
   });
 
-  it("returns null when the CR has no networking.ingress at all", async () => {
+  it("returns null when the CR has no networking at all", async () => {
     const { buildAgentEndpoint } = await importFresh();
     expect(buildAgentEndpoint({ spec: {} } as unknown as HermesAgent)).toBeNull();
   });
@@ -687,5 +702,46 @@ describe("buildAgentEndpoint", () => {
     expect(buildAgentEndpoint(makeHermesAgentWithIngress("agent-1.agents.example.com"))).toBe(
       "https://agent-1.agents.example.com"
     );
+  });
+
+  it("falls back to the in-cluster Service DNS when no ingress host is present but api-server is enabled", async () => {
+    vi.stubEnv("HERMEUM_KUBERNETES_NAMESPACE", "hermeum");
+    const { buildAgentEndpoint } = await importFresh();
+    expect(buildAgentEndpoint(makeHermesAgentWithServicePorts(["api-server"]))).toBe(
+      "http://agent-1.hermeum.svc.cluster.local"
+    );
+  });
+
+  it("falls back to the in-cluster Service DNS when only webhook is enabled", async () => {
+    vi.stubEnv("HERMEUM_KUBERNETES_NAMESPACE", "hermeum");
+    const { buildAgentEndpoint } = await importFresh();
+    expect(buildAgentEndpoint(makeHermesAgentWithServicePorts(["webhook"]))).toBe(
+      "http://agent-1.hermeum.svc.cluster.local"
+    );
+  });
+
+  it("prefers the ingress host over the internal Service DNS when both are present", async () => {
+    vi.stubEnv("HERMEUM_AGENT_INGRESS_BASE_HOSTNAME", "agents.example.com");
+    vi.stubEnv("HERMEUM_KUBERNETES_NAMESPACE", "hermeum");
+    const { buildAgentEndpoint } = await importFresh();
+    const raw = {
+      metadata: { name: "agent-1" },
+      spec: {
+        networking: {
+          ingress: {
+            enabled: true,
+            hosts: [{ host: "agent-1.agents.example.com", paths: [] }],
+          },
+          service: { ports: [{ name: "api-server", port: 8642, targetPort: 8642, protocol: "TCP" }] },
+        },
+      },
+    } as unknown as HermesAgent;
+    expect(buildAgentEndpoint(raw)).toBe("http://agent-1.agents.example.com");
+  });
+
+  it("returns null when service ports exist but none are HTTP platforms", async () => {
+    vi.stubEnv("HERMEUM_KUBERNETES_NAMESPACE", "hermeum");
+    const { buildAgentEndpoint } = await importFresh();
+    expect(buildAgentEndpoint(makeHermesAgentWithServicePorts(["misc"]))).toBeNull();
   });
 });

--- a/apps/dashboard/src/server/infras/kubernetes/client.ts
+++ b/apps/dashboard/src/server/infras/kubernetes/client.ts
@@ -8,6 +8,8 @@ import {
   ENV_SECRET_SENTINEL,
   Env,
   EnvVar,
+  PLATFORM_INGRESS_SUBPATHS,
+  PlatformId,
   SharedEnvSet,
   SharedEnvSetEnvVar,
   getApiServerPort,
@@ -212,14 +214,17 @@ export function agentToHermesAgent(agent: Agent): HermesAgent {
     const host = `${agent.id}.${config.agentIngressBaseHostname}`;
     const ingressPaths: IngressPath[] = [];
     if (webhookPort !== null) {
-      ingressPaths.push({ path: "/webhooks", pathType: "Prefix", port: webhookPort });
+      for (const path of PLATFORM_INGRESS_SUBPATHS[PlatformId.Webhook] ?? []) {
+        ingressPaths.push({ path, pathType: "Prefix", port: webhookPort });
+      }
     }
     if (apiServerPort !== null) {
-      ingressPaths.push(
-        { path: "/api", pathType: "Prefix", port: apiServerPort },
-        { path: "/v1", pathType: "Prefix", port: apiServerPort },
-        { path: "/health", pathType: "Prefix", port: apiServerPort }
-      );
+      for (const path of PLATFORM_INGRESS_SUBPATHS[PlatformId.ApiServer] ?? []) {
+        ingressPaths.push({ path, pathType: "Prefix", port: apiServerPort });
+      }
+      // /health is an infra health probe, not a messaging endpoint — kept
+      // local to the ingress builder (not surfaced in the UI subpath map).
+      ingressPaths.push({ path: "/health", pathType: "Prefix", port: apiServerPort });
     }
     ingress = {
       enabled: true,

--- a/apps/dashboard/src/server/infras/kubernetes/client.ts
+++ b/apps/dashboard/src/server/infras/kubernetes/client.ts
@@ -308,17 +308,33 @@ export function mapHermesConfig(config: HermesConfig | undefined): Agent["config
   return config?.raw;
 }
 
-// Derive the agent's public endpoint URL from the reconciled ingress host.
-// The host is written into spec.networking.ingress by agentToHermesAgent only
-// when at least one HTTP platform (api-server / webhook) is enabled AND the
-// operator has configured agentIngressBaseHostname — so a null return here
-// exactly mirrors "no public endpoint exists for this agent / deployment".
-// The scheme comes from agentIngressScheme (display-only; TLS is governed
-// separately by agentIngressTlsSecretName).
+// Derive the agent's base endpoint URL.
+//
+// When the operator configures agentIngressBaseHostname, the reconciled
+// ingress writes its host into spec.networking.ingress and we surface it as
+// `${agentIngressScheme}://${host}` — a single host serving all HTTP platforms
+// (routing by path), so no port appears in the URL.
+//
+// When no base hostname is configured, the per-agent ClusterIP Service is
+// still emitted (it is independent of ingress), so callers can reach the
+// agent in-cluster at `http://${agent.id}.${kubernetesNamespace}.svc.cluster.local`.
+// The per-platform port is inserted client-side (different platforms listen
+// on different ports), which is why this base carries no port.
+//
+// Returns null only when neither an ingress host nor an enabled HTTP platform
+// (api-server / webhook) is present — i.e. no endpoint exists at all.
 export function buildAgentEndpoint(raw: HermesAgent): string | null {
-  const host = raw.spec.networking?.ingress?.hosts?.[0]?.host;
-  if (!host) return null;
-  return `${config.agentIngressScheme}://${host}`;
+  const ingressHost = raw.spec.networking?.ingress?.hosts?.[0]?.host;
+  if (ingressHost) {
+    return `${config.agentIngressScheme}://${ingressHost}`;
+  }
+  const hasHttpPlatform =
+    raw.spec.networking?.service?.ports?.some((p) => p.name === "api-server" || p.name === "webhook") ?? false;
+  if (hasHttpPlatform) {
+    const id = raw.metadata?.name ?? "";
+    return `http://${id}.${config.kubernetesNamespace}.svc.cluster.local`;
+  }
+  return null;
 }
 
 export function mapHermesAgent(raw: HermesAgent): Agent {

--- a/packages/components/ui/popover.tsx
+++ b/packages/components/ui/popover.tsx
@@ -1,0 +1,53 @@
+"use client"
+
+import { Popover as PopoverPrimitive } from "@base-ui/react/popover"
+
+import { cn } from "@hermeum/components/lib/utils"
+
+function Popover({ ...props }: PopoverPrimitive.Root.Props) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger({ ...props }: PopoverPrimitive.Trigger.Props) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+function PopoverContent({
+  className,
+  side = "top",
+  align = "center",
+  sideOffset = 4,
+  alignOffset = 0,
+  children,
+  ...props
+}: PopoverPrimitive.Popup.Props &
+  Pick<
+    PopoverPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Positioner
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+        className="isolate z-50"
+      >
+        <PopoverPrimitive.Popup
+          data-slot="popover-content"
+          className={cn(
+            "z-50 inline-flex w-fit max-w-xs origin-(--transform-origin) items-center gap-1.5 rounded-none bg-foreground px-3 py-1.5 text-xs text-background data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            className
+          )}
+          {...props}
+        >
+          {children}
+          <PopoverPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-none bg-foreground fill-foreground data-[side=bottom]:top-1 data-[side=inline-end]:top-1/2! data-[side=inline-end]:-left-1 data-[side=inline-end]:translate-x-[1.5px] data-[side=inline-end]:-translate-y-1/2 data-[side=inline-start]:top-1/2! data-[side=inline-start]:-right-1 data-[side=inline-start]:translate-x-[-1.5px] data-[side=inline-start]:-translate-y-1/2 data-[side=left]:top-1/2! data-[side=left]:-right-1 data-[side=left]:-translate-y-1/2 data-[side=right]:top-1/2! data-[side=right]:-left-1 data-[side=right]:-translate-y-1/2 data-[side=top]:-bottom-2.5" />
+        </PopoverPrimitive.Popup>
+      </PopoverPrimitive.Positioner>
+    </PopoverPrimitive.Portal>
+  )
+}
+
+export { Popover, PopoverTrigger, PopoverContent }


### PR DESCRIPTION
### What this PR does

- Replaces the hover-only platform badge tooltip with a click-to-open popover that reveals the agent's endpoint URL(s) including the per-platform subpath.
- Adds a shared PLATFORM_INGRESS_SUBPATHS map (api-server -> /v1 + /api, webhook -> /webhooks) used by both the ingress builder and the UI.
- Extends buildAgentEndpoint to fall back to the in-cluster Service DNS (http://<agent-id>.<namespace>.svc.cluster.local) when no ingress base hostname is configured, so internal endpoints are visible in the dashboard.
- Front-end inserts the per-platform port into internal URLs, since each HTTP platform listens on its own port.
- Cleans up the badge trigger (label only) and popover layout, fixes long internal URL overflow, and removes the separate generic endpoint row in the page header.

### Files changed

- packages/components/ui/popover.tsx (new)
- apps/dashboard/src/entities/agent.ts
- apps/dashboard/src/server/infras/kubernetes/client.ts
- apps/dashboard/src/client/ui/routes/agents/$id/index.tsx
- apps/dashboard/src/entities/agent.test.ts
- apps/dashboard/src/server/infras/kubernetes/client.test.ts
