### PR TITLE
refactor(dashboard): simplify agent detail badges and align platform section with toolsets

### DIFF
--- a/apps/dashboard/src/client/ui/routes/agents/$id/index.tsx
+++ b/apps/dashboard/src/client/ui/routes/agents/$id/index.tsx
@@ -8,7 +8,6 @@ import { toast } from "sonner";
 import { Badge } from "@hermeum/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@hermeum/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@hermeum/components/ui/tooltip";
-import { Popover, PopoverContent, PopoverTrigger } from "@hermeum/components/ui/popover";
 import { useTRPC } from "@/router";
 import {
   TOOLSET_IDS,
@@ -144,8 +143,8 @@ function PlatformBadge({ id, agent }: { id: PlatformId; agent: Agent }) {
   const label = getPlatformLabel(id);
   const description = getPlatformDescription(id);
   return (
-    <Popover>
-      <PopoverTrigger
+    <Tooltip>
+      <TooltipTrigger
         render={
           <Button
             variant="outline"
@@ -157,8 +156,8 @@ function PlatformBadge({ id, agent }: { id: PlatformId; agent: Agent }) {
         }
       >
         {label}
-      </PopoverTrigger>
-      <PopoverContent className="max-w-sm">
+      </TooltipTrigger>
+      <TooltipContent className="max-w-sm">
         <div className="flex flex-col gap-0.5">
           <span>{description}</span>
           {endpoints !== undefined && endpoints.length > 0 && (
@@ -178,8 +177,8 @@ function PlatformBadge({ id, agent }: { id: PlatformId; agent: Agent }) {
             </span>
           )}
         </div>
-      </PopoverContent>
-    </Popover>
+      </TooltipContent>
+    </Tooltip>
   );
 }
 
@@ -203,11 +202,13 @@ function PlatformsSection({ agent }: { agent: Agent }) {
           </TooltipContent>
         </Tooltip>
       </div>
-      <div className="flex flex-wrap gap-2">
-        {PLATFORM_IDS.map((id) => (
-          <PlatformBadge key={id} id={id} agent={agent} />
-        ))}
-      </div>
+      <TooltipProvider>
+        <div className="flex flex-wrap gap-2">
+          {PLATFORM_IDS.map((id) => (
+            <PlatformBadge key={id} id={id} agent={agent} />
+          ))}
+        </div>
+      </TooltipProvider>
     </div>
   );
 }

--- a/apps/dashboard/src/client/ui/routes/agents/$id/index.tsx
+++ b/apps/dashboard/src/client/ui/routes/agents/$id/index.tsx
@@ -67,7 +67,7 @@ function ButtonList({ items, max = BADGE_MAX }: { items: string[]; max?: number 
           key={item}
           variant="outline"
           size="sm"
-          className="h-auto px-2 py-1 font-mono text-xs"
+          className="h-auto px-2 py-1 font-mono text-xs normal-case tracking-normal"
         >
           {item}
         </Button>
@@ -88,7 +88,7 @@ function ToolsetBadge({ id, agent }: { id: ToolsetId; agent: Agent }) {
           <Button
             variant="outline"
             size="sm"
-            className={`h-auto px-2 py-1 font-mono text-xs ${
+            className={`h-auto px-2 py-1 font-mono text-xs normal-case tracking-normal ${
               status === "unavailable" ? "text-muted-foreground opacity-60" : ""
             }`}
           />
@@ -150,7 +150,7 @@ function PlatformBadge({ id, agent }: { id: PlatformId; agent: Agent }) {
           <Button
             variant="outline"
             size="sm"
-            className={`h-auto px-2 py-1 font-mono text-xs ${
+            className={`h-auto px-2 py-1 font-mono text-xs normal-case tracking-normal ${
               status === "unavailable" ? "text-muted-foreground opacity-60" : ""
             }`}
           />
@@ -170,9 +170,6 @@ function PlatformBadge({ id, agent }: { id: PlatformId; agent: Agent }) {
                 </div>
               ))}
             </div>
-          )}
-          {status === "available" && id === "slack" && endpoints === undefined && (
-            <span className="opacity-80">Socket Mode — no public endpoint.</span>
           )}
           {home !== undefined && <span>Home channel: {home}</span>}
           {reason && (
@@ -419,7 +416,7 @@ function AgentDetailPage() {
                       key={v.name}
                       variant="outline"
                       size="sm"
-                      className="h-auto px-2 py-1 font-mono text-xs"
+                      className="h-auto px-2 py-1 font-mono text-xs normal-case tracking-normal"
                     >
                       {v.name}={v.value}
                     </Button>
@@ -457,7 +454,7 @@ function AgentDetailPage() {
                                 key={v.name}
                                 variant="outline"
                                 size="sm"
-                                className="h-auto px-2 py-1 font-mono text-xs"
+                                className="h-auto px-2 py-1 font-mono text-xs normal-case tracking-normal"
                               >
                                 {v.name}
                               </Button>


### PR DESCRIPTION
## Summary

Cleans up the badge UX on the agent detail page (`apps/dashboard/src/client/ui/routes/agents//index.tsx`).

### Changes

- **Remove Slack socket-mode notice** — the "Socket Mode — no public endpoint." popover notice was Slack-specific and no longer necessary; dropped the conditional block.
- **Normalize badge case** — override the Button base styles (`uppercase tracking-widest`) with `normal-case tracking-normal` on all outline badge-style buttons (toolsets, platforms, skills/plugins, env vars, shared env set vars) so mono labels render in their natural case.
- **Align platform badges with toolsets** — replace the click-to-open `Popover` in `PlatformBadge` with a hover `Tooltip`, mirroring `ToolsetBadge`. Wrap `PlatformsSection` badges in `TooltipProvider` and remove the now-unused `Popover` import.

### Verification

- `pnpm --filter @hermeum/dashboard typecheck` — passes
- `pnpm --filter @hermeum/dashboard lint` — passes (only 2 pre-existing unrelated warnings)

### Notes

Tooltips close on mouse-out, so endpoint URLs and their copy buttons inside the platform tooltip are no longer clickable. If preserving click-to-copy for endpoints is needed, we can keep the endpoints list out of the tooltip or revisit using a Popover solely for available platforms.

### Commits

- `c37e565` refactor(dashboard): drop Slack socket-mode notice and normalize badge case
- `e14bd5d` refactor(dashboard): align platform badges with tooltip-based toolsets section