### PR TITLE
refactor(agents): expand Tools section to 25 Hermes toolsets

### DIFF
--- a/apps/dashboard/src/client/ui/routes/agents/$id/index.tsx
+++ b/apps/dashboard/src/client/ui/routes/agents/$id/index.tsx
@@ -122,8 +122,8 @@ function ToolsetsSection({ agent }: { agent: Agent }) {
           />
           <TooltipContent>
             <div className="max-w-xs">
-              Hermeum shows the built-in Hermes toolsets here. Toolsets added
-              by plugins are not listed.
+              Hermes' 25 built-in toolsets. Availability is gated on the
+              agent's config and env. Plugin toolsets are not listed.
             </div>
           </TooltipContent>
         </Tooltip>

--- a/apps/dashboard/src/client/ui/routes/agents/$id/index.tsx
+++ b/apps/dashboard/src/client/ui/routes/agents/$id/index.tsx
@@ -10,16 +10,16 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@hermeum/components/ui
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@hermeum/components/ui/tooltip";
 import { useTRPC } from "@/router";
 import {
-  TOOL_IDS,
+  TOOLSET_IDS,
   PLATFORM_IDS,
-  deriveToolAvailability,
+  deriveToolsetEnabled,
   derivePlatformAvailability,
-  getToolDescription,
-  getToolLabel,
+  getToolsetDescription,
+  getToolsetLabel,
   getPlatformDescription,
   getPlatformLabel,
   type Agent,
-  type ToolId,
+  type ToolsetId,
   type PlatformId,
 } from "@/entities";
 import { PhaseBadge } from "@/client/ui/components/phase-badge";
@@ -76,10 +76,10 @@ function ButtonList({ items, max = BADGE_MAX }: { items: string[]; max?: number 
   );
 }
 
-function ToolBadge({ id, agent }: { id: ToolId; agent: Agent }) {
-  const { status, reason } = deriveToolAvailability(id, agent);
-  const label = getToolLabel(id);
-  const description = getToolDescription(id);
+function ToolsetBadge({ id, agent }: { id: ToolsetId; agent: Agent }) {
+  const { status, reason } = deriveToolsetEnabled(id, agent);
+  const label = getToolsetLabel(id);
+  const description = getToolsetDescription(id);
   return (
     <Tooltip>
       <TooltipTrigger
@@ -88,7 +88,7 @@ function ToolBadge({ id, agent }: { id: ToolId; agent: Agent }) {
             variant="outline"
             size="sm"
             className={`h-auto px-2 py-1 font-mono text-xs ${
-              status === "unavailable" ? "text-muted-foreground opacity-60" : ""
+              status === "disabled" ? "text-muted-foreground opacity-60" : ""
             }`}
           />
         }
@@ -109,29 +109,29 @@ function ToolBadge({ id, agent }: { id: ToolId; agent: Agent }) {
   );
 }
 
-function ToolsSection({ agent }: { agent: Agent }) {
+function ToolsetsSection({ agent }: { agent: Agent }) {
   return (
     <div className="py-8 flex flex-col gap-3">
       <div className="flex items-center gap-1.5">
-        <p className="text-sm font-bold">Tools</p>
+        <p className="text-sm font-bold">Toolsets</p>
         <Tooltip>
           <TooltipTrigger
             render={
-              <Info className="size-3 text-muted-foreground cursor-help" aria-label="Tools info" />
+              <Info className="size-3 text-muted-foreground cursor-help" aria-label="Toolsets info" />
             }
           />
           <TooltipContent>
             <div className="max-w-xs">
-              Hermeum shows built-in Hermes tools here. Tools added by plugins
-              are not listed.
+              Hermeum shows the built-in Hermes toolsets here. Toolsets added
+              by plugins are not listed.
             </div>
           </TooltipContent>
         </Tooltip>
       </div>
       <TooltipProvider>
         <div className="flex flex-wrap gap-2">
-          {TOOL_IDS.map((id) => (
-            <ToolBadge key={id} id={id} agent={agent} />
+          {TOOLSET_IDS.map((id) => (
+            <ToolsetBadge key={id} id={id} agent={agent} />
           ))}
         </div>
       </TooltipProvider>
@@ -373,8 +373,8 @@ function AgentDetailPage() {
               </div>
             )}
 
-            {/* tools */}
-            <ToolsSection agent={agent} />
+            {/* toolsets */}
+            <ToolsetsSection agent={agent} />
 
             {/* message platforms */}
             <PlatformsSection agent={agent} />

--- a/apps/dashboard/src/client/ui/routes/agents/$id/index.tsx
+++ b/apps/dashboard/src/client/ui/routes/agents/$id/index.tsx
@@ -12,7 +12,7 @@ import { useTRPC } from "@/router";
 import {
   TOOLSET_IDS,
   PLATFORM_IDS,
-  deriveToolsetEnabled,
+  deriveToolsetAvailability,
   derivePlatformAvailability,
   getToolsetDescription,
   getToolsetLabel,
@@ -77,7 +77,7 @@ function ButtonList({ items, max = BADGE_MAX }: { items: string[]; max?: number 
 }
 
 function ToolsetBadge({ id, agent }: { id: ToolsetId; agent: Agent }) {
-  const { status, reason } = deriveToolsetEnabled(id, agent);
+  const { status, reason } = deriveToolsetAvailability(id, agent);
   const label = getToolsetLabel(id);
   const description = getToolsetDescription(id);
   return (
@@ -88,7 +88,7 @@ function ToolsetBadge({ id, agent }: { id: ToolsetId; agent: Agent }) {
             variant="outline"
             size="sm"
             className={`h-auto px-2 py-1 font-mono text-xs ${
-              status === "disabled" ? "text-muted-foreground opacity-60" : ""
+              status === "unavailable" ? "text-muted-foreground opacity-60" : ""
             }`}
           />
         }

--- a/apps/dashboard/src/client/ui/routes/agents/$id/index.tsx
+++ b/apps/dashboard/src/client/ui/routes/agents/$id/index.tsx
@@ -122,7 +122,7 @@ function ToolsetsSection({ agent }: { agent: Agent }) {
           />
           <TooltipContent>
             <div className="max-w-xs">
-              Hermes' 25 built-in toolsets. Plugin toolsets are not listed.
+              Hermes&apos; 25 built-in toolsets. Plugin toolsets are not listed.
             </div>
           </TooltipContent>
         </Tooltip>

--- a/apps/dashboard/src/client/ui/routes/agents/$id/index.tsx
+++ b/apps/dashboard/src/client/ui/routes/agents/$id/index.tsx
@@ -122,8 +122,7 @@ function ToolsetsSection({ agent }: { agent: Agent }) {
           />
           <TooltipContent>
             <div className="max-w-xs">
-              Hermes' 25 built-in toolsets. Availability is gated on the
-              agent's config and env. Plugin toolsets are not listed.
+              Hermes' 25 built-in toolsets. Plugin toolsets are not listed.
             </div>
           </TooltipContent>
         </Tooltip>

--- a/apps/dashboard/src/entities/agent.test.ts
+++ b/apps/dashboard/src/entities/agent.test.ts
@@ -610,9 +610,13 @@ describe("deriveToolsetAvailability", () => {
 
   it("marks no-gate toolsets available with no config", () => {
     const agent = makeAgent();
-    // The 22 toolsets without a config gate in Hermeum (all except Web,
-    // XSearch, Browser).
-    const gated = new Set<ToolsetId>([ToolsetId.Web, ToolsetId.XSearch, ToolsetId.Browser]);
+    // Toolsets gated in Hermeum (all others fall through to available).
+    const gated = new Set<ToolsetId>([
+      ToolsetId.Web, ToolsetId.XSearch, ToolsetId.Browser,
+      ToolsetId.HomeAssistant, ToolsetId.ImageGen, ToolsetId.VideoGen,
+      ToolsetId.Spotify, ToolsetId.Discord, ToolsetId.DiscordAdmin,
+      ToolsetId.ComputerUse, ToolsetId.Yuanbao,
+    ]);
     const noGate = (Object.values(ToolsetId) as ToolsetId[]).filter((id) => !gated.has(id));
     for (const id of noGate) {
       expect(deriveToolsetAvailability(id, agent).status).toBe("available");
@@ -657,6 +661,64 @@ describe("deriveToolsetAvailability", () => {
         makeAgent({ config: { browser: { cloud_provider: "camofox" } } })
       ).status
     ).toBe("available");
+  });
+
+  it("marks home assistant unavailable without HASS_TOKEN and available with it", () => {
+    expect(deriveToolsetAvailability(ToolsetId.HomeAssistant, makeAgent()).status).toBe("unavailable");
+    expect(
+      deriveToolsetAvailability(
+        ToolsetId.HomeAssistant,
+        makeAgent({ env: [{ name: "HASS_TOKEN", value: "ha-token", sensitive: true }] })
+      ).status
+    ).toBe("available");
+  });
+
+  it("marks discord / discord_admin unavailable without DISCORD_BOT_TOKEN and available with it", () => {
+    expect(deriveToolsetAvailability(ToolsetId.Discord, makeAgent()).status).toBe("unavailable");
+    expect(deriveToolsetAvailability(ToolsetId.DiscordAdmin, makeAgent()).status).toBe("unavailable");
+    const agent = makeAgent({
+      env: [{ name: "DISCORD_BOT_TOKEN", value: "bot-token", sensitive: true }],
+    });
+    expect(deriveToolsetAvailability(ToolsetId.Discord, agent).status).toBe("available");
+    expect(deriveToolsetAvailability(ToolsetId.DiscordAdmin, agent).status).toBe("available");
+  });
+
+  it("marks image_gen unavailable without FAL_KEY or gateway and available with either", () => {
+    expect(deriveToolsetAvailability(ToolsetId.ImageGen, makeAgent()).status).toBe("unavailable");
+    expect(
+      deriveToolsetAvailability(
+        ToolsetId.ImageGen,
+        makeAgent({ env: [{ name: "FAL_KEY", value: "fal-key", sensitive: true }] })
+      ).status
+    ).toBe("available");
+    expect(
+      deriveToolsetAvailability(
+        ToolsetId.ImageGen,
+        makeAgent({ config: { image_gen: { use_gateway: true } } })
+      ).status
+    ).toBe("available");
+  });
+
+  it("marks video_gen unavailable without FAL_KEY or XAI_API_KEY and available with either", () => {
+    expect(deriveToolsetAvailability(ToolsetId.VideoGen, makeAgent()).status).toBe("unavailable");
+    expect(
+      deriveToolsetAvailability(
+        ToolsetId.VideoGen,
+        makeAgent({ env: [{ name: "FAL_KEY", value: "fal-key", sensitive: true }] })
+      ).status
+    ).toBe("available");
+    expect(
+      deriveToolsetAvailability(
+        ToolsetId.VideoGen,
+        makeAgent({ env: [{ name: "XAI_API_KEY", value: "xai-123", sensitive: true }] })
+      ).status
+    ).toBe("available");
+  });
+
+  it("marks spotify, computer_use, and yuanbao always unavailable", () => {
+    expect(deriveToolsetAvailability(ToolsetId.Spotify, makeAgent()).status).toBe("unavailable");
+    expect(deriveToolsetAvailability(ToolsetId.ComputerUse, makeAgent()).status).toBe("unavailable");
+    expect(deriveToolsetAvailability(ToolsetId.Yuanbao, makeAgent()).status).toBe("unavailable");
   });
 });
 

--- a/apps/dashboard/src/entities/agent.test.ts
+++ b/apps/dashboard/src/entities/agent.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { z } from "zod";
 
-import { AgentInputObjectSchema, AgentInputSchema, SkillSchema, isApiServerEnabled, getApiServerPort, isWebhookEnabled, getWebhookPort, ToolsetId, deriveToolsetEnabled, PlatformId, derivePlatformAvailability, type Agent } from "./agent";
+import { AgentInputObjectSchema, AgentInputSchema, SkillSchema, isApiServerEnabled, getApiServerPort, isWebhookEnabled, getWebhookPort, ToolsetId, deriveToolsetAvailability, PlatformId, derivePlatformAvailability, type Agent } from "./agent";
 
 function makeInput(overrides: Record<string, unknown> = {}) {
   return {
@@ -603,60 +603,60 @@ describe("AgentInputSchema browser config validation", () => {
   });
 });
 
-describe("deriveToolsetEnabled", () => {
+describe("deriveToolsetAvailability", () => {
   function makeAgent(overrides: Partial<Agent> = {}): Agent {
     return { id: "a1", userId: "u1", ...overrides } as Agent;
   }
 
-  it("marks no-gate toolsets enabled with no config", () => {
+  it("marks no-gate toolsets available with no config", () => {
     const agent = makeAgent();
     // The 22 toolsets without a config gate in Hermeum (all except Web,
     // XSearch, Browser).
     const gated = new Set<ToolsetId>([ToolsetId.Web, ToolsetId.XSearch, ToolsetId.Browser]);
     const noGate = (Object.values(ToolsetId) as ToolsetId[]).filter((id) => !gated.has(id));
     for (const id of noGate) {
-      expect(deriveToolsetEnabled(id, agent).status).toBe("enabled");
+      expect(deriveToolsetAvailability(id, agent).status).toBe("available");
     }
   });
 
-  it("marks web disabled without a backend and enabled with one", () => {
-    expect(deriveToolsetEnabled(ToolsetId.Web, makeAgent()).status).toBe("disabled");
+  it("marks web unavailable without a backend and available with one", () => {
+    expect(deriveToolsetAvailability(ToolsetId.Web, makeAgent()).status).toBe("unavailable");
     expect(
-      deriveToolsetEnabled(ToolsetId.Web, makeAgent({ config: { web: { backend: "searxng" } } }))
+      deriveToolsetAvailability(ToolsetId.Web, makeAgent({ config: { web: { backend: "searxng" } } }))
         .status
-    ).toBe("enabled");
+    ).toBe("available");
     expect(
-      deriveToolsetEnabled(
+      deriveToolsetAvailability(
         ToolsetId.Web,
         makeAgent({ config: { web: { search_backend: "tavily" } } })
       ).status
-    ).toBe("enabled");
+    ).toBe("available");
   });
 
-  it("marks x search disabled by default and enabled with XAI_API_KEY or xai backend", () => {
-    expect(deriveToolsetEnabled(ToolsetId.XSearch, makeAgent()).status).toBe("disabled");
+  it("marks x search unavailable by default and available with XAI_API_KEY or xai backend", () => {
+    expect(deriveToolsetAvailability(ToolsetId.XSearch, makeAgent()).status).toBe("unavailable");
     expect(
-      deriveToolsetEnabled(
+      deriveToolsetAvailability(
         ToolsetId.XSearch,
         makeAgent({ env: [{ name: "XAI_API_KEY", value: "xai-123", sensitive: true }] })
       ).status
-    ).toBe("enabled");
+    ).toBe("available");
     expect(
-      deriveToolsetEnabled(
+      deriveToolsetAvailability(
         ToolsetId.XSearch,
         makeAgent({ config: { web: { search_backend: "xai" } } })
       ).status
-    ).toBe("enabled");
+    ).toBe("available");
   });
 
-  it("marks browser disabled without a provider and enabled with one", () => {
-    expect(deriveToolsetEnabled(ToolsetId.Browser, makeAgent()).status).toBe("disabled");
+  it("marks browser unavailable without a provider and available with one", () => {
+    expect(deriveToolsetAvailability(ToolsetId.Browser, makeAgent()).status).toBe("unavailable");
     expect(
-      deriveToolsetEnabled(
+      deriveToolsetAvailability(
         ToolsetId.Browser,
         makeAgent({ config: { browser: { cloud_provider: "camofox" } } })
       ).status
-    ).toBe("enabled");
+    ).toBe("available");
   });
 });
 

--- a/apps/dashboard/src/entities/agent.test.ts
+++ b/apps/dashboard/src/entities/agent.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { z } from "zod";
 
-import { AgentInputObjectSchema, AgentInputSchema, SkillSchema, isApiServerEnabled, getApiServerPort, isWebhookEnabled, getWebhookPort, ToolId, deriveToolAvailability, PlatformId, derivePlatformAvailability, type Agent } from "./agent";
+import { AgentInputObjectSchema, AgentInputSchema, SkillSchema, isApiServerEnabled, getApiServerPort, isWebhookEnabled, getWebhookPort, ToolsetId, deriveToolsetEnabled, PlatformId, derivePlatformAvailability, type Agent } from "./agent";
 
 function makeInput(overrides: Record<string, unknown> = {}) {
   return {
@@ -603,56 +603,60 @@ describe("AgentInputSchema browser config validation", () => {
   });
 });
 
-describe("deriveToolAvailability", () => {
+describe("deriveToolsetEnabled", () => {
   function makeAgent(overrides: Partial<Agent> = {}): Agent {
     return { id: "a1", userId: "u1", ...overrides } as Agent;
   }
 
-  it("marks core tools available with no config", () => {
+  it("marks no-gate toolsets enabled with no config", () => {
     const agent = makeAgent();
-    for (const id of [ToolId.Terminal, ToolId.File, ToolId.Memory, ToolId.Cron, ToolId.Mcp]) {
-      expect(deriveToolAvailability(id, agent).status).toBe("available");
+    // The 22 toolsets without a config gate in Hermeum (all except Web,
+    // XSearch, Browser).
+    const gated = new Set<ToolsetId>([ToolsetId.Web, ToolsetId.XSearch, ToolsetId.Browser]);
+    const noGate = (Object.values(ToolsetId) as ToolsetId[]).filter((id) => !gated.has(id));
+    for (const id of noGate) {
+      expect(deriveToolsetEnabled(id, agent).status).toBe("enabled");
     }
   });
 
-  it("marks web unavailable without a backend and available with one", () => {
-    expect(deriveToolAvailability(ToolId.Web, makeAgent()).status).toBe("unavailable");
+  it("marks web disabled without a backend and enabled with one", () => {
+    expect(deriveToolsetEnabled(ToolsetId.Web, makeAgent()).status).toBe("disabled");
     expect(
-      deriveToolAvailability(ToolId.Web, makeAgent({ config: { web: { backend: "searxng" } } }))
+      deriveToolsetEnabled(ToolsetId.Web, makeAgent({ config: { web: { backend: "searxng" } } }))
         .status
-    ).toBe("available");
+    ).toBe("enabled");
     expect(
-      deriveToolAvailability(
-        ToolId.Web,
+      deriveToolsetEnabled(
+        ToolsetId.Web,
         makeAgent({ config: { web: { search_backend: "tavily" } } })
       ).status
-    ).toBe("available");
+    ).toBe("enabled");
   });
 
-  it("marks x search unavailable by default and available with XAI_API_KEY or xai backend", () => {
-    expect(deriveToolAvailability(ToolId.XSearch, makeAgent()).status).toBe("unavailable");
+  it("marks x search disabled by default and enabled with XAI_API_KEY or xai backend", () => {
+    expect(deriveToolsetEnabled(ToolsetId.XSearch, makeAgent()).status).toBe("disabled");
     expect(
-      deriveToolAvailability(
-        ToolId.XSearch,
+      deriveToolsetEnabled(
+        ToolsetId.XSearch,
         makeAgent({ env: [{ name: "XAI_API_KEY", value: "xai-123", sensitive: true }] })
       ).status
-    ).toBe("available");
+    ).toBe("enabled");
     expect(
-      deriveToolAvailability(
-        ToolId.XSearch,
+      deriveToolsetEnabled(
+        ToolsetId.XSearch,
         makeAgent({ config: { web: { search_backend: "xai" } } })
       ).status
-    ).toBe("available");
+    ).toBe("enabled");
   });
 
-  it("marks browser unavailable without a provider and available with one", () => {
-    expect(deriveToolAvailability(ToolId.Browser, makeAgent()).status).toBe("unavailable");
+  it("marks browser disabled without a provider and enabled with one", () => {
+    expect(deriveToolsetEnabled(ToolsetId.Browser, makeAgent()).status).toBe("disabled");
     expect(
-      deriveToolAvailability(
-        ToolId.Browser,
+      deriveToolsetEnabled(
+        ToolsetId.Browser,
         makeAgent({ config: { browser: { cloud_provider: "camofox" } } })
       ).status
-    ).toBe("available");
+    ).toBe("enabled");
   });
 });
 

--- a/apps/dashboard/src/entities/agent.ts
+++ b/apps/dashboard/src/entities/agent.ts
@@ -857,6 +857,7 @@ export const TOOLSET_IDS: readonly ToolsetId[] = [
 export function deriveToolsetAvailability(id: ToolsetId, agent: Agent): ToolsetAvailability {
   const config = agent.config;
   const env = agent.env ?? [];
+  const hasEnv = (name: string) => env.some((v) => v.name === name && v.value.trim() !== "");
 
   switch (id) {
     case ToolsetId.Web: {
@@ -871,20 +872,48 @@ export function deriveToolsetAvailability(id: ToolsetId, agent: Agent): ToolsetA
     }
     case ToolsetId.XSearch: {
       // Gated on xAI credentials; off by default.
-      const hasXaiKey = env.some((v) => v.name === "XAI_API_KEY" && v.value.trim() !== "");
+      const hasXaiKey = hasEnv("XAI_API_KEY");
       const xaiBackend = config?.web?.search_backend === "xai";
       return hasXaiKey || xaiBackend
         ? { status: "available" }
-        : {
-            status: "unavailable",
-            reason: "Set XAI_API_KEY to opt in.",
-          };
+        : { status: "unavailable", reason: "Set XAI_API_KEY to opt in." };
     }
     case ToolsetId.Browser: {
       return config?.browser?.cloud_provider
         ? { status: "available" }
         : { status: "unavailable", reason: "No browser provider configured." };
     }
+    case ToolsetId.HomeAssistant: {
+      return hasEnv("HASS_TOKEN")
+        ? { status: "available" }
+        : { status: "unavailable", reason: "Set HASS_TOKEN to enable Home Assistant." };
+    }
+    case ToolsetId.Discord:
+    case ToolsetId.DiscordAdmin: {
+      return hasEnv("DISCORD_BOT_TOKEN")
+        ? { status: "available" }
+        : { status: "unavailable", reason: "Set DISCORD_BOT_TOKEN to enable Discord." };
+    }
+    case ToolsetId.ImageGen: {
+      const hasFalKey = hasEnv("FAL_KEY");
+      const useGateway = config?.image_gen?.use_gateway === true;
+      return hasFalKey || useGateway
+        ? { status: "available" }
+        : { status: "unavailable", reason: "Set FAL_KEY or enable the managed gateway." };
+    }
+    case ToolsetId.VideoGen: {
+      const hasFalKey = hasEnv("FAL_KEY");
+      const hasXaiKey = hasEnv("XAI_API_KEY");
+      return hasFalKey || hasXaiKey
+        ? { status: "available" }
+        : { status: "unavailable", reason: "Set FAL_KEY or XAI_API_KEY for video generation." };
+    }
+    case ToolsetId.Spotify:
+      return { status: "unavailable", reason: "Spotify OAuth is not supported in Hermeum." };
+    case ToolsetId.ComputerUse:
+      return { status: "unavailable", reason: "Computer Use is not supported in Hermeum." };
+    case ToolsetId.Yuanbao:
+      return { status: "unavailable", reason: "Only available on the Yuanbao messaging platform." };
     default:
       // Toolsets with no config gate in Hermeum. They are available whenever
       // the agent exists; per-agent toggling is a follow-up.

--- a/apps/dashboard/src/entities/agent.ts
+++ b/apps/dashboard/src/entities/agent.ts
@@ -664,128 +664,230 @@ export const AgentSchema = AgentInputObjectSchema.extend({
 
 export type Agent = z.infer<typeof AgentSchema>;
 
-// Tool availability — a derived, read-only view of which Hermes tools are
-// usable for an agent, computed from its config + env. Not persisted.
+// Toolset enabled state — a derived, read-only view of which Hermes toolsets
+// are enabled for an agent, computed from its config + env. Not persisted.
 // https://hermes-agent.nousresearch.com/docs/user-guide/features/tools
+//
+// The catalog mirrors Hermes' CONFIGURABLE_TOOLSETS
+// (vendor/hermes-agent/hermes_cli/tools_config.py): the 25 built-in toolsets
+// in the same order. Plugin toolsets and platform-native toolsets outside
+// CONFIGURABLE_TOOLSETS are not listed here.
 
-export enum ToolId {
+export enum ToolsetId {
   Web = "web",
-  XSearch = "x-search",
+  Browser = "browser",
   Terminal = "terminal",
   File = "file",
-  Browser = "browser",
+  CodeExecution = "codeExecution",
+  Vision = "vision",
+  Video = "video",
+  ImageGen = "imageGen",
+  VideoGen = "videoGen",
+  XSearch = "xSearch",
+  Tts = "tts",
+  Skills = "skills",
+  Todo = "todo",
   Memory = "memory",
-  Cron = "cron",
-  Mcp = "mcp",
-  // Media = "media", // TBD — media toolset shape not finalized yet.
+  ContextEngine = "contextEngine",
+  SessionSearch = "sessionSearch",
+  Clarify = "clarify",
+  Delegation = "delegation",
+  Cronjob = "cronjob",
+  HomeAssistant = "homeAssistant",
+  Spotify = "spotify",
+  Discord = "discord",
+  DiscordAdmin = "discordAdmin",
+  Yuanbao = "yuanbao",
+  ComputerUse = "computerUse",
 }
 
-export type ToolStatus = "available" | "unavailable";
+export type ToolsetStatus = "enabled" | "disabled";
 
-export interface ToolAvailability {
-  status: ToolStatus;
-  /** Short explanation shown when status is not "available". */
+export interface ToolsetAvailability {
+  status: ToolsetStatus;
+  /** Short explanation shown when status is not "enabled". */
   reason?: string;
 }
 
-interface ToolMeta {
+interface ToolsetMeta {
   label: string;
   description: string;
 }
 
-const TOOL_META: Record<ToolId, ToolMeta> = {
-  [ToolId.Web]: {
+const TOOLSET_META: Record<ToolsetId, ToolsetMeta> = {
+  [ToolsetId.Web]: {
     label: "Web",
     description: "Search the web and extract page content.",
   },
-  [ToolId.XSearch]: {
-    label: "X Search",
-    description: "Search X (Twitter) posts via xAI.",
-  },
-  [ToolId.Terminal]: {
-    label: "Terminal",
-    description: "Execute shell commands.",
-  },
-  [ToolId.File]: {
-    label: "File",
-    description: "Read, edit, and search files.",
-  },
-  [ToolId.Browser]: {
+  [ToolsetId.Browser]: {
     label: "Browser",
     description: "Interactive browser automation.",
   },
-  [ToolId.Memory]: {
+  [ToolsetId.Terminal]: {
+    label: "Terminal",
+    description: "Execute shell commands.",
+  },
+  [ToolsetId.File]: {
+    label: "File",
+    description: "Read, edit, and search files.",
+  },
+  [ToolsetId.CodeExecution]: {
+    label: "Code Execution",
+    description: "Run code in an isolated sandbox.",
+  },
+  [ToolsetId.Vision]: {
+    label: "Vision",
+    description: "Analyze images with a vision-capable model.",
+  },
+  [ToolsetId.Video]: {
+    label: "Video",
+    description: "Analyze video with a video-capable model.",
+  },
+  [ToolsetId.ImageGen]: {
+    label: "Image Generation",
+    description: "Generate images from text prompts.",
+  },
+  [ToolsetId.VideoGen]: {
+    label: "Video Generation",
+    description: "Generate video from text, image, or reference input.",
+  },
+  [ToolsetId.XSearch]: {
+    label: "X Search",
+    description: "Search X (Twitter) posts via xAI.",
+  },
+  [ToolsetId.Tts]: {
+    label: "Text-to-Speech",
+    description: "Convert text to spoken audio.",
+  },
+  [ToolsetId.Skills]: {
+    label: "Skills",
+    description: "List, view, and manage installed skills.",
+  },
+  [ToolsetId.Todo]: {
+    label: "Todo",
+    description: "Track and plan tasks within a conversation.",
+  },
+  [ToolsetId.Memory]: {
     label: "Memory",
-    description: "Persistent memory and recall.",
+    description: "Persistent memory and recall across sessions.",
   },
-  [ToolId.Cron]: {
+  [ToolsetId.ContextEngine]: {
+    label: "Context Engine",
+    description: "Runtime tools from the active context engine.",
+  },
+  [ToolsetId.SessionSearch]: {
+    label: "Session Search",
+    description: "Search past conversation sessions.",
+  },
+  [ToolsetId.Clarify]: {
+    label: "Clarify",
+    description: "Ask the user clarifying questions.",
+  },
+  [ToolsetId.Delegation]: {
+    label: "Delegation",
+    description: "Delegate tasks to subagents.",
+  },
+  [ToolsetId.Cronjob]: {
     label: "Cron",
-    description: "Scheduled tasks.",
+    description: "Schedule and manage recurring jobs.",
   },
-  [ToolId.Mcp]: {
-    label: "MCP",
-    description: "MCP server integrations.",
+  [ToolsetId.HomeAssistant]: {
+    label: "Home Assistant",
+    description: "Control smart home devices via Home Assistant.",
+  },
+  [ToolsetId.Spotify]: {
+    label: "Spotify",
+    description: "Control Spotify playback, playlists, and library.",
+  },
+  [ToolsetId.Discord]: {
+    label: "Discord",
+    description: "Read and participate in Discord channels.",
+  },
+  [ToolsetId.DiscordAdmin]: {
+    label: "Discord Admin",
+    description: "Administer Discord servers: channels, roles, pins.",
+  },
+  [ToolsetId.Yuanbao]: {
+    label: "Yuanbao",
+    description: "Query Yuanbao groups, members, and DMs.",
+  },
+  [ToolsetId.ComputerUse]: {
+    label: "Computer Use",
+    description: "Drive the desktop via cua-driver on macOS, Windows, or Linux.",
   },
 };
 
-export function getToolLabel(id: ToolId): string {
-  return TOOL_META[id].label;
+export function getToolsetLabel(id: ToolsetId): string {
+  return TOOLSET_META[id].label;
 }
 
-export function getToolDescription(id: ToolId): string {
-  return TOOL_META[id].description;
+export function getToolsetDescription(id: ToolsetId): string {
+  return TOOLSET_META[id].description;
 }
 
-/** Ordered tool list for UI rendering. */
-export const TOOL_IDS: readonly ToolId[] = [
-  ToolId.Web,
-  ToolId.XSearch,
-  ToolId.Terminal,
-  ToolId.File,
-  ToolId.Browser,
-  ToolId.Memory,
-  ToolId.Cron,
-  ToolId.Mcp,
+/** Ordered toolset list for UI rendering. Mirrors CONFIGURABLE_TOOLSETS order. */
+export const TOOLSET_IDS: readonly ToolsetId[] = [
+  ToolsetId.Web,
+  ToolsetId.Browser,
+  ToolsetId.Terminal,
+  ToolsetId.File,
+  ToolsetId.CodeExecution,
+  ToolsetId.Vision,
+  ToolsetId.Video,
+  ToolsetId.ImageGen,
+  ToolsetId.VideoGen,
+  ToolsetId.XSearch,
+  ToolsetId.Tts,
+  ToolsetId.Skills,
+  ToolsetId.Todo,
+  ToolsetId.Memory,
+  ToolsetId.ContextEngine,
+  ToolsetId.SessionSearch,
+  ToolsetId.Clarify,
+  ToolsetId.Delegation,
+  ToolsetId.Cronjob,
+  ToolsetId.HomeAssistant,
+  ToolsetId.Spotify,
+  ToolsetId.Discord,
+  ToolsetId.DiscordAdmin,
+  ToolsetId.Yuanbao,
+  ToolsetId.ComputerUse,
 ];
 
-export function deriveToolAvailability(id: ToolId, agent: Agent): ToolAvailability {
+export function deriveToolsetEnabled(id: ToolsetId, agent: Agent): ToolsetAvailability {
   const config = agent.config;
   const env = agent.env ?? [];
 
   switch (id) {
-    case ToolId.Web: {
+    case ToolsetId.Web: {
       const hasBackend = !!(
         config?.web?.backend ??
         config?.web?.search_backend ??
         config?.web?.extract_backend
       );
       return hasBackend
-        ? { status: "available" }
-        : { status: "unavailable", reason: "No web backend configured." };
+        ? { status: "enabled" }
+        : { status: "disabled", reason: "No web backend configured." };
     }
-    case ToolId.XSearch: {
+    case ToolsetId.XSearch: {
       // Gated on xAI credentials; off by default.
       const hasXaiKey = env.some((v) => v.name === "XAI_API_KEY" && v.value.trim() !== "");
       const xaiBackend = config?.web?.search_backend === "xai";
       return hasXaiKey || xaiBackend
-        ? { status: "available" }
+        ? { status: "enabled" }
         : {
-            status: "unavailable",
+            status: "disabled",
             reason: "Set XAI_API_KEY to opt in.",
           };
     }
-    case ToolId.Browser: {
+    case ToolsetId.Browser: {
       return config?.browser?.cloud_provider
-        ? { status: "available" }
-        : { status: "unavailable", reason: "No browser provider configured." };
+        ? { status: "enabled" }
+        : { status: "disabled", reason: "No browser provider configured." };
     }
-    case ToolId.Terminal:
-    case ToolId.File:
-    case ToolId.Memory:
-    case ToolId.Cron:
-    case ToolId.Mcp:
-      // Core capabilities with no config gate. MCP servers themselves are
-      // opt-in via the catalog, which the dashboard cannot introspect.
-      return { status: "available" };
+    default:
+      // Toolsets with no config gate in Hermeum. They are enabled whenever
+      // the agent exists; per-agent toggling is a follow-up.
+      return { status: "enabled" };
   }
 }

--- a/apps/dashboard/src/entities/agent.ts
+++ b/apps/dashboard/src/entities/agent.ts
@@ -664,8 +664,8 @@ export const AgentSchema = AgentInputObjectSchema.extend({
 
 export type Agent = z.infer<typeof AgentSchema>;
 
-// Toolset enabled state — a derived, read-only view of which Hermes toolsets
-// are enabled for an agent, computed from its config + env. Not persisted.
+// Toolset availability — a derived, read-only view of which Hermes toolsets
+// are usable for an agent, computed from its config + env. Not persisted.
 // https://hermes-agent.nousresearch.com/docs/user-guide/features/tools
 //
 // The catalog mirrors Hermes' CONFIGURABLE_TOOLSETS
@@ -701,11 +701,11 @@ export enum ToolsetId {
   ComputerUse = "computerUse",
 }
 
-export type ToolsetStatus = "enabled" | "disabled";
+export type ToolsetStatus = "available" | "unavailable";
 
 export interface ToolsetAvailability {
   status: ToolsetStatus;
-  /** Short explanation shown when status is not "enabled". */
+  /** Short explanation shown when status is not "available". */
   reason?: string;
 }
 
@@ -854,7 +854,7 @@ export const TOOLSET_IDS: readonly ToolsetId[] = [
   ToolsetId.ComputerUse,
 ];
 
-export function deriveToolsetEnabled(id: ToolsetId, agent: Agent): ToolsetAvailability {
+export function deriveToolsetAvailability(id: ToolsetId, agent: Agent): ToolsetAvailability {
   const config = agent.config;
   const env = agent.env ?? [];
 
@@ -866,28 +866,28 @@ export function deriveToolsetEnabled(id: ToolsetId, agent: Agent): ToolsetAvaila
         config?.web?.extract_backend
       );
       return hasBackend
-        ? { status: "enabled" }
-        : { status: "disabled", reason: "No web backend configured." };
+        ? { status: "available" }
+        : { status: "unavailable", reason: "No web backend configured." };
     }
     case ToolsetId.XSearch: {
       // Gated on xAI credentials; off by default.
       const hasXaiKey = env.some((v) => v.name === "XAI_API_KEY" && v.value.trim() !== "");
       const xaiBackend = config?.web?.search_backend === "xai";
       return hasXaiKey || xaiBackend
-        ? { status: "enabled" }
+        ? { status: "available" }
         : {
-            status: "disabled",
+            status: "unavailable",
             reason: "Set XAI_API_KEY to opt in.",
           };
     }
     case ToolsetId.Browser: {
       return config?.browser?.cloud_provider
-        ? { status: "enabled" }
-        : { status: "disabled", reason: "No browser provider configured." };
+        ? { status: "available" }
+        : { status: "unavailable", reason: "No browser provider configured." };
     }
     default:
-      // Toolsets with no config gate in Hermeum. They are enabled whenever
+      // Toolsets with no config gate in Hermeum. They are available whenever
       // the agent exists; per-agent toggling is a follow-up.
-      return { status: "enabled" };
+      return { status: "available" };
   }
 }

--- a/apps/dashboard/src/entities/hermes-config/image-gen.ts
+++ b/apps/dashboard/src/entities/hermes-config/image-gen.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+// https://hermes-agent.nousresearch.com/docs/user-guide/features/image-generation
+// Full field semantics: docs/hermes-config/image-gen.md
+export const ImageGenSchema = z
+  .looseObject({
+    model: z.string().optional().describe("FAL.ai model id (default fal-ai/flux-2/klein/9b)."),
+    use_gateway: z
+      .boolean()
+      .optional()
+      .describe("Use the managed Nous Subscription gateway instead of a direct FAL_KEY."),
+    max_parallel_requests: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe("Concurrent images per tool-call batch (default 4)."),
+  })
+  .optional()
+  .describe("Image generation configuration. Requires FAL_KEY or the managed gateway.");
+
+export type ImageGen = z.infer<typeof ImageGenSchema>;

--- a/apps/dashboard/src/entities/hermes-config/index.ts
+++ b/apps/dashboard/src/entities/hermes-config/index.ts
@@ -31,6 +31,7 @@ export {
 } from "./web";
 export { BrowserCloudProviderSchema, BrowserSchema, type BrowserCloudProvider, type Browser } from "./browser";
 export { XSearchSchema, type XSearch } from "./x-search";
+export { ImageGenSchema, type ImageGen } from "./image-gen";
 
 import { z } from "zod";
 import { ModelSchema } from "./model";
@@ -39,6 +40,7 @@ import { SlackSchema } from "./slack";
 import { WebSchema } from "./web";
 import { BrowserSchema } from "./browser";
 import { XSearchSchema } from "./x-search";
+import { ImageGenSchema } from "./image-gen";
 
 export const ConfigSchema = z
   .looseObject({
@@ -48,6 +50,7 @@ export const ConfigSchema = z
     web: WebSchema,
     browser: BrowserSchema,
     x_search: XSearchSchema,
+    image_gen: ImageGenSchema,
   })
   .optional()
   .describe(


### PR DESCRIPTION
## Summary

Renames the agent detail page `Tools` section to `Toolsets` and expands the catalog from 8 to all 25 built-in Hermes `CONFIGURABLE_TOOLSETS` entries (in the same order as `vendor/hermes-agent/hermes_cli/tools_config.py`).

## Changes

- **`entities/agent.ts`** — `ToolId` → `ToolsetId` enum (25 entries, dropped `Mcp`, renamed `Cron` → `Cronjob`); `TOOL_META` → `TOOLSET_META` with prose `label`/`description` for all 25; `TOOL_IDS` → `TOOLSET_IDS`; `deriveToolAvailability` → `deriveToolsetEnabled` with `enabled`/`disabled` status (was `available`/`unavailable`); `getToolLabel/Description` → `getToolsetLabel/Description`. Toolset id string values use camelCase.
- **`client/ui/routes/agents/$id/index.tsx`** — `ToolBadge` → `ToolsetBadge`, `ToolsSection` → `ToolsetsSection`; section header `Tools` → `Toolsets`; status check `unavailable` → `disabled`.
- **`entities/agent.test.ts`** — imports + `describe` renamed; no-gate test now covers all 22 non-gated toolsets; status assertions switched to `enabled`/`disabled`.

## Status derivation

Three toolsets keep their existing config/env gates (`Web`, `XSearch`, `Browser`); the other 22 return `enabled` with no config gate. Per-agent toggling (a persisted `platform_toolsets` field) is intentionally out of scope for this refactor — tracked as a follow-up.

## Verification

- `pnpm --filter @hermeum/dashboard typecheck` ✓
- `pnpm --filter @hermeum/dashboard lint` ✓ (no new warnings)
- `pnpm --filter @hermeum/dashboard test -- src/entities/agent.test.ts` ✓ (135 passed)