### PR TITLE
refactor(dashboard): rename env vars to reflect their meaning

### DIFF
--- a/apps/dashboard/src/server/libs/config.ts
+++ b/apps/dashboard/src/server/libs/config.ts
@@ -7,11 +7,11 @@ export const ConfigSchema = z.object({
   agentConfigPath: z
     .string()
     .default("./agent-config.yaml")
-    .describe("Path to the agent templates config file (HERMEUM_CONFIG_PATH)."),
-  docsPath: z
+    .describe("Path to the agent templates config file (HERMEUM_AGENT_CONFIG_PATH)."),
+  hermesDocsPath: z
     .string()
     .default("./docs/hermes-config")
-    .describe("Path to the hermes-config docs directory (HERMEUM_DOCS_PATH)."),
+    .describe("Path to the hermes-config docs directory (HERMEUM_HERMES_DOCS_PATH)."),
   databaseDialect: z
     .enum(["postgres", "sqlite"])
     .default("sqlite")
@@ -84,8 +84,8 @@ export const ConfigSchema = z.object({
 });
 
 export const config = ConfigSchema.parse({
-  agentConfigPath: process.env.HERMEUM_CONFIG_PATH,
-  docsPath: process.env.HERMEUM_DOCS_PATH,
+  agentConfigPath: process.env.HERMEUM_AGENT_CONFIG_PATH,
+  hermesDocsPath: process.env.HERMEUM_HERMES_DOCS_PATH,
   databaseDialect: process.env.HERMEUM_DATABASE_DIALECT,
   databaseUrl: process.env.HERMEUM_DATABASE_URL,
   kubernetesNamespace: process.env.HERMEUM_KUBERNETES_NAMESPACE,

--- a/apps/dashboard/src/server/usecases/agent.test.ts
+++ b/apps/dashboard/src/server/usecases/agent.test.ts
@@ -4,7 +4,7 @@ vi.mock("../infras/kubernetes/client", () => ({ KubernetesClient: vi.fn() }));
 vi.mock("../infras/local-files", () => ({ LocalFiles: vi.fn() }));
 vi.mock("../infras/console-logger", () => ({ ConsoleLogger: vi.fn() }));
 vi.mock("@/server/libs/config", () => ({
-  config: { agentConfigPath: "./agent-config.yaml", docsPath: "./docs/hermes-config" },
+  config: { agentConfigPath: "./agent-config.yaml", hermesDocsPath: "./docs/hermes-config" },
 }));
 
 import { stringify } from "yaml";

--- a/apps/dashboard/src/server/usecases/chat.test.ts
+++ b/apps/dashboard/src/server/usecases/chat.test.ts
@@ -7,7 +7,7 @@ vi.mock("../infras/kubernetes/client", () => ({ KubernetesClient: vi.fn() }));
 vi.mock("../infras/hermes-skill-index", () => ({ HermesSkillIndex: vi.fn() }));
 vi.mock("../infras/console-logger", () => ({ ConsoleLogger: vi.fn() }));
 vi.mock("@/server/libs/config", () => ({
-  config: { agentConfigPath: "./agent-config.yaml", docsPath: "./docs/hermes-config" },
+  config: { agentConfigPath: "./agent-config.yaml", hermesDocsPath: "./docs/hermes-config" },
 }));
 
 import { ChatUseCase, AGENT_CONFIG_CHAT_SYSTEM_PROMPT } from "./chat";

--- a/apps/dashboard/src/server/usecases/chat.ts
+++ b/apps/dashboard/src/server/usecases/chat.ts
@@ -6,7 +6,7 @@ import { config } from "@/server/libs/config";
 import { BaseUseCase, HermeumConfigLoadable } from "./mixin";
 import type { File } from "./adaptors/file";
 
-const DOCS_PATH = config.docsPath;
+const DOCS_PATH = config.hermesDocsPath;
 
 // Document names come from the LLM; only simple slugs are accepted so a
 // crafted name can't traverse outside DOCS_PATH.

--- a/dockerfiles/Dockerfile.dashboard
+++ b/dockerfiles/Dockerfile.dashboard
@@ -66,7 +66,7 @@ COPY --from=builder --chown=node:node /deploy/dist ./dist
 # Runtime data referenced by config.ts defaults.
 # agent-config.yaml is gitignored (instance-specific), so we ship the tracked
 # example as the runtime default. Operators override via a volume mount or
-# HERMEUM_CONFIG_PATH.
+# HERMEUM_AGENT_CONFIG_PATH.
 COPY --from=builder --chown=node:node /app/apps/dashboard/agent-config.example.yaml ./agent-config.yaml
 COPY --from=builder --chown=node:node /app/apps/dashboard/docs/hermes-config ./docs/hermes-config
 # Drizzle migrations + config for both dialects (postgres & sqlite).


### PR DESCRIPTION
Renames env vars so their names reflect what they point at, and aligns the `config` field name with the new `HERMEUM_HERMES_DOCS_PATH` var.

- `HERMEUM_CONFIG_PATH` -> `HERMEUM_AGENT_CONFIG_PATH`
- `HERMEUM_DOCS_PATH` -> `HERMEUM_HERMES_DOCS_PATH`
- `config.docsPath` -> `config.hermesDocsPath`

Touched files:
- `apps/dashboard/src/server/libs/config.ts`
- `apps/dashboard/src/server/usecases/chat.ts`
- `apps/dashboard/src/server/usecases/chat.test.ts`
- `apps/dashboard/src/server/usecases/agent.test.ts`
- `dockerfiles/Dockerfile.dashboard`

Typecheck + all 296 tests pass.