### PR TITLE
refactor(dashboard): move PORT/HMR_PORT env vars into config

### DIFF
--- a/apps/dashboard/src/server/libs/config.ts
+++ b/apps/dashboard/src/server/libs/config.ts
@@ -81,6 +81,18 @@ export const ConfigSchema = z.object({
         "When set, the ingress emits a tls block with this secret; when unset, no tls block is " +
         "emitted (covers plain HTTP and load-balancer-terminated TLS)."
     ),
+  serverPort: z
+    .number()
+    .int()
+    .positive()
+    .default(3000)
+    .describe("Port the dashboard server listens on (HERMEUM_SERVER_PORT)."),
+  hmrPort: z
+    .number()
+    .int()
+    .positive()
+    .default(3001)
+    .describe("Port used by Vite's HMR websocket in dev (HERMEUM_HMR_PORT)."),
 });
 
 export const config = ConfigSchema.parse({
@@ -100,4 +112,8 @@ export const config = ConfigSchema.parse({
   agentIngressBaseHostname: process.env.HERMEUM_AGENT_INGRESS_BASE_HOSTNAME,
   agentIngressClassName: process.env.HERMEUM_AGENT_INGRESS_CLASS_NAME,
   agentIngressTlsSecretName: process.env.HERMEUM_AGENT_INGRESS_TLS_SECRET_NAME,
+  serverPort: process.env.HERMEUM_SERVER_PORT
+    ? parseInt(process.env.HERMEUM_SERVER_PORT, 10)
+    : undefined,
+  hmrPort: process.env.HERMEUM_HMR_PORT ? parseInt(process.env.HERMEUM_HMR_PORT, 10) : undefined,
 });

--- a/apps/dashboard/src/server/server.ts
+++ b/apps/dashboard/src/server/server.ts
@@ -10,9 +10,7 @@ import { webhookRouter } from "./routers/webhook";
 import { aiSdkRouter } from "./routers/ai-sdk/agent-config";
 import { auth } from "./routers/better-auth/auth";
 
-const PORT = typeof process.env.PORT !== "undefined" ? parseInt(process.env.PORT, 10) : 3000;
-const HMR_PORT =
-  typeof process.env.HMR_PORT !== "undefined" ? parseInt(process.env.HMR_PORT, 10) : 3001;
+const { serverPort, hmrPort } = config;
 
 const isTest = process.env.NODE_ENV === "test" || !!process.env.VITE_TEST_BUILD;
 
@@ -46,7 +44,7 @@ export const createServer = async (
           interval: 100,
         },
         hmr: {
-          port: HMR_PORT,
+          port: hmrPort,
         },
       },
       appType: "custom",
@@ -78,8 +76,8 @@ export const createServer = async (
 
 if (!isTest) {
   createServer().then(({ app }) =>
-    app.listen(PORT, () => {
-      console.info(`Server available at: http://localhost:${PORT}`);
+    app.listen(serverPort, () => {
+      console.info(`Server available at: http://localhost:${serverPort}`);
     })
   );
 }


### PR DESCRIPTION
Renames the inline `PORT` and `HMR_PORT` env vars to the `HERMEUM_`-prefixed convention (`HERMEUM_SERVER_PORT`, `HERMEUM_HMR_PORT`) and moves them into the Zod-backed config module as `serverPort` and `hmrPort`. `server.ts` now consumes them via the shared `config` object instead of reading `process.env` directly, consistent with the rest of the config.