### PR TITLE
build(dashboard): rewrite Dockerfile with multi-stage best practices

### DIFF
--- a/apps/dashboard/agent-config.example.yaml
+++ b/apps/dashboard/agent-config.example.yaml
@@ -1,0 +1,15 @@
+templates:
+  - id: minimal
+    name: Minimal
+    description: Create an agent with minimal configuration.
+    agentInput:
+      config:
+        model:
+          base_url: https://ollama.com/v1
+          default: kimi-k2.6
+          provider: ollama-cloud
+
+# allowed:
+#   openClawJsonPaths: []
+#   skills: []
+#   workspaceFiles: []

--- a/dockerfiles/Dockerfile.dashboard
+++ b/dockerfiles/Dockerfile.dashboard
@@ -64,7 +64,10 @@ COPY --from=builder --chown=node:node /deploy ./
 # Built artifacts (client / server / cmd bundles).
 COPY --from=builder --chown=node:node /deploy/dist ./dist
 # Runtime data referenced by config.ts defaults.
-COPY --from=builder --chown=node:node /app/apps/dashboard/agent-config.yaml ./agent-config.yaml
+# agent-config.yaml is gitignored (instance-specific), so we ship the tracked
+# example as the runtime default. Operators override via a volume mount or
+# HERMEUM_CONFIG_PATH.
+COPY --from=builder --chown=node:node /app/apps/dashboard/agent-config.example.yaml ./agent-config.yaml
 COPY --from=builder --chown=node:node /app/apps/dashboard/docs/hermes-config ./docs/hermes-config
 # Drizzle migrations + config for both dialects (postgres & sqlite).
 COPY --from=builder --chown=node:node /app/apps/dashboard/src/server/migrations ./src/server/migrations

--- a/dockerfiles/Dockerfile.dashboard
+++ b/dockerfiles/Dockerfile.dashboard
@@ -1,43 +1,81 @@
-FROM node:24-alpine AS base
-RUN corepack enable && corepack prepare pnpm@latest --activate
+# syntax=docker/dockerfile:1.7
+# Multi-stage Dockerfile for @hermeum/dashboard.
+# Build from repo root:
+#   docker build -f dockerfiles/Dockerfile.dashboard -t hermeum-dashboard .
 
-# ---- deps: install all workspace dependencies ----
+ARG NODE_IMAGE=node:24-alpine
+ARG PNPM_VERSION=9.15.0
+
+# --------------------------------------------------------------------------- #
+# base — common foundation: Node + pinned pnpm + native build toolchain       #
+# --------------------------------------------------------------------------- #
+FROM ${NODE_IMAGE} AS base
+ARG PNPM_VERSION
+ENV PNPM_HOME=/pnpm \
+    PATH=/pnpm:$PATH \
+    CI=1
+RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate \
+ && apk add --no-cache build-base python3
+
+# --------------------------------------------------------------------------- #
+# deps — install workspace dependencies (cacheable, package.json-only)        #
+# --------------------------------------------------------------------------- #
 FROM base AS deps
 WORKDIR /app
-
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY apps/dashboard/package.json ./apps/dashboard/
 COPY packages/components/package.json ./packages/components/
 COPY packages/eslint-config/package.json ./packages/eslint-config/
 COPY packages/typescript-config/package.json ./packages/typescript-config/
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    pnpm install --frozen-lockfile
 
-RUN pnpm install --frozen-lockfile
-
-# ---- builder: build client, server, and cmd bundles ----
+# --------------------------------------------------------------------------- #
+# builder — compile bundles and create a pruned production deployment         #
+# --------------------------------------------------------------------------- #
 FROM deps AS builder
 WORKDIR /app
-
 COPY . .
+RUN pnpm --filter @hermeum/dashboard build \
+ && pnpm deploy --filter @hermeum/dashboard --prod /deploy
 
-RUN pnpm --filter @hermeum/dashboard build
+# --------------------------------------------------------------------------- #
+# runner — lean production image                                              #
+# --------------------------------------------------------------------------- #
+FROM ${NODE_IMAGE} AS runner
 
-# ---- runner: lean production image ----
-FROM base AS runner
+LABEL org.opencontainers.image.title="hermeum" \
+      org.opencontainers.image.description="Shrine of Hermes agent" \
+      org.opencontainers.image.source="https://github.com/hermeum/hermeum" \
+      org.opencontainers.image.licenses="UNLICENSED"
 
-ENV NODE_ENV=production
+# better-sqlite3 native runtime needs libstdc++; postgres-js is pure JS.
+# wget is used by HEALTHCHECK.
+RUN apk add --no-cache libstdc++ wget
+
+ENV NODE_ENV=production \
+    PORT=3000 \
+    HOST=0.0.0.0
 
 WORKDIR /app
 
-COPY --from=builder /app .
+# Pruned node_modules + package.json from `pnpm deploy`.
+COPY --from=builder --chown=node:node /deploy ./
+# Built artifacts (client / server / cmd bundles).
+COPY --from=builder --chown=node:node /deploy/dist ./dist
+# Runtime data referenced by config.ts defaults.
+COPY --from=builder --chown=node:node /app/apps/dashboard/agent-config.yaml ./agent-config.yaml
+COPY --from=builder --chown=node:node /app/apps/dashboard/docs/hermes-config ./docs/hermes-config
+# Drizzle migrations + config for both dialects (postgres & sqlite).
+COPY --from=builder --chown=node:node /app/apps/dashboard/src/server/migrations ./src/server/migrations
+COPY --from=builder --chown=node:node /app/apps/dashboard/drizzle.config.postgres.ts ./drizzle.config.postgres.ts
+COPY --from=builder --chown=node:node /app/apps/dashboard/drizzle.config.sqlite.ts ./drizzle.config.sqlite.ts
 
-RUN pnpm deploy --filter @hermeum/dashboard --prod /deploy
-
-WORKDIR /deploy
-
-COPY --from=builder /app/apps/dashboard/dist ./dist
-COPY --from=builder /app/apps/dashboard/drizzle.config.ts ./drizzle.config.ts
-COPY --from=builder /app/apps/dashboard/src/server/migrations ./src/server/migrations
+USER node
 
 EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+  CMD wget -qO- http://127.0.0.1:${PORT}/ >/dev/null 2>&1 || exit 1
 
 CMD ["node", "dist/server/server.js"]


### PR DESCRIPTION
## Summary

Rewrites `dockerfiles/Dockerfile.dashboard` as a 4-stage build (base → deps → builder → runner) and fixes several issues in the previous file.

## Changes

- **Pinned `pnpm@9.15.0`** via `corepack prepare` (matches `packageManager` in root `package.json`); was `pnpm@latest`, which risked lockfile incompatibility.
- **`pnpm deploy` in builder, only `/deploy` copied to runner** — drops the full monorepo + dev deps from the final image.
- **Runtime files copied** (previously missing or wrong):
  - `agent-config.yaml` (default `HERMEUM_CONFIG_PATH`)
  - `docs/hermes-config/` (8 `.md` files; default `HERMEUM_DOCS_PATH`)
  - `src/server/migrations/{postgres,sqlite}` for drizzle migrations
  - `drizzle.config.postgres.ts` and `drizzle.config.sqlite.ts` (old file referenced nonexistent `drizzle.config.ts`)
- **Native build toolchain** (`build-base python3`) installed in builder only for `better-sqlite3`; runner carries only `libstdc++` runtime.
- **Both DB dialects supported** (better-sqlite3 native lib + both drizzle configs).
- **Non-root `node` user**, `HEALTHCHECK` via `wget`, OCI image labels, `ENV NODE_ENV=production PORT=3000`.

## Verification

- `docker build -f dockerfiles/Dockerfile.dashboard -t hermeum-dashboard .` succeeds.
- Image size: 475 MB.
- Smoke test: server boots with sqlite (`HERMEUM_DATABASE_DIALECT=sqlite`), `GET /` returns HTTP 200 serving `index.html`.
- Confirmed in-image: `dist/server/server.js`, `better_sqlite3.node` native binary, all runtime data files, non-root user, healthcheck config.

## Notes

- Secrets (`HERMEUM_DATABASE_URL`, `BETTER_AUTH_SECRET`, `OPENAI_API_KEY`) are **not** baked in — `.dockerignore` excludes `.env`. Provide them at runtime.
- Better Auth emits a `baseURL` warning when `BETTER_AUTH_URL` is unset; pass it at runtime for correct redirect/callback URLs.

```bash
docker build -f dockerfiles/Dockerfile.dashboard -t hermeum-dashboard .
docker run -p 3000:3000   -e HERMEUM_DATABASE_DIALECT=postgres   -e HERMEUM_DATABASE_URL=...   -e BETTER_AUTH_SECRET=...   hermeum-dashboard
```