### PR TITLE
refactor(dashboard): replace boolean debugMode with leveled debugLevel

### DIFF
--- a/apps/dashboard/src/server/libs/config.ts
+++ b/apps/dashboard/src/server/libs/config.ts
@@ -48,10 +48,10 @@ export const ConfigSchema = z.object({
     .url()
     .optional()
     .describe("Override the OpenAI API base URL (HERMEUM_OPENAI_BASE_URL)."),
-  debugMode: z
-    .preprocess((v) => v === "true", z.boolean())
-    .default(false)
-    .describe("Enable verbose debug logging (HERMEUM_DEBUG_MODE)."),
+  debugLevel: z
+    .enum(["debug", "info", "warn", "error"])
+    .default("info")
+    .describe("Log verbosity level (HERMEUM_DEBUG_LEVEL)."),
   agentIngressScheme: z
     .enum(["http", "https"])
     .default("http")
@@ -95,7 +95,7 @@ export const config = ConfigSchema.parse({
   hermesImageTag: process.env.HERMEUM_HERMES_IMAGE_TAG,
   openaiModel: process.env.HERMEUM_OPENAI_MODEL,
   openaiBaseUrl: process.env.HERMEUM_OPENAI_BASE_URL,
-  debugMode: process.env.HERMEUM_DEBUG_MODE,
+  debugLevel: process.env.HERMEUM_DEBUG_LEVEL,
   agentIngressScheme: process.env.HERMEUM_AGENT_INGRESS_SCHEME,
   agentIngressBaseHostname: process.env.HERMEUM_AGENT_INGRESS_BASE_HOSTNAME,
   agentIngressClassName: process.env.HERMEUM_AGENT_INGRESS_CLASS_NAME,

--- a/apps/dashboard/src/server/routers/ai-sdk/agent-config.ts
+++ b/apps/dashboard/src/server/routers/ai-sdk/agent-config.ts
@@ -70,7 +70,7 @@ aiSdkRouter.post("/agent-config", async (req, res) => {
     providerOptions: {
       openai: { strictJsonSchema: false },
     },
-    ...(config.debugMode && {
+    ...(config.debugLevel === "debug" && {
       onStepFinish: ({ stepNumber, finishReason, toolCalls, text, usage }) => {
         const toolsCalled = toolCalls.map((c) => c.toolName).join(",") || "-";
         const preview = text.slice(0, 80).replace(/\n/g, " ");

--- a/apps/dashboard/src/server/usecases/mixin.ts
+++ b/apps/dashboard/src/server/usecases/mixin.ts
@@ -20,7 +20,7 @@ export class BaseUseCase {
     readonly runtime: Runtime = new KubernetesClient(),
     readonly files: FileAdaptor = new LocalFiles(),
     readonly skillIndex: SkillIndexAdaptor = new HermesSkillIndex(),
-    readonly logger: LoggerAdaptor = new ConsoleLogger(config.debugMode ? "debug" : "info")
+    readonly logger: LoggerAdaptor = new ConsoleLogger(config.debugLevel)
   ) {}
 }
 


### PR DESCRIPTION
Replaces the boolean `debugMode` config (env `HERMEUM_DEBUG_MODE`) with a leveled `debugLevel` enum (env `HERMEUM_DEBUG_LEVEL`) supporting `debug`/`info`/`warn`/`error`, defaulting to `info`.

## Changes

- **`apps/dashboard/src/server/libs/config.ts`** — Replaced `debugMode: z.preprocess((v) => v === "true", z.boolean()).default(false)` with `debugLevel: z.enum(["debug","info","warn","error"]).default("info")`. Kept the enum inline rather than importing from `adaptors/logger.ts` to avoid an upward `libs → usecases` dependency.
- **`apps/dashboard/src/server/usecases/mixin.ts`** — `BaseUseCase` now constructs `new ConsoleLogger(config.debugLevel)` (was `config.debugMode ? "debug" : "info"`).
- **`apps/dashboard/src/server/routers/ai-sdk/agent-config.ts`** — The verbose `onStepFinish` hook gate is now `config.debugLevel === "debug"` (was `config.debugMode && …`), preserving the "only emit step logs at debug level" semantic.

## Verification

- Typecheck: clean
- Lint: 0 errors (2 pre-existing warnings unrelated to this change)
- Tests: 267 passed