### PR TITLE
feat(dashboard): add LoggerAdaptor port with ConsoleLogger default

### DIFF
--- a/apps/dashboard/src/server/infras/console-logger.ts
+++ b/apps/dashboard/src/server/infras/console-logger.ts
@@ -1,0 +1,37 @@
+import { LogContext, LogLevel, LoggerAdaptor } from "../usecases/adaptors/logger";
+
+const ORDER: Record<LogLevel, number> = { debug: 10, info: 20, warn: 30, error: 40 };
+
+export class ConsoleLogger implements LoggerAdaptor {
+  #level: LogLevel;
+
+  constructor(level: LogLevel = "info") {
+    this.#level = level;
+  }
+
+  debug(message: string, context?: LogContext): void {
+    this.#emit("debug", console.debug, message, context);
+  }
+
+  info(message: string, context?: LogContext): void {
+    this.#emit("info", console.info, message, context);
+  }
+
+  warn(message: string, context?: LogContext): void {
+    this.#emit("warn", console.warn, message, context);
+  }
+
+  error(message: string, context?: LogContext): void {
+    this.#emit("error", console.error, message, context);
+  }
+
+  #emit(
+    level: LogLevel,
+    sink: (message: string, context: LogContext) => void,
+    message: string,
+    context?: LogContext
+  ): void {
+    if (ORDER[level] < ORDER[this.#level]) return;
+    sink(message, context ?? {});
+  }
+}

--- a/apps/dashboard/src/server/usecases/adaptors/logger.ts
+++ b/apps/dashboard/src/server/usecases/adaptors/logger.ts
@@ -1,0 +1,10 @@
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+export type LogContext = Record<string, unknown>;
+
+export interface LoggerAdaptor {
+  debug(message: string, context?: LogContext): void;
+  info(message: string, context?: LogContext): void;
+  warn(message: string, context?: LogContext): void;
+  error(message: string, context?: LogContext): void;
+}

--- a/apps/dashboard/src/server/usecases/agent.test.ts
+++ b/apps/dashboard/src/server/usecases/agent.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 
 vi.mock("../infras/kubernetes/client", () => ({ KubernetesClient: vi.fn() }));
 vi.mock("../infras/local-files", () => ({ LocalFiles: vi.fn() }));
+vi.mock("../infras/console-logger", () => ({ ConsoleLogger: vi.fn() }));
 vi.mock("@/server/libs/config", () => ({
   config: { agentConfigPath: "./agent-config.yaml", docsPath: "./docs/hermes-config" },
 }));

--- a/apps/dashboard/src/server/usecases/chat.test.ts
+++ b/apps/dashboard/src/server/usecases/chat.test.ts
@@ -5,6 +5,7 @@ import { stringify } from "yaml";
 vi.mock("../infras/local-files", () => ({ LocalFiles: vi.fn() }));
 vi.mock("../infras/kubernetes/client", () => ({ KubernetesClient: vi.fn() }));
 vi.mock("../infras/hermes-skill-index", () => ({ HermesSkillIndex: vi.fn() }));
+vi.mock("../infras/console-logger", () => ({ ConsoleLogger: vi.fn() }));
 vi.mock("@/server/libs/config", () => ({
   config: { agentConfigPath: "./agent-config.yaml", docsPath: "./docs/hermes-config" },
 }));

--- a/apps/dashboard/src/server/usecases/mixin.ts
+++ b/apps/dashboard/src/server/usecases/mixin.ts
@@ -3,20 +3,24 @@ import { parse } from "yaml";
 import { Context, HermeumConfig, HermeumConfigSchema, User } from "@/entities";
 import { config } from "@/server/libs/config";
 
+import { ConsoleLogger } from "../infras/console-logger";
 import { KubernetesClient } from "../infras/kubernetes/client";
 import { HermesSkillIndex } from "../infras/hermes-skill-index";
 import { LocalFiles } from "../infras/local-files";
 import { FileAdaptor } from "./adaptors/file";
+import { LoggerAdaptor } from "./adaptors/logger";
 import { Runtime } from "./adaptors/runtime";
 import { SkillIndexAdaptor } from "./adaptors/skill-index";
 
-// Core base class for use cases backed by the file, runtime, and skill index
-// adaptors; mixins like HermeumConfigLoadable build on the injected adaptors.
+// Core base class for use cases backed by the file, runtime, skill index, and
+// logger adaptors; mixins like HermeumConfigLoadable build on the injected
+// adaptors.
 export class BaseUseCase {
   constructor(
     readonly runtime: Runtime = new KubernetesClient(),
     readonly files: FileAdaptor = new LocalFiles(),
-    readonly skillIndex: SkillIndexAdaptor = new HermesSkillIndex()
+    readonly skillIndex: SkillIndexAdaptor = new HermesSkillIndex(),
+    readonly logger: LoggerAdaptor = new ConsoleLogger(config.debugMode ? "debug" : "info")
   ) {}
 }
 


### PR DESCRIPTION
## Summary

Introduces a new logger adaptor following the existing hexagonal (ports-and-adapters) pattern: the interface lives in `usecases/adaptors/`, the concrete implementation in `infras/`, and it is constructor-injected into `BaseUseCase` alongside `runtime`, `files`, and `skillIndex`.

This is the **first step** of reporter/logging support — only the adaptor itself is added. No usecase method bodies are touched and no automatic exception reporting is wired yet; that comes in a follow-up.

## Changes

- **`usecases/adaptors/logger.ts`** (new) — `LoggerAdaptor` interface with `debug`/`info`/`warn`/`error` (each `(message: string, context?: LogContext) => void`), plus the `LogLevel` and `LogContext` types.
- **`infras/console-logger.ts`** (new) — `ConsoleLogger implements LoggerAdaptor`. Routes each level to its `console.*` sink and gates output by a constructor-level threshold (default `info`).
- **`usecases/mixin.ts`** — `BaseUseCase` now takes `logger` as its fourth adaptor param, defaulting to `ConsoleLogger(config.debugMode ? "debug" : "info")` so the level respects the existing `HERMEUM_DEBUG_MODE` env flag.
- **`usecases/agent.test.ts`, `usecases/chat.test.ts`** — added `vi.mock("../infras/console-logger", ...)` next to the existing infras mocks to preserve the no-production-defaults convention in tests.

## Verification

- `pnpm --filter @hermeum/dashboard typecheck` — clean
- `pnpm --filter @hermeum/dashboard lint` — 0 errors (only pre-existing warnings)
- `pnpm --filter @hermeum/dashboard test` — 262/262 passing (6 files)

## Next step (follow-up)

Wire the logger into usecase execution — either manually in catch blocks (`this.logger.error(...)`) or via a new `LoggerReporting` mixin analogous to `OwnershipGuarded`/`HermeumConfigLoadable`, plus a `captureException` method on the interface.