### PR TITLE
feat(dashboard): add minimal logging to agent and chat use cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .claude
+.opencode
 node_modules
 dist
 .output

--- a/apps/dashboard/src/server/usecases/agent.test.ts
+++ b/apps/dashboard/src/server/usecases/agent.test.ts
@@ -2,7 +2,14 @@ import { describe, it, expect, vi } from "vitest";
 
 vi.mock("../infras/kubernetes/client", () => ({ KubernetesClient: vi.fn() }));
 vi.mock("../infras/local-files", () => ({ LocalFiles: vi.fn() }));
-vi.mock("../infras/console-logger", () => ({ ConsoleLogger: vi.fn() }));
+vi.mock("../infras/console-logger", () => ({
+  ConsoleLogger: vi.fn().mockImplementation(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
 vi.mock("@/server/libs/config", () => ({
   config: { agentConfigPath: "./agent-config.yaml", hermesDocsPath: "./docs/hermes-config" },
 }));

--- a/apps/dashboard/src/server/usecases/agent.ts
+++ b/apps/dashboard/src/server/usecases/agent.ts
@@ -19,23 +19,31 @@ export class AgentUseCase extends OwnershipGuarded(HermeumConfigLoadable(BaseUse
   }
 
   async listHermesAgents(ctx: Context, input?: ListAgentsFilter): Promise<Agent[]> {
-    return this.runtime.listHermesAgents(input);
+    const agents = await this.runtime.listHermesAgents(input);
+    this.logger.info("listed hermes agents", { count: agents.length, filter: input });
+    return agents;
   }
 
   async getHermesAgent(ctx: Context, id: string): Promise<Agent | null> {
-    return this.runtime.getHermesAgent(id);
+    const agent = await this.runtime.getHermesAgent(id);
+    this.logger.info("got hermes agent", { id, found: agent !== null });
+    return agent;
   }
 
   async createHermesAgent(ctx: Context, agentInput: AgentInput): Promise<Agent> {
     agentInput = AgentInputSchema.parse(agentInput);
 
     await this.checkAgentInputAllowed(agentInput);
-    return this.runtime.createHermesAgent({ ...agentInput, userId: this.requireUser(ctx).id });
+    const userId = this.requireUser(ctx).id;
+    const agent = await this.runtime.createHermesAgent({ ...agentInput, userId });
+    this.logger.info("created hermes agent", { id: agent.id, userId });
+    return agent;
   }
 
   async updateHermesAgent(ctx: Context, id: string, patch: AgentInput): Promise<Agent> {
     const agent = await this.runtime.getHermesAgent(id);
     if (!agent) {
+      this.logger.warn("can't update — agent not found", { id });
       throw new Error(`HermesAgent ${id} not found`);
     }
     this.verifyOwnership(ctx, agent);
@@ -46,7 +54,9 @@ export class AgentUseCase extends OwnershipGuarded(HermeumConfigLoadable(BaseUse
     if (patch.env !== undefined) {
       this.checkEnvSensitivityNotDowngraded(agent.env, patch.env);
     }
-    return this.runtime.patchHermesAgent({ id, patch });
+    const updated = await this.runtime.patchHermesAgent({ id, patch });
+    this.logger.info("updated hermes agent", { id, userId: this.requireUser(ctx).id });
+    return updated;
   }
 
   private checkEnvSensitivityNotDowngraded(existingEnv: Env, patchEnv: Env): void {
@@ -62,37 +72,49 @@ export class AgentUseCase extends OwnershipGuarded(HermeumConfigLoadable(BaseUse
   async archiveHermesAgent(ctx: Context, id: string): Promise<Agent> {
     const agent = await this.runtime.getHermesAgent(id);
     if (!agent) {
+      this.logger.warn("can't archive — agent not found", { id });
       throw new Error(`HermesAgent ${id} not found`);
     }
     this.verifyOwnership(ctx, agent);
-    return this.runtime.archiveHermesAgent(id);
+    const archived = await this.runtime.archiveHermesAgent(id);
+    this.logger.info("archived hermes agent", { id, userId: this.requireUser(ctx).id });
+    return archived;
   }
 
   async suspendHermesAgent(ctx: Context, id: string): Promise<Agent> {
     const agent = await this.runtime.getHermesAgent(id);
     if (!agent) {
+      this.logger.warn("can't suspend — agent not found", { id });
       throw new Error(`HermesAgent ${id} not found`);
     }
     this.verifyOwnership(ctx, agent);
-    return this.runtime.patchHermesAgent({ id, patch: { suspended: true } });
+    const suspended = await this.runtime.patchHermesAgent({ id, patch: { suspended: true } });
+    this.logger.info("suspended hermes agent", { id, userId: this.requireUser(ctx).id });
+    return suspended;
   }
 
   async resumeHermesAgent(ctx: Context, id: string): Promise<Agent> {
     const agent = await this.runtime.getHermesAgent(id);
     if (!agent) {
+      this.logger.warn("can't resume — agent not found", { id });
       throw new Error(`HermesAgent ${id} not found`);
     }
     this.verifyOwnership(ctx, agent);
-    return this.runtime.patchHermesAgent({ id, patch: { suspended: false } });
+    const resumed = await this.runtime.patchHermesAgent({ id, patch: { suspended: false } });
+    this.logger.info("resumed hermes agent", { id, userId: this.requireUser(ctx).id });
+    return resumed;
   }
 
   async getGatewayToken(ctx: Context, agentId: string): Promise<string | null> {
     const agent = await this.runtime.getHermesAgent(agentId);
     if (!agent) {
+      this.logger.warn("can't get gateway token — agent not found", { agentId });
       throw new Error(`HermesAgent ${agentId} not found`);
     }
     this.verifyOwnership(ctx, agent);
-    return this.runtime.getGatewayToken(agentId);
+    const token = await this.runtime.getGatewayToken(agentId);
+    this.logger.info("got gateway token", { agentId, userId: this.requireUser(ctx).id });
+    return token;
   }
 
   private async checkAgentInputAllowed(

--- a/apps/dashboard/src/server/usecases/chat.test.ts
+++ b/apps/dashboard/src/server/usecases/chat.test.ts
@@ -5,7 +5,14 @@ import { stringify } from "yaml";
 vi.mock("../infras/local-files", () => ({ LocalFiles: vi.fn() }));
 vi.mock("../infras/kubernetes/client", () => ({ KubernetesClient: vi.fn() }));
 vi.mock("../infras/hermes-skill-index", () => ({ HermesSkillIndex: vi.fn() }));
-vi.mock("../infras/console-logger", () => ({ ConsoleLogger: vi.fn() }));
+vi.mock("../infras/console-logger", () => ({
+  ConsoleLogger: vi.fn().mockImplementation(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
 vi.mock("@/server/libs/config", () => ({
   config: { agentConfigPath: "./agent-config.yaml", hermesDocsPath: "./docs/hermes-config" },
 }));

--- a/apps/dashboard/src/server/usecases/chat.ts
+++ b/apps/dashboard/src/server/usecases/chat.ts
@@ -28,7 +28,7 @@ export class ChatUseCase extends HermeumConfigLoadable(BaseUseCase) {
   // appended), a context block describing the current draft, and the
   // client-side tool the model uses to apply config changes.
   async getAgentConfigContext(currentConfig?: AgentInput): Promise<AgentConfigContext> {
-    return {
+    const ctx: AgentConfigContext = {
       instructions: await this.buildInstructions(),
       prompt:
         currentConfig === undefined
@@ -77,6 +77,8 @@ export class ChatUseCase extends HermeumConfigLoadable(BaseUseCase) {
         }),
       },
     };
+    this.logger.info("built agent config context", { hasDraft: currentConfig !== undefined });
+    return ctx;
   }
 
   // Server-executed tool that lets the model pull a Hermes agent configuration
@@ -92,8 +94,8 @@ export class ChatUseCase extends HermeumConfigLoadable(BaseUseCase) {
       inputSchema: z.object({
         names: z.array(z.string()).min(1).describe("Document names listed in the system prompt."),
       }),
-      execute: async ({ names }) => ({
-        documents: await Promise.all(
+      execute: async ({ names }) => {
+        const documents = await Promise.all(
           names.map(async (name) => {
             const file = DOCUMENT_NAME_RE.test(name)
               ? await this.files.readFile(`${DOCS_PATH}/${name}.md`)
@@ -105,8 +107,10 @@ export class ChatUseCase extends HermeumConfigLoadable(BaseUseCase) {
                 }
               : { name, content: file.content };
           })
-        ),
-      }),
+        );
+        this.logger.debug("read documents", { names });
+        return { documents };
+      },
     });
   }
 
@@ -126,8 +130,8 @@ export class ChatUseCase extends HermeumConfigLoadable(BaseUseCase) {
       inputSchema: z.object({
         ids: z.array(z.string()).min(1).describe("Shared env set ids listed in the system prompt."),
       }),
-      execute: async ({ ids }) => ({
-        sharedEnvSets: await Promise.all(
+      execute: async ({ ids }) => {
+        const sharedEnvSets = await Promise.all(
           ids.map(async (id) => {
             const set = await this.runtime.getSharedEnvSet(id);
             if (set === null || set.archived) {
@@ -138,8 +142,10 @@ export class ChatUseCase extends HermeumConfigLoadable(BaseUseCase) {
             }
             return { id, envVars: set.envVars.map(({ name }) => ({ name })) };
           })
-        ),
-      }),
+        );
+        this.logger.debug("read shared env sets", { ids });
+        return { sharedEnvSets };
+      },
     });
   }
 


### PR DESCRIPTION
Introduces minimal logging to the agent and chat use cases using the already-injected `LoggerAdaptor`.

**agent.ts** — `info` log after each public method completes (casual message + structured context with id/userId/count/found); `warn` on the not-found path before the throw.
**chat.ts** — `info` after `getAgentConfigContext` builds the context; `debug` after each server-executed tool (`readDocument`, `readSharedEnvSet`) fetches its data.
**tests** — updated the `ConsoleLogger` mocks to return a stubbed logger instance so the new `this.logger.*` calls don't throw.
**.gitignore** — ignore `.opencode/`.

No secrets or env values are logged — only ids, counts, and flags.