### PR TITLE
refactor(dashboard): rename HERMEUM_DEBUG_LEVEL to HERMEUM_LOG_LEVEL

### DIFF
--- a/apps/dashboard/src/server/libs/config.ts
+++ b/apps/dashboard/src/server/libs/config.ts
@@ -48,10 +48,10 @@ export const ConfigSchema = z.object({
     .url()
     .optional()
     .describe("Override the OpenAI API base URL (HERMEUM_OPENAI_BASE_URL)."),
-  debugLevel: z
+  logLevel: z
     .enum(["debug", "info", "warn", "error"])
     .default("info")
-    .describe("Log verbosity level (HERMEUM_DEBUG_LEVEL)."),
+    .describe("Log verbosity level (HERMEUM_LOG_LEVEL)."),
   agentIngressScheme: z
     .enum(["http", "https"])
     .default("http")
@@ -95,7 +95,7 @@ export const config = ConfigSchema.parse({
   hermesImageTag: process.env.HERMEUM_HERMES_IMAGE_TAG,
   openaiModel: process.env.HERMEUM_OPENAI_MODEL,
   openaiBaseUrl: process.env.HERMEUM_OPENAI_BASE_URL,
-  debugLevel: process.env.HERMEUM_DEBUG_LEVEL,
+  logLevel: process.env.HERMEUM_LOG_LEVEL,
   agentIngressScheme: process.env.HERMEUM_AGENT_INGRESS_SCHEME,
   agentIngressBaseHostname: process.env.HERMEUM_AGENT_INGRESS_BASE_HOSTNAME,
   agentIngressClassName: process.env.HERMEUM_AGENT_INGRESS_CLASS_NAME,

--- a/apps/dashboard/src/server/routers/ai-sdk/agent-config.ts
+++ b/apps/dashboard/src/server/routers/ai-sdk/agent-config.ts
@@ -70,7 +70,7 @@ aiSdkRouter.post("/agent-config", async (req, res) => {
     providerOptions: {
       openai: { strictJsonSchema: false },
     },
-    ...(config.debugLevel === "debug" && {
+    ...(config.logLevel === "debug" && {
       onStepFinish: ({ stepNumber, finishReason, toolCalls, text, usage }) => {
         const toolsCalled = toolCalls.map((c) => c.toolName).join(",") || "-";
         const preview = text.slice(0, 80).replace(/\n/g, " ");

--- a/apps/dashboard/src/server/usecases/mixin.ts
+++ b/apps/dashboard/src/server/usecases/mixin.ts
@@ -20,7 +20,7 @@ export class BaseUseCase {
     readonly runtime: Runtime = new KubernetesClient(),
     readonly files: FileAdaptor = new LocalFiles(),
     readonly skillIndex: SkillIndexAdaptor = new HermesSkillIndex(),
-    readonly logger: LoggerAdaptor = new ConsoleLogger(config.debugLevel)
+    readonly logger: LoggerAdaptor = new ConsoleLogger(config.logLevel)
   ) {}
 }
 


### PR DESCRIPTION
Renames the env var `HERMEUM_DEBUG_LEVEL` → `HERMEUM_LOG_LEVEL` and the corresponding `config.debugLevel` → `config.logLevel` across the dashboard package for clarity (the value controls log verbosity, not a debug toggle).