### PR TITLE
feat(agents): support Microsoft Teams as a message platform

### DIFF
--- a/apps/dashboard/docs/hermes-config/slack.md
+++ b/apps/dashboard/docs/hermes-config/slack.md
@@ -13,6 +13,12 @@ Requires `SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`, and `SLACK_ALLOWED_USERS`
 env vars (see [Environment variables](#environment-variables)); without
 `SLACK_ALLOWED_USERS` the gateway denies all messages by default.
 
+Using Slack also requires configuration on the Slack side (app creation,
+socket mode, scopes, event subscriptions). Follow the official Hermes
+Agent guide at
+https://hermes-agent.nousresearch.com/docs/user-guide/messaging/slack
+to complete that setup.
+
 Slack config lives in **two** `config.yaml` locations — keep them
 straight, they are not interchangeable:
 

--- a/apps/dashboard/docs/hermes-config/teams.md
+++ b/apps/dashboard/docs/hermes-config/teams.md
@@ -45,12 +45,6 @@ platforms:
 
 `extra.port` takes precedence over the `TEAMS_PORT` env var when both are set.
 
-## Ingress routing
-
-The Teams webhook path `/api/messages` is emitted in the generated ingress
-**before** the api-server's `/api` prefix so the controller's longest-prefix
-match routes inbound Teams traffic to port 3978, not 8642.
-
 ## Example
 
 ### Enabling the Teams bot with env vars

--- a/apps/dashboard/docs/hermes-config/teams.md
+++ b/apps/dashboard/docs/hermes-config/teams.md
@@ -12,6 +12,12 @@ publicly reachable endpoint — either a dev tunnel (local dev) or a real
 domain (production). Unlike Slack's Socket Mode, Teams is an HTTP-webhook
 platform.
 
+Using Teams also requires configuration on the Teams side (bot
+registration, messaging endpoint, app installation). Follow the official
+Hermes Agent guide at
+https://hermes-agent.nousresearch.com/docs/user-guide/messaging/teams
+to complete that setup.
+
 ## Configuration
 
 Teams is enabled when the three credentials are present as environment

--- a/apps/dashboard/docs/hermes-config/teams.md
+++ b/apps/dashboard/docs/hermes-config/teams.md
@@ -1,7 +1,7 @@
 ---
 name: teams
 category: platforms
-description: Microsoft Teams bot — HTTPS webhook on /api/messages.
+description: Microsoft Teams bot configuration.
 ---
 
 # Microsoft Teams configuration

--- a/apps/dashboard/docs/hermes-config/teams.md
+++ b/apps/dashboard/docs/hermes-config/teams.md
@@ -1,0 +1,78 @@
+---
+name: teams
+category: platforms
+description: Microsoft Teams bot — HTTPS webhook on /api/messages.
+---
+
+# Microsoft Teams configuration
+
+Exposes hermes-agent as a Microsoft Teams bot. Teams delivers messages by
+calling a public HTTPS webhook at `/api/messages`, so the agent needs a
+publicly reachable endpoint — either a dev tunnel (local dev) or a real
+domain (production). Unlike Slack's Socket Mode, Teams is an HTTP-webhook
+platform.
+
+## Configuration
+
+Teams is enabled when the three credentials are present as environment
+variables (`TEAMS_CLIENT_ID`, `TEAMS_CLIENT_SECRET`, `TEAMS_TENANT_ID`).
+Credentials must not be written into `config.yaml` — `config.yaml` is for
+non-secret settings only. An explicit `enabled: false` disables the bot
+while keeping credentials in env.
+
+### Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `TEAMS_CLIENT_ID` | _(required)_ | Azure AD App (client) ID. |
+| `TEAMS_CLIENT_SECRET` | _(required)_ | Azure AD client secret. Mark `sensitive: true` in the agent env. |
+| `TEAMS_TENANT_ID` | _(required)_ | Azure AD tenant ID. |
+| `TEAMS_PORT` | `3978` | Webhook server port. |
+| `TEAMS_ALLOWED_USERS` | _(recommended)_ | Comma-separated AAD object IDs allowed to use the bot. |
+| `TEAMS_ALLOW_ALL_USERS` | _(none)_ | Set `true` to skip the allowlist and allow anyone. |
+
+### config.yaml
+
+Only behavioral settings live under `config.platforms.teams.extra`:
+
+```yaml
+platforms:
+  teams:
+    enabled: true
+    extra:
+      port: 3978
+```
+
+`extra.port` takes precedence over the `TEAMS_PORT` env var when both are set.
+
+## Ingress routing
+
+The Teams webhook path `/api/messages` is emitted in the generated ingress
+**before** the api-server's `/api` prefix so the controller's longest-prefix
+match routes inbound Teams traffic to port 3978, not 8642.
+
+## Example
+
+### Enabling the Teams bot with env vars
+
+Credentials come from env vars; the config only needs to opt in:
+
+```yaml
+platforms:
+  teams:
+    enabled: true
+env:
+  - name: TEAMS_CLIENT_ID
+    value: 00000000-0000-0000-0000-000000000000
+  - name: TEAMS_CLIENT_SECRET
+    value: change-me
+    sensitive: true
+  - name: TEAMS_TENANT_ID
+    value: 00000000-0000-0000-0000-000000000000
+  - name: TEAMS_ALLOWED_USERS
+    value: 00000000-0000-0000-0000-000000000000
+```
+
+When `enabled` is omitted, Teams is auto-enabled once all three `TEAMS_*`
+credentials are present — so the `platforms.teams` block above is optional
+but makes the intent explicit.

--- a/apps/dashboard/src/entities/agent.test.ts
+++ b/apps/dashboard/src/entities/agent.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { z } from "zod";
 
-import { AgentInputObjectSchema, AgentInputSchema, SkillSchema, isApiServerEnabled, getApiServerPort, isWebhookEnabled, getWebhookPort, ToolId, deriveToolAvailability, PlatformId, derivePlatformAvailability, type Agent } from "./agent";
+import { AgentInputObjectSchema, AgentInputSchema, SkillSchema, isApiServerEnabled, getApiServerPort, isWebhookEnabled, getWebhookPort, isTeamsEnabled, getTeamsPort, ToolId, deriveToolAvailability, PlatformId, derivePlatformAvailability, type Agent } from "./agent";
 
 function makeInput(overrides: Record<string, unknown> = {}) {
   return {
@@ -270,6 +270,150 @@ describe("getWebhookPort", () => {
         config: { platforms: { webhook: { extra: { port: 9000 } } } },
       })
     ).toBe(9000);
+  });
+});
+
+describe("AgentInputSchema teams secret validation", () => {
+  const teamsCredsEnv = [
+    { name: "TEAMS_CLIENT_ID", value: "cid" },
+    { name: "TEAMS_CLIENT_SECRET", value: "sec", sensitive: true },
+    { name: "TEAMS_TENANT_ID", value: "tid" },
+  ];
+
+  it("fails when teams is enabled via creds and env lacks sensitive TEAMS_CLIENT_SECRET", () => {
+    const result = AgentInputSchema.safeParse({
+      env: [
+        { name: "TEAMS_CLIENT_ID", value: "cid" },
+        { name: "TEAMS_CLIENT_SECRET", value: "sec" },
+        { name: "TEAMS_TENANT_ID", value: "tid" },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("succeeds when teams is enabled and TEAMS_CLIENT_SECRET is sensitive", () => {
+    const result = AgentInputSchema.safeParse({ env: teamsCredsEnv });
+    expect(result.success).toBe(true);
+  });
+
+  it("fails when teams is enabled via config flag and TEAMS_CLIENT_SECRET is missing", () => {
+    const result = AgentInputSchema.safeParse({
+      config: { platforms: { teams: { enabled: true } } },
+      env: [
+        { name: "TEAMS_CLIENT_ID", value: "cid" },
+        { name: "TEAMS_TENANT_ID", value: "tid" },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("succeeds when teams is explicitly disabled regardless of env", () => {
+    const result = AgentInputSchema.safeParse({
+      config: { platforms: { teams: { enabled: false } } },
+      env: teamsCredsEnv,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("succeeds when teams config is omitted entirely", () => {
+    const result = AgentInputSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("isTeamsEnabled", () => {
+  const teamsCredsEnv = [
+    { name: "TEAMS_CLIENT_ID", value: "cid" },
+    { name: "TEAMS_CLIENT_SECRET", value: "sec", sensitive: true },
+    { name: "TEAMS_TENANT_ID", value: "tid" },
+  ];
+
+  it("is enabled when all three credentials are in env", () => {
+    expect(isTeamsEnabled({ env: teamsCredsEnv })).toBe(true);
+  });
+
+  it("is disabled when any credential is missing from env", () => {
+    expect(isTeamsEnabled({ env: teamsCredsEnv.slice(0, 2) })).toBe(false);
+    expect(
+      isTeamsEnabled({ env: [{ name: "TEAMS_CLIENT_ID", value: "cid" }] })
+    ).toBe(false);
+    expect(isTeamsEnabled({})).toBe(false);
+  });
+
+  it("treats the <secret> sentinel for sensitive TEAMS_CLIENT_SECRET as set", () => {
+    expect(
+      isTeamsEnabled({
+        env: [
+          { name: "TEAMS_CLIENT_ID", value: "cid" },
+          { name: "TEAMS_CLIENT_SECRET", value: "<secret>", sensitive: true },
+          { name: "TEAMS_TENANT_ID", value: "tid" },
+        ],
+      })
+    ).toBe(true);
+  });
+
+  it("prefers config.platforms.teams.enabled=false over present credentials", () => {
+    expect(
+      isTeamsEnabled({
+        env: teamsCredsEnv,
+        config: { platforms: { teams: { enabled: false } } },
+      })
+    ).toBe(false);
+  });
+
+  it("prefers config.platforms.teams.enabled=true over missing credentials", () => {
+    expect(
+      isTeamsEnabled({
+        config: { platforms: { teams: { enabled: true } } },
+      })
+    ).toBe(true);
+  });
+
+  it("ignores whitespace-only credential values", () => {
+    expect(
+      isTeamsEnabled({
+        env: [
+          { name: "TEAMS_CLIENT_ID", value: "  " },
+          { name: "TEAMS_CLIENT_SECRET", value: "sec", sensitive: true },
+          { name: "TEAMS_TENANT_ID", value: "tid" },
+        ],
+      })
+    ).toBe(false);
+  });
+});
+
+describe("getTeamsPort", () => {
+  it("returns the parsed port when TEAMS_PORT is a positive integer", () => {
+    expect(getTeamsPort({ env: [{ name: "TEAMS_PORT", value: "4000" }] })).toBe(4000);
+  });
+
+  it("falls back to 3978 when TEAMS_PORT is missing or empty", () => {
+    expect(getTeamsPort({})).toBe(3978);
+    expect(getTeamsPort({ env: [] })).toBe(3978);
+    expect(getTeamsPort({ env: [{ name: "TEAMS_PORT", value: "" }] })).toBe(3978);
+    expect(getTeamsPort({ env: [{ name: "TEAMS_PORT", value: "   " }] })).toBe(3978);
+  });
+
+  it("falls back to 3978 when TEAMS_PORT is not a positive integer", () => {
+    expect(getTeamsPort({ env: [{ name: "TEAMS_PORT", value: "0" }] })).toBe(3978);
+    expect(getTeamsPort({ env: [{ name: "TEAMS_PORT", value: "-1" }] })).toBe(3978);
+    expect(getTeamsPort({ env: [{ name: "TEAMS_PORT", value: "abc" }] })).toBe(3978);
+    expect(getTeamsPort({ env: [{ name: "TEAMS_PORT", value: "1.5" }] })).toBe(3978);
+  });
+
+  it("returns config.platforms.teams.extra.port when TEAMS_PORT env var is absent", () => {
+    expect(
+      getTeamsPort({ config: { platforms: { teams: { extra: { port: 4000 } } } } })
+    ).toBe(4000);
+  });
+
+  it("prefers config.platforms.teams.extra.port over the TEAMS_PORT env var", () => {
+    expect(
+      getTeamsPort({
+        env: [{ name: "TEAMS_PORT", value: "4001" }],
+        config: { platforms: { teams: { extra: { port: 4000 } } } },
+      })
+    ).toBe(4000);
   });
 });
 
@@ -910,6 +1054,97 @@ describe("derivePlatformAvailability", () => {
         makeAgent({ config: { slack: { allowed_channels: ["C01"] } } })
       );
       expect(result.status).toBe("unavailable");
+    });
+  });
+
+  describe("teams", () => {
+    const teamsCredsEnv = [
+      { name: "TEAMS_CLIENT_ID", value: "cid" },
+      { name: "TEAMS_CLIENT_SECRET", value: "sec", sensitive: true },
+      { name: "TEAMS_TENANT_ID", value: "tid" },
+    ];
+
+    it("is unavailable when all credentials are missing", () => {
+      const result = derivePlatformAvailability(PlatformId.Teams, makeAgent());
+      expect(result.status).toBe("unavailable");
+      expect(result.reason).toContain("TEAMS_CLIENT_ID");
+      expect(result.reason).toContain("TEAMS_CLIENT_SECRET");
+      expect(result.reason).toContain("TEAMS_TENANT_ID");
+    });
+
+    it("names only the missing credentials when some are set", () => {
+      const result = derivePlatformAvailability(
+        PlatformId.Teams,
+        makeAgent({ env: [{ name: "TEAMS_CLIENT_ID", value: "cid" }] })
+      );
+      expect(result.status).toBe("unavailable");
+      expect(result.reason).not.toContain("TEAMS_CLIENT_ID");
+      expect(result.reason).toContain("TEAMS_CLIENT_SECRET");
+      expect(result.reason).toContain("TEAMS_TENANT_ID");
+    });
+
+    it("is unavailable when enabled:false is explicit (even with creds present)", () => {
+      const result = derivePlatformAvailability(
+        PlatformId.Teams,
+        makeAgent({ env: teamsCredsEnv, config: { platforms: { teams: { enabled: false } } } })
+      );
+      expect(result.status).toBe("unavailable");
+      expect(result.reason).toContain("Disabled");
+    });
+
+    it("is available with no home when all credentials are set via env", () => {
+      const result = derivePlatformAvailability(
+        PlatformId.Teams,
+        makeAgent({ env: teamsCredsEnv })
+      );
+      expect(result.status).toBe("available");
+      expect(result.port).toBe(3978);
+      expect(result.home).toBeUndefined();
+    });
+
+    it("is available when enabled:true is set explicitly without env creds", () => {
+      const result = derivePlatformAvailability(
+        PlatformId.Teams,
+        makeAgent({ config: { platforms: { teams: { enabled: true } } } })
+      );
+      expect(result.status).toBe("available");
+      expect(result.port).toBe(3978);
+    });
+
+    it("reports endpoints on an ingress base URL (no port inserted)", () => {
+      const result = derivePlatformAvailability(
+        PlatformId.Teams,
+        makeAgent({ endpoint: "https://a1.example.com", env: teamsCredsEnv })
+      );
+      expect(result.status).toBe("available");
+      expect(result.endpoints).toEqual(["https://a1.example.com/api/messages"]);
+    });
+
+    it("inserts the port on internal .svc.cluster.local endpoints", () => {
+      const result = derivePlatformAvailability(
+        PlatformId.Teams,
+        makeAgent({
+          endpoint: "http://a1.agents.svc.cluster.local",
+          env: teamsCredsEnv,
+        })
+      );
+      expect(result.endpoints).toEqual([
+        "http://a1.agents.svc.cluster.local:3978/api/messages",
+      ]);
+    });
+
+    it("respects a custom TEAMS_PORT env var in the endpoint URL", () => {
+      const result = derivePlatformAvailability(
+        PlatformId.Teams,
+        makeAgent({
+          endpoint: "http://a1.agents.svc.cluster.local",
+          env: [...teamsCredsEnv, { name: "TEAMS_PORT", value: "4000" }],
+        })
+      );
+      expect(result.port).toBe(4000);
+      expect(result.endpoints).toEqual([
+        "http://a1.agents.svc.cluster.local:4000/api/messages",
+      ]);
     });
   });
 });

--- a/apps/dashboard/src/entities/agent.ts
+++ b/apps/dashboard/src/entities/agent.ts
@@ -479,6 +479,9 @@ export const AgentInputSchema = AgentInputObjectSchema.superRefine((data, ctx) =
   if (isApiServerEnabled(data)) {
     requireSensitiveEnv("API_SERVER_KEY", "env.API_SERVER_ENABLED");
   }
+  if (isTeamsEnabled(data)) {
+    requireSensitiveEnv("TEAMS_CLIENT_SECRET", "teams enabled (env var or config)");
+  }
 
   data.env?.forEach((v, i) => {
     if (v.value === ENV_PLACEHOLDER_SENTINEL) {
@@ -543,6 +546,37 @@ export function getWebhookPort(input: AgentInput): number {
   return WEBHOOK_DEFAULT_PORT;
 }
 
+// Teams is an HTTP webhook platform (like webhook / api-server). Credentials
+// (client_id, client_secret, tenant_id) are env-only (TEAMS_*) — they must not
+// be written into config.yaml. An explicit `enabled` flag overrides the
+// credentials-presence detection (set false to disable while keeping creds);
+// when `enabled` is absent, Teams is on when all three TEAMS_* env vars are set.
+const TEAMS_DEFAULT_PORT = 3978;
+const TEAMS_REQUIRED_ENV_VARS = ["TEAMS_CLIENT_ID", "TEAMS_CLIENT_SECRET", "TEAMS_TENANT_ID"];
+
+function hasAllTeamsCredentials(input: AgentInput): boolean {
+  return TEAMS_REQUIRED_ENV_VARS.every(
+    (name) => input.env?.some((v) => v.name === name && v.value.trim() !== "") ?? false,
+  );
+}
+
+export function isTeamsEnabled(input: AgentInput): boolean {
+  const enabledFlag = input.config?.platforms?.teams?.enabled;
+  if (enabledFlag !== undefined) return enabledFlag;
+  return hasAllTeamsCredentials(input);
+}
+
+export function getTeamsPort(input: AgentInput): number {
+  const configPort = input.config?.platforms?.teams?.extra?.port;
+  if (configPort !== undefined) return configPort;
+  const envRaw = input.env?.find((v) => v.name === "TEAMS_PORT")?.value;
+  if (envRaw !== undefined && envRaw.trim() !== "") {
+    const n = Number(envRaw);
+    return Number.isInteger(n) && n > 0 ? n : TEAMS_DEFAULT_PORT;
+  }
+  return TEAMS_DEFAULT_PORT;
+}
+
 // Message-platform availability — a derived, read-only view of which inbound
 // message platforms are wired up for an agent, computed from its config + env.
 // Not persisted.
@@ -552,6 +586,7 @@ export enum PlatformId {
   ApiServer = "api-server",
   Webhook = "webhook",
   Slack = "slack",
+  Teams = "teams",
 }
 
 export interface PlatformAvailability {
@@ -583,6 +618,10 @@ export const PLATFORM_INGRESS_SUBPATHS: Partial<Record<PlatformId, string[]>> = 
   // /v1 is the main OpenAI-compatible path; /api is the generic alias.
   [PlatformId.ApiServer]: ["/v1", "/api"],
   [PlatformId.Webhook]: ["/webhooks"],
+  // Teams Bot Framework posts inbound messages to /api/messages.
+  // Must be emitted before the api-server /api prefix in the ingress so
+  // the longest-prefix match routes to the Teams port (3978), not 8642.
+  [PlatformId.Teams]: ["/api/messages"],
   // Slack uses Socket Mode — no inbound HTTP subpath.
 };
 
@@ -604,6 +643,10 @@ const PLATFORM_META: Record<PlatformId, PlatformMeta> = {
     label: "Slack",
     description: "Slack bot relayed through the gateway (Socket Mode).",
   },
+  [PlatformId.Teams]: {
+    label: "Teams",
+    description: "Microsoft Teams bot relayed through the gateway (HTTPS webhook).",
+  },
 };
 
 export function getPlatformLabel(id: PlatformId): string {
@@ -619,6 +662,7 @@ export const PLATFORM_IDS: readonly PlatformId[] = [
   PlatformId.ApiServer,
   PlatformId.Webhook,
   PlatformId.Slack,
+  PlatformId.Teams,
 ];
 
 const SLACK_REQUIRED_ENV_VARS = ["SLACK_BOT_TOKEN", "SLACK_APP_TOKEN", "SLACK_ALLOWED_USERS"];
@@ -669,6 +713,29 @@ export function derivePlatformAvailability(id: PlatformId, agent: Agent): Platfo
         return { status: "available", home: homeName ? `${home} (${homeName})` : home };
       }
       return { status: "available" };
+    }
+    case PlatformId.Teams: {
+      // An explicit `enabled: false` short-circuits to unavailable even when
+      // credentials are present.
+      if (!isTeamsEnabled(agent)) {
+        const enabledFlag = agent.config?.platforms?.teams?.enabled;
+        if (enabledFlag === false) {
+          return { status: "unavailable", reason: "Disabled by config.platforms.teams.enabled." };
+        }
+        const missing = TEAMS_REQUIRED_ENV_VARS.filter(
+          (name) => !env.some((v) => v.name === name && v.value.trim() !== ""),
+        );
+        return {
+          status: "unavailable",
+          reason: `Missing env var${missing.length > 1 ? "s" : ""}: ${missing.join(", ")}.`,
+        };
+      }
+      const port = getTeamsPort(agent);
+      return {
+        status: "available",
+        port,
+        ...endpointsFor(agent.endpoint, subpaths, port),
+      };
     }
   }
 }

--- a/apps/dashboard/src/entities/hermes-config/index.ts
+++ b/apps/dashboard/src/entities/hermes-config/index.ts
@@ -13,13 +13,12 @@ export {
   DeliverExtraSchema,
   WebhookRouteSchema,
   WebhookSchema,
-  PlatformsSchema,
   type WebhookDeliver,
   type DeliverExtra,
   type WebhookRoute,
   type Webhook,
-  type Platforms,
 } from "./webhook";
+export { TeamsSchema, type Teams } from "./teams";
 export { SlackSchema, ChannelSkillBindingSchema, type Slack, type ChannelSkillBinding } from "./slack";
 export {
   WebSearchBackendSchema,
@@ -34,11 +33,26 @@ export { XSearchSchema, type XSearch } from "./x-search";
 
 import { z } from "zod";
 import { ModelSchema } from "./model";
-import { PlatformsSchema } from "./webhook";
+import { WebhookSchema } from "./webhook";
+import { TeamsSchema } from "./teams";
 import { SlackSchema } from "./slack";
 import { WebSchema } from "./web";
 import { BrowserSchema } from "./browser";
 import { XSearchSchema } from "./x-search";
+
+// Aggregator for the per-platform sub-schemas under config.platforms.*.
+// Each platform owns its own schema file (slack.ts, webhook.ts, teams.ts,
+// ...); this loose object composes them and lets untyped platforms pass
+// through unchanged.
+export const PlatformsSchema = z
+  .looseObject({
+    webhook: WebhookSchema,
+    teams: TeamsSchema,
+  })
+  .optional()
+  .describe("Messaging platform integrations.");
+
+export type Platforms = z.infer<typeof PlatformsSchema>;
 
 export const ConfigSchema = z
   .looseObject({

--- a/apps/dashboard/src/entities/hermes-config/teams.ts
+++ b/apps/dashboard/src/entities/hermes-config/teams.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+
+// https://hermes-agent.nousresearch.com/docs/user-guide/messaging/teams
+// Full field semantics: docs/hermes-config/teams.md
+// Only behavioral settings live here — credentials (client_id, client_secret,
+// tenant_id) are env-only (TEAMS_*) and must not be written into config.yaml.
+export const TeamsSchema = z
+  .looseObject({
+    enabled: z.boolean().optional().describe("Whether the Teams bot is enabled."),
+    extra: z
+      .looseObject({
+        port: z
+          .number()
+          .int()
+          .optional()
+          .describe("Webhook port. Falls back to TEAMS_PORT env var (default 3978)."),
+      })
+      .optional()
+      .describe("Teams bot settings."),
+  })
+  .optional()
+  .describe("Microsoft Teams platform configuration. Requires TEAMS_* env vars.");
+
+export type Teams = z.infer<typeof TeamsSchema>;

--- a/apps/dashboard/src/entities/hermes-config/webhook.ts
+++ b/apps/dashboard/src/entities/hermes-config/webhook.ts
@@ -78,12 +78,3 @@ export const WebhookSchema = z
   .describe("Webhook platform configuration.");
 
 export type Webhook = z.infer<typeof WebhookSchema>;
-
-export const PlatformsSchema = z
-  .looseObject({
-    webhook: WebhookSchema,
-  })
-  .optional()
-  .describe("Messaging platform integrations.");
-
-export type Platforms = z.infer<typeof PlatformsSchema>;

--- a/apps/dashboard/src/server/infras/kubernetes/client.test.ts
+++ b/apps/dashboard/src/server/infras/kubernetes/client.test.ts
@@ -563,6 +563,117 @@ describe("agentToHermesAgent ingress wiring", () => {
     ]);
   });
 
+  it("includes only the teams route when only teams is enabled", async () => {
+    vi.stubEnv("HERMEUM_AGENT_INGRESS_BASE_HOSTNAME", "agents.example.com");
+    const { agentToHermesAgent } = await importFresh();
+    const hermesAgent = agentToHermesAgent(
+      makeAgent({
+        env: [
+          { name: "TEAMS_CLIENT_ID", value: "cid" },
+          { name: "TEAMS_CLIENT_SECRET", value: "sec", sensitive: true },
+          { name: "TEAMS_TENANT_ID", value: "tid" },
+        ],
+      })
+    );
+    expect(hermesAgent.spec.networking?.ingress?.hosts?.[0]?.paths).toEqual([
+      { path: "/api/messages", pathType: "Prefix", port: 3978 },
+    ]);
+  });
+
+  it("emits /api/messages before /v1 and /api when teams + api-server are both enabled", async () => {
+    vi.stubEnv("HERMEUM_AGENT_INGRESS_BASE_HOSTNAME", "agents.example.com");
+    const { agentToHermesAgent } = await importFresh();
+    const hermesAgent = agentToHermesAgent(
+      makeAgent({
+        env: [
+          { name: "API_SERVER_ENABLED", value: "true" },
+          { name: "TEAMS_CLIENT_ID", value: "cid" },
+          { name: "TEAMS_CLIENT_SECRET", value: "sec", sensitive: true },
+          { name: "TEAMS_TENANT_ID", value: "tid" },
+        ],
+      })
+    );
+    const paths = hermesAgent.spec.networking?.ingress?.hosts?.[0]?.paths ?? [];
+    const teamsIdx = paths.findIndex((p) => p.path === "/api/messages");
+    const apiIdx = paths.findIndex((p) => p.path === "/api");
+    const v1Idx = paths.findIndex((p) => p.path === "/v1");
+    expect(teamsIdx).toBeGreaterThanOrEqual(0);
+    expect(apiIdx).toBeGreaterThan(teamsIdx);
+    expect(v1Idx).toBeGreaterThan(teamsIdx);
+    // Teams routes to its own port (3978), not the api-server port (8642).
+    expect(paths[teamsIdx]?.port).toBe(3978);
+    expect(paths[apiIdx]?.port).toBe(8642);
+  });
+
+  it("emits all routes in precedence order when webhook, teams, and api-server are enabled", async () => {
+    vi.stubEnv("HERMEUM_AGENT_INGRESS_BASE_HOSTNAME", "agents.example.com");
+    const { agentToHermesAgent } = await importFresh();
+    const hermesAgent = agentToHermesAgent(
+      makeAgent({
+        env: [
+          { name: "API_SERVER_ENABLED", value: "true" },
+          { name: "WEBHOOK_ENABLED", value: "true" },
+          { name: "TEAMS_CLIENT_ID", value: "cid" },
+          { name: "TEAMS_CLIENT_SECRET", value: "sec", sensitive: true },
+          { name: "TEAMS_TENANT_ID", value: "tid" },
+        ],
+      })
+    );
+    expect(hermesAgent.spec.networking?.ingress?.hosts?.[0]?.paths).toEqual([
+      { path: "/webhooks", pathType: "Prefix", port: 8644 },
+      { path: "/api/messages", pathType: "Prefix", port: 3978 },
+      { path: "/v1", pathType: "Prefix", port: 8642 },
+      { path: "/api", pathType: "Prefix", port: 8642 },
+      { path: "/health", pathType: "Prefix", port: 8642 },
+    ]);
+  });
+
+  it("honors a custom teams port via config.platforms.teams.extra.port", async () => {
+    vi.stubEnv("HERMEUM_AGENT_INGRESS_BASE_HOSTNAME", "agents.example.com");
+    const { agentToHermesAgent } = await importFresh();
+    const hermesAgent = agentToHermesAgent(
+      makeAgent({
+        config: {
+          platforms: {
+            teams: {
+              enabled: true,
+              extra: {
+                client_id: "cid",
+                client_secret: "sec",
+                tenant_id: "tid",
+                port: 4000,
+              },
+            },
+          },
+        },
+      })
+    );
+    expect(hermesAgent.spec.networking?.ingress?.hosts?.[0]?.paths).toEqual([
+      { path: "/api/messages", pathType: "Prefix", port: 4000 },
+    ]);
+  });
+
+  it("exposes the teams service port when teams is enabled", async () => {
+    vi.stubEnv("HERMEUM_AGENT_INGRESS_BASE_HOSTNAME", "agents.example.com");
+    const { agentToHermesAgent } = await importFresh();
+    const hermesAgent = agentToHermesAgent(
+      makeAgent({
+        env: [
+          { name: "TEAMS_CLIENT_ID", value: "cid" },
+          { name: "TEAMS_CLIENT_SECRET", value: "sec", sensitive: true },
+          { name: "TEAMS_TENANT_ID", value: "tid" },
+        ],
+      })
+    );
+    const ports = hermesAgent.spec.networking?.service?.ports ?? [];
+    expect(ports).toContainEqual({
+      name: "teams",
+      port: 3978,
+      targetPort: 3978,
+      protocol: "TCP",
+    });
+  });
+
   it("emits a tls block with secretName when a tls secret is configured (regardless of scheme)", async () => {
     vi.stubEnv("HERMEUM_AGENT_INGRESS_BASE_HOSTNAME", "agents.example.com");
     vi.stubEnv("HERMEUM_AGENT_INGRESS_TLS_SECRET_NAME", "agent-tls");

--- a/apps/dashboard/src/server/infras/kubernetes/client.ts
+++ b/apps/dashboard/src/server/infras/kubernetes/client.ts
@@ -13,8 +13,10 @@ import {
   SharedEnvSet,
   SharedEnvSetEnvVar,
   getApiServerPort,
+  getTeamsPort,
   getWebhookPort,
   isApiServerEnabled,
+  isTeamsEnabled,
   isWebhookEnabled,
 } from "@/entities";
 import { config } from "@/server/libs/config";
@@ -181,6 +183,10 @@ export function agentToHermesAgent(agent: Agent): HermesAgent {
   // Expose the webhook container + service ports when the agent opts in via
   // the WEBHOOK_ENABLED env var OR config.platforms.webhook.enabled.
   const webhookPort = isWebhookEnabled(agent) ? getWebhookPort(agent) : null;
+  // Expose the Teams bot container + service ports when the agent is enabled
+  // via config.platforms.teams.enabled OR the TEAMS_* credentials being
+  // present (env or config). Teams listens on /api/messages (default 3978).
+  const teamsPort = isTeamsEnabled(agent) ? getTeamsPort(agent) : null;
   const servicePorts: ServicePort[] = [];
   if (apiServerPort !== null) {
     hermes.ports = [
@@ -206,9 +212,21 @@ export function agentToHermesAgent(agent: Agent): HermesAgent {
       protocol: "TCP",
     });
   }
+  if (teamsPort !== null) {
+    hermes.ports = [
+      ...(hermes.ports ?? []),
+      { name: "teams", containerPort: teamsPort, protocol: "TCP" },
+    ];
+    servicePorts.push({
+      name: "teams",
+      port: teamsPort,
+      targetPort: teamsPort,
+      protocol: "TCP",
+    });
+  }
   // Ingress is generated only when the operator configures a base hostname —
-  // routing inbound traffic from message platforms (api-server, webhook) to
-  // the agent's Service. Host takes the form <agent-id>.<base-hostname>.
+  // routing inbound traffic from message platforms (api-server, webhook,
+  // teams) to the agent's Service. Host takes the form <agent-id>.<base-hostname>.
   let ingress: Ingress | undefined;
   if (servicePorts.length > 0 && config.agentIngressBaseHostname !== undefined) {
     const host = `${agent.id}.${config.agentIngressBaseHostname}`;
@@ -216,6 +234,15 @@ export function agentToHermesAgent(agent: Agent): HermesAgent {
     if (webhookPort !== null) {
       for (const path of PLATFORM_INGRESS_SUBPATHS[PlatformId.Webhook] ?? []) {
         ingressPaths.push({ path, pathType: "Prefix", port: webhookPort });
+      }
+    }
+    // Teams must be emitted BEFORE api-server: the api-server route uses the
+    // broad /api prefix, which would otherwise swallow /api/messages. The
+    // ingress controller's longest-prefix match routes /api/messages to the
+    // Teams port (3978) only if it appears before /api.
+    if (teamsPort !== null) {
+      for (const path of PLATFORM_INGRESS_SUBPATHS[PlatformId.Teams] ?? []) {
+        ingressPaths.push({ path, pathType: "Prefix", port: teamsPort });
       }
     }
     if (apiServerPort !== null) {


### PR DESCRIPTION
## What

Adds Microsoft Teams as a fourth inbound message platform for Hermeum agents, alongside `api-server`, `webhook`, and `Slack`.

Teams is an HTTPS-webhook platform: the Teams Bot Framework posts inbound messages to `/api/messages` on port 3978. Credentials (`TEAMS_CLIENT_ID`, `TEAMS_CLIENT_SECRET`, `TEAMS_TENANT_ID`) are **env-only** — `config.yaml` carries only non-secret behavioral settings (`enabled` flag + `extra.port`), consistent with the existing webhook/api-server platforms.

## Why

The Hermes agent submodule already ships a Teams adapter (`plugins/platforms/teams/adapter.py`). This wires the dashboard side: platform availability UI, env-var validation, Kubernetes Service/Ingress emission, and a `readDocument`-able config doc for the chat agent.

## How

### Config schema
- **New** `entities/hermes-config/teams.ts` — `TeamsSchema` typing `enabled` + `extra.port` only. Credentials, `service_url`, and `home_channel` are intentionally excluded so secrets never land in `config.yaml`.
- **Extract** `PlatformsSchema` out of `webhook.ts` into `hermes-config/index.ts` (it was the `config.platforms.*` aggregator living in a platform-named file). `webhook.ts` keeps only the webhook-specific schemas. `PlatformsSchema` now composes `webhook` + `teams` via `looseObject` so untyped platforms still pass through.

### Platform model (`entities/agent.ts`)
- `PlatformId.Teams` + `PLATFORM_META` + `PLATFORM_IDS` entry.
- `isTeamsEnabled`: `config.platforms.teams.enabled` wins if set; otherwise auto-enabled when all three `TEAMS_*` env vars are present. An explicit `enabled: false` disables even with creds present.
- `getTeamsPort`: `config.platforms.teams.extra.port` → `TEAMS_PORT` env → default `3978`.
- `derivePlatformAvailability` case: reports endpoints (`<base>/api/messages`, with `:3978` on internal `.svc.cluster.local`), surfaces missing-credential reasons.
- `AgentInputSchema.superRefine`: requires `TEAMS_CLIENT_SECRET` as a sensitive env var when Teams is enabled (matches the `WEBHOOK_SECRET` / `API_SERVER_KEY` precedent).
- Ingress subpath `/api/messages` added to `PLATFORM_INGRESS_SUBPATHS`.

### Ingress wiring (`server/infras/kubernetes/client.ts`)
- Computes `teamsPort`, emits a `teams` `ServicePort` + `hermes.ports` entry.
- **Path ordering**: `/api/messages` (port 3978) is inserted **before** the api-server `/v1` and `/api` prefixes (port 8642). The api-server `/api` Prefix route would otherwise swallow `/api/messages`; the ingress controller's longest-prefix match routes correctly only with this ordering. Final order: `webhook → teams → api-server → /health`.

### Docs
- **New** `docs/hermes-config/teams.md` (frontmatter `category: platforms`) — surfaces in the chat agent's `readDocument` catalog.

## Tests
- `agent.test.ts`: enablement (env-only creds, `enabled` flag override both directions, `<secret>` sentinel, whitespace handling), port resolution (config/env/defaults/invalid), `derivePlatformAvailability` (missing creds naming, endpoints on ingress + internal Service DNS, custom port), `superRefine` secret gating.
- `client.test.ts`: Teams-only ingress, `/api/messages` precedence over `/api` (load-bearing), full ordering with all three HTTP platforms enabled, custom port via config, ServicePort emission.

All 291 dashboard tests pass; `typecheck` and `lint` clean (only pre-existing warnings).

## Verification
```bash
pnpm --filter @hermeum/dashboard typecheck
pnpm --filter @hermeum/dashboard lint
pnpm --filter @hermeum/dashboard test
```

## Non-goals
- No changes to the hermes-agent submodule — Teams is already fully supported there.
- No `teams_pipeline` delivery-mode config typing (out of scope; passes through via `looseObject`).
- No `service_url` / `home_channel` in the typed config (credentials and proactive-delivery wiring stay env-only per the stated policy).