### PR TITLE
refactor(dashboard): hoist Agent type next to AgentInput

### DIFF
--- a/apps/dashboard/src/entities/agent.ts
+++ b/apps/dashboard/src/entities/agent.ts
@@ -495,6 +495,30 @@ export const AgentInputSchema = AgentInputObjectSchema.superRefine((data, ctx) =
 
 export type AgentInput = z.infer<typeof AgentInputSchema>;
 
+export const AgentPhaseSchema = z.enum([
+  "Pending",
+  "Running",
+  "Succeeded",
+  "Failed",
+  "Unknown",
+  "Suspended",
+]);
+export type AgentPhase = z.infer<typeof AgentPhaseSchema>;
+
+export const AgentSchema = AgentInputObjectSchema.extend({
+  id: z.string().min(1),
+  userId: z.string().min(1),
+  suspended: z.boolean().optional(),
+  archived: z.boolean().optional(),
+  phase: AgentPhaseSchema.optional(),
+  reason: z.string().optional(),
+  // Public base URL of the agent's ingress. Output-only; null when no ingress.
+  endpoint: z.string().url().nullable().optional(),
+  createdAt: z.date().optional(),
+}).readonly();
+
+export type Agent = z.infer<typeof AgentSchema>;
+
 // API server settings are configured exclusively via env vars (see
 // docs/hermes-config/api-server.md). These helpers read those env vars off an
 // `AgentInput`.
@@ -694,30 +718,6 @@ function endpointsFor(
   }
   return { endpoints: subpaths.map((p) => `${endpoint}${p}`) };
 }
-
-export const AgentPhaseSchema = z.enum([
-  "Pending",
-  "Running",
-  "Succeeded",
-  "Failed",
-  "Unknown",
-  "Suspended",
-]);
-export type AgentPhase = z.infer<typeof AgentPhaseSchema>;
-
-export const AgentSchema = AgentInputObjectSchema.extend({
-  id: z.string().min(1),
-  userId: z.string().min(1),
-  suspended: z.boolean().optional(),
-  archived: z.boolean().optional(),
-  phase: AgentPhaseSchema.optional(),
-  reason: z.string().optional(),
-  // Public base URL of the agent's ingress. Output-only; null when no ingress.
-  endpoint: z.string().url().nullable().optional(),
-  createdAt: z.date().optional(),
-}).readonly();
-
-export type Agent = z.infer<typeof AgentSchema>;
 
 // Toolset availability — a derived, read-only view of which Hermes toolsets
 // are usable for an agent, computed from its config + env. Not persisted.


### PR DESCRIPTION
## What

Hoists `AgentSchema`, `Agent`, `AgentPhaseSchema`, and `AgentPhase` from the bottom of `src/entities/agent.ts` to sit immediately after `AgentInput` (line ~496), separating the input/persisted type pair from the helper functions that follow.

## Why

The `AgentInput` → `Agent` type pair is the core type definition of the entity, but `Agent` was defined ~220 lines below `AgentInput`, buried after the API-server/webhook helpers and the platform-availability section. Colocating them makes the schema hierarchy readable as one unit and leaves the derived/helper code below.

## Notes

- No behavior change — pure relocation; 24 lines moved, 0 added/removed.
- All four hoisted symbols are prerequisites of nothing in the intervening helper block (`isApiServerEnabled`, `getApiServerPort`, `isWebhookEnabled`, `getWebhookPort`, the platform-availability section) — those consume only `AgentInput`.
- The downstream toolset-availability section (`deriveToolsetAvailability`) consumes `Agent` and now finds it defined further up; still valid.

## Verification

- `pnpm --filter @hermeum/dashboard typecheck` — passes
- `pnpm --filter @hermeum/dashboard test -- src/entities/agent.test.ts` — 149/149 pass