### PR TITLE
feat(dashboard): add TLS termination for mutating webhook server

### DIFF
--- a/apps/dashboard/src/server/libs/config.ts
+++ b/apps/dashboard/src/server/libs/config.ts
@@ -86,13 +86,36 @@ export const ConfigSchema = z.object({
     .int()
     .positive()
     .default(3000)
-    .describe("Port the dashboard server listens on (HERMEUM_SERVER_PORT)."),
+    .describe("Port the web server listens on (HERMEUM_SERVER_PORT)."),
   hmrPort: z
     .number()
     .int()
     .positive()
     .default(3001)
     .describe("Port used by Vite's HMR websocket in dev (HERMEUM_HMR_PORT)."),
+  tlsCertFile: z
+    .string()
+    .optional()
+    .describe("Path to the web TLS cert file (PEM) (HERMEUM_TLS_CERT_FILE). When set with HERMEUM_TLS_KEY_FILE, the web server serves HTTPS on HERMEUM_SERVER_PORT."),
+  tlsKeyFile: z
+    .string()
+    .optional()
+    .describe("Path to the web TLS key file (PEM) (HERMEUM_TLS_KEY_FILE). When set with HERMEUM_TLS_CERT_FILE, the web server serves HTTPS on HERMEUM_SERVER_PORT."),
+  webhookTlsCertFile: z
+    .string()
+    .optional()
+    .describe("Path to the mutating webhook TLS cert file (PEM) (HERMEUM_WEBHOOK_TLS_CERT_FILE). When set with HERMEUM_WEBHOOK_TLS_KEY_FILE, the webhook HTTPS listener starts on HERMEUM_WEBHOOK_PORT."),
+  webhookTlsKeyFile: z
+    .string()
+    .optional()
+    .describe("Path to the mutating webhook TLS key file (PEM) (HERMEUM_WEBHOOK_TLS_KEY_FILE). When set with HERMEUM_WEBHOOK_TLS_CERT_FILE, the webhook HTTPS listener starts on HERMEUM_WEBHOOK_PORT."),
+  webhookPort: z
+    .number()
+    .int()
+    .min(1)
+    .max(65535)
+    .default(8443)
+    .describe("HTTPS port for the mutating admission webhook (HERMEUM_WEBHOOK_PORT). Only used when HERMEUM_WEBHOOK_TLS_CERT_FILE and HERMEUM_WEBHOOK_TLS_KEY_FILE are set."),
 });
 
 export const config = ConfigSchema.parse({
@@ -116,4 +139,11 @@ export const config = ConfigSchema.parse({
     ? parseInt(process.env.HERMEUM_SERVER_PORT, 10)
     : undefined,
   hmrPort: process.env.HERMEUM_HMR_PORT ? parseInt(process.env.HERMEUM_HMR_PORT, 10) : undefined,
+  tlsCertFile: process.env.HERMEUM_TLS_CERT_FILE,
+  tlsKeyFile: process.env.HERMEUM_TLS_KEY_FILE,
+  webhookTlsCertFile: process.env.HERMEUM_WEBHOOK_TLS_CERT_FILE,
+  webhookTlsKeyFile: process.env.HERMEUM_WEBHOOK_TLS_KEY_FILE,
+  webhookPort: process.env.HERMEUM_WEBHOOK_PORT
+    ? parseInt(process.env.HERMEUM_WEBHOOK_PORT, 10)
+    : undefined,
 });

--- a/apps/dashboard/src/server/libs/config.ts
+++ b/apps/dashboard/src/server/libs/config.ts
@@ -81,12 +81,12 @@ export const ConfigSchema = z.object({
         "When set, the ingress emits a tls block with this secret; when unset, no tls block is " +
         "emitted (covers plain HTTP and load-balancer-terminated TLS)."
     ),
-  serverPort: z
+  port: z
     .number()
     .int()
     .positive()
     .default(3000)
-    .describe("Port the web server listens on (HERMEUM_SERVER_PORT)."),
+    .describe("Port the web server listens on (HERMEUM_PORT)."),
   hmrPort: z
     .number()
     .int()
@@ -96,11 +96,11 @@ export const ConfigSchema = z.object({
   tlsCertFile: z
     .string()
     .optional()
-    .describe("Path to the web TLS cert file (PEM) (HERMEUM_TLS_CERT_FILE). When set with HERMEUM_TLS_KEY_FILE, the web server serves HTTPS on HERMEUM_SERVER_PORT."),
+    .describe("Path to the web TLS cert file (PEM) (HERMEUM_TLS_CERT_FILE). When set with HERMEUM_TLS_KEY_FILE, the web server serves HTTPS on HERMEUM_PORT."),
   tlsKeyFile: z
     .string()
     .optional()
-    .describe("Path to the web TLS key file (PEM) (HERMEUM_TLS_KEY_FILE). When set with HERMEUM_TLS_CERT_FILE, the web server serves HTTPS on HERMEUM_SERVER_PORT."),
+    .describe("Path to the web TLS key file (PEM) (HERMEUM_TLS_KEY_FILE). When set with HERMEUM_TLS_CERT_FILE, the web server serves HTTPS on HERMEUM_PORT."),
   webhookTlsCertFile: z
     .string()
     .optional()
@@ -135,8 +135,8 @@ export const config = ConfigSchema.parse({
   agentIngressBaseHostname: process.env.HERMEUM_AGENT_INGRESS_BASE_HOSTNAME,
   agentIngressClassName: process.env.HERMEUM_AGENT_INGRESS_CLASS_NAME,
   agentIngressTlsSecretName: process.env.HERMEUM_AGENT_INGRESS_TLS_SECRET_NAME,
-  serverPort: process.env.HERMEUM_SERVER_PORT
-    ? parseInt(process.env.HERMEUM_SERVER_PORT, 10)
+  port: process.env.HERMEUM_PORT
+    ? parseInt(process.env.HERMEUM_PORT, 10)
     : undefined,
   hmrPort: process.env.HERMEUM_HMR_PORT ? parseInt(process.env.HERMEUM_HMR_PORT, 10) : undefined,
   tlsCertFile: process.env.HERMEUM_TLS_CERT_FILE,

--- a/apps/dashboard/src/server/server.test.ts
+++ b/apps/dashboard/src/server/server.test.ts
@@ -27,29 +27,29 @@ vi.mock("./routers/better-auth/auth", () => ({
 
 describe("createServer TLS", () => {
   describe("TLS disabled (default)", () => {
-    it("returns HTTP servers for dashboard and webhook", async () => {
+    it("returns HTTP servers for web and webhook", async () => {
       vi.resetModules();
       const { createServer } = await import("./server");
       const result = await createServer(process.cwd(), true);
 
-      expect(result.dashboardServer).toBeDefined();
+      expect(result.webServer).toBeDefined();
       expect(result.webhookServer).toBeDefined();
-      result.dashboardServer.close();
+      result.webServer.close();
       result.webhookServer!.close();
     });
   });
 
   describe("TLS enabled", () => {
     let dir: string;
-    let dashboardCertFile: string;
-    let dashboardKeyFile: string;
+    let webCertFile: string;
+    let webKeyFile: string;
     let webhookCertFile: string;
     let webhookKeyFile: string;
 
     beforeAll(() => {
       dir = fs.mkdtempSync(path.join(os.tmpdir(), "tls-server-"));
-      dashboardCertFile = path.join(dir, "dashboard.crt");
-      dashboardKeyFile = path.join(dir, "dashboard.key");
+      webCertFile = path.join(dir, "web.crt");
+      webKeyFile = path.join(dir, "web.key");
       webhookCertFile = path.join(dir, "webhook.crt");
       webhookKeyFile = path.join(dir, "webhook.key");
 
@@ -61,7 +61,7 @@ describe("createServer TLS", () => {
             `-addext "subjectAltName=DNS:localhost,IP:127.0.0.1"`
         );
 
-      genCert(dashboardCertFile, dashboardKeyFile);
+      genCert(webCertFile, webKeyFile);
       genCert(webhookCertFile, webhookKeyFile);
     });
 
@@ -69,10 +69,10 @@ describe("createServer TLS", () => {
       fs.rmSync(dir, { recursive: true, force: true });
     });
 
-    it("serves the dashboard and webhook over HTTPS with separate cert/key pairs", async () => {
+    it("serves the web and webhook over HTTPS with separate cert/key pairs", async () => {
       vi.resetModules();
-      vi.stubEnv("HERMEUM_TLS_CERT_FILE", dashboardCertFile);
-      vi.stubEnv("HERMEUM_TLS_KEY_FILE", dashboardKeyFile);
+      vi.stubEnv("HERMEUM_TLS_CERT_FILE", webCertFile);
+      vi.stubEnv("HERMEUM_TLS_KEY_FILE", webKeyFile);
       vi.stubEnv("HERMEUM_WEBHOOK_TLS_CERT_FILE", webhookCertFile);
       vi.stubEnv("HERMEUM_WEBHOOK_TLS_KEY_FILE", webhookKeyFile);
       // Self-signed cert: skip verification for the test client.
@@ -84,19 +84,19 @@ describe("createServer TLS", () => {
       expect(result.webhookServer).toBeDefined();
 
       await new Promise<void>((resolve) => {
-        result.dashboardServer.listen(0, "127.0.0.1", () => resolve());
+        result.webServer.listen(0, "127.0.0.1", () => resolve());
       });
       await new Promise<void>((resolve) => {
         result.webhookServer!.listen(0, "127.0.0.1", () => resolve());
       });
 
-      const dashboardAddr = result.dashboardServer.address() as AddressInfo;
+      const webAddr = result.webServer.address() as AddressInfo;
       const webhookAddr = result.webhookServer!.address() as AddressInfo;
 
-      // Dashboard listener is up over HTTPS (static files aren't built in
+      // Web listener is up over HTTPS (static files aren't built in
       // tests, so we only assert the TLS handshake succeeds).
-      const dashboardRes = await fetch(`https://127.0.0.1:${dashboardAddr.port}/`);
-      expect(dashboardRes.status).toBe(404);
+      const webRes = await fetch(`https://127.0.0.1:${webAddr.port}/`);
+      expect(webRes.status).toBe(404);
 
       // Webhook listener serves /webhook/mutating over HTTPS.
       const webhookRes = await fetch(`https://127.0.0.1:${webhookAddr.port}/webhook/mutating`, {
@@ -116,7 +116,7 @@ describe("createServer TLS", () => {
       const body = (await webhookRes.json()) as { response?: { allowed: boolean } };
       expect(body.response?.allowed).toBe(true);
 
-      result.dashboardServer.close();
+      result.webServer.close();
       result.webhookServer!.close();
 
       vi.unstubAllEnvs();

--- a/apps/dashboard/src/server/server.test.ts
+++ b/apps/dashboard/src/server/server.test.ts
@@ -1,0 +1,125 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { execSync } from "node:child_process";
+import { AddressInfo } from "node:net";
+import { Router } from "express";
+
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+// Mock heavy routers/auth so createServer stays light and fast in tests.
+vi.mock("@/server/routers/trpc/index.js", () => ({
+  trpcMiddleware: Router(),
+}));
+vi.mock("./routers/webhook", () => ({
+  webhookRouter: Router().post("/mutating", (_req, res) =>
+    res.json({
+      apiVersion: "admission.k8s.io/v1",
+      kind: "AdmissionReview",
+      response: { uid: "test-uid", allowed: true },
+    })
+  ),
+}));
+vi.mock("./routers/ai-sdk/agent-config", () => ({ aiSdkRouter: Router() }));
+vi.mock("./routers/better-auth/auth", () => ({
+  auth: { handler: () => (req: unknown, res: { end: () => void }) => res.end() },
+}));
+
+describe("createServer TLS", () => {
+  describe("TLS disabled (default)", () => {
+    it("returns HTTP servers for dashboard and webhook", async () => {
+      vi.resetModules();
+      const { createServer } = await import("./server");
+      const result = await createServer(process.cwd(), true);
+
+      expect(result.dashboardServer).toBeDefined();
+      expect(result.webhookServer).toBeDefined();
+      result.dashboardServer.close();
+      result.webhookServer!.close();
+    });
+  });
+
+  describe("TLS enabled", () => {
+    let dir: string;
+    let dashboardCertFile: string;
+    let dashboardKeyFile: string;
+    let webhookCertFile: string;
+    let webhookKeyFile: string;
+
+    beforeAll(() => {
+      dir = fs.mkdtempSync(path.join(os.tmpdir(), "tls-server-"));
+      dashboardCertFile = path.join(dir, "dashboard.crt");
+      dashboardKeyFile = path.join(dir, "dashboard.key");
+      webhookCertFile = path.join(dir, "webhook.crt");
+      webhookKeyFile = path.join(dir, "webhook.key");
+
+      const genCert = (cert: string, key: string) =>
+        execSync(
+          `openssl req -x509 -newkey rsa:2048 -nodes ` +
+            `-keyout "${key}" -out "${cert}" -days 1 ` +
+            `-subj "/CN=localhost" ` +
+            `-addext "subjectAltName=DNS:localhost,IP:127.0.0.1"`
+        );
+
+      genCert(dashboardCertFile, dashboardKeyFile);
+      genCert(webhookCertFile, webhookKeyFile);
+    });
+
+    afterAll(() => {
+      fs.rmSync(dir, { recursive: true, force: true });
+    });
+
+    it("serves the dashboard and webhook over HTTPS with separate cert/key pairs", async () => {
+      vi.resetModules();
+      vi.stubEnv("HERMEUM_TLS_CERT_FILE", dashboardCertFile);
+      vi.stubEnv("HERMEUM_TLS_KEY_FILE", dashboardKeyFile);
+      vi.stubEnv("HERMEUM_WEBHOOK_TLS_CERT_FILE", webhookCertFile);
+      vi.stubEnv("HERMEUM_WEBHOOK_TLS_KEY_FILE", webhookKeyFile);
+      // Self-signed cert: skip verification for the test client.
+      vi.stubEnv("NODE_TLS_REJECT_UNAUTHORIZED", "0");
+
+      const { createServer } = await import("./server");
+      const result = await createServer(process.cwd(), true);
+
+      expect(result.webhookServer).toBeDefined();
+
+      await new Promise<void>((resolve) => {
+        result.dashboardServer.listen(0, "127.0.0.1", () => resolve());
+      });
+      await new Promise<void>((resolve) => {
+        result.webhookServer!.listen(0, "127.0.0.1", () => resolve());
+      });
+
+      const dashboardAddr = result.dashboardServer.address() as AddressInfo;
+      const webhookAddr = result.webhookServer!.address() as AddressInfo;
+
+      // Dashboard listener is up over HTTPS (static files aren't built in
+      // tests, so we only assert the TLS handshake succeeds).
+      const dashboardRes = await fetch(`https://127.0.0.1:${dashboardAddr.port}/`);
+      expect(dashboardRes.status).toBe(404);
+
+      // Webhook listener serves /webhook/mutating over HTTPS.
+      const webhookRes = await fetch(`https://127.0.0.1:${webhookAddr.port}/webhook/mutating`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          apiVersion: "admission.k8s.io/v1",
+          kind: "AdmissionReview",
+          request: {
+            uid: "test-uid",
+            operation: "CREATE",
+            kind: { group: "", version: "v1", kind: "Pod" },
+          },
+        }),
+      });
+      expect(webhookRes.status).toBe(200);
+      const body = (await webhookRes.json()) as { response?: { allowed: boolean } };
+      expect(body.response?.allowed).toBe(true);
+
+      result.dashboardServer.close();
+      result.webhookServer!.close();
+
+      vi.unstubAllEnvs();
+    });
+  });
+});

--- a/apps/dashboard/src/server/server.ts
+++ b/apps/dashboard/src/server/server.ts
@@ -1,6 +1,10 @@
 import path from "node:path";
 import url from "node:url";
 import * as fs from "node:fs";
+import http from "node:http";
+import https from "node:https";
+import type { Server as HttpServer } from "node:http";
+import type { Server as HttpsServer } from "node:https";
 import express from "express";
 import { toNodeHandler } from "better-auth/node";
 
@@ -20,16 +24,34 @@ void config;
 const __filename = url.fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+export interface CreateServerResult {
+  app: express.Express;
+  webhookApp: express.Express;
+  webServer: HttpServer | HttpsServer;
+  webhookServer?: HttpServer | HttpsServer;
+}
+
+const loadTlsCredentials = (certFile: string, keyFile: string): { cert: Buffer; key: Buffer } => {
+  try {
+    return {
+      cert: fs.readFileSync(certFile),
+      key: fs.readFileSync(keyFile),
+    };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new Error(`Failed to read TLS cert/key files (cert=${certFile}, key=${keyFile}): ${msg}`);
+  }
+};
+
 export const createServer = async (
   root = process.cwd(),
   isProd = process.env.NODE_ENV === "production"
-) => {
+): Promise<CreateServerResult> => {
   const app = express();
 
   app.all("/auth/*", toNodeHandler(auth));
   app.use(express.json());
   app.use("/trpc", trpcMiddleware);
-  app.use("/webhook", webhookRouter);
   app.use("/chat", aiSdkRouter);
 
   if (!isProd) {
@@ -61,8 +83,6 @@ export const createServer = async (
         return next(e);
       }
     });
-
-    return { app };
   } else {
     app.use(express.static(path.resolve(__dirname, "../client")));
 
@@ -71,13 +91,64 @@ export const createServer = async (
     });
   }
 
-  return { app };
+  // Separate Express app for the mutating webhook — only mounts webhookRouter.
+  const webhookApp = express();
+  webhookApp.use(express.json());
+  webhookApp.use("/webhook", webhookRouter);
+
+  // Web server: HTTPS on serverPort when cert/key are set, otherwise HTTP.
+  const webHasTls = config.tlsCertFile !== undefined && config.tlsKeyFile !== undefined;
+  let webServer: HttpServer | HttpsServer;
+  if (webHasTls) {
+    const { cert, key } = loadTlsCredentials(config.tlsCertFile!, config.tlsKeyFile!);
+    webServer = https.createServer({ cert, key }, app);
+  } else {
+    webServer = http.createServer(app);
+  }
+
+  // Webhook server: HTTPS on webhookPort when cert/key are set, otherwise HTTP.
+  const webhookHasTls =
+    config.webhookTlsCertFile !== undefined && config.webhookTlsKeyFile !== undefined;
+  let webhookServer: HttpServer | HttpsServer | undefined;
+  if (webhookHasTls) {
+    const { cert, key } = loadTlsCredentials(config.webhookTlsCertFile!, config.webhookTlsKeyFile!);
+    webhookServer = https.createServer({ cert, key }, webhookApp);
+  } else {
+    webhookServer = http.createServer(webhookApp);
+  }
+
+  return {
+    app,
+    webhookApp,
+    webServer,
+    webhookServer,
+  };
 };
 
 if (!isTest) {
-  createServer().then(({ app }) =>
-    app.listen(serverPort, () => {
-      console.info(`Server available at: http://localhost:${serverPort}`);
+  createServer()
+    .then(({ webServer, webhookServer }) => {
+      webServer.listen(serverPort, () => {
+        const scheme = config.tlsCertFile ? "https" : "http";
+        console.info(`Server available at: ${scheme}://localhost:${serverPort}`);
+      });
+
+      if (webhookServer) {
+        webhookServer.listen(config.webhookPort, () => {
+          const scheme = config.webhookTlsCertFile ? "https" : "http";
+          console.info(`Webhook server available at: ${scheme}://localhost:${config.webhookPort}`);
+        });
+      }
     })
-  );
+    .catch((e) => {
+      console.error("Failed to start server:", e);
+      process.exit(1);
+    });
+}
+>>>>>>> f7b7c24 (feat(dashboard): add TLS termination for mutating webhook server)
+    })
+    .catch((e) => {
+      console.error("Failed to start server:", e);
+      process.exit(1);
+    });
 }

--- a/apps/dashboard/src/server/server.ts
+++ b/apps/dashboard/src/server/server.ts
@@ -14,7 +14,7 @@ import { webhookRouter } from "./routers/webhook";
 import { aiSdkRouter } from "./routers/ai-sdk/agent-config";
 import { auth } from "./routers/better-auth/auth";
 
-const { serverPort, hmrPort } = config;
+const { port, hmrPort } = config;
 
 const isTest = process.env.NODE_ENV === "test" || !!process.env.VITE_TEST_BUILD;
 
@@ -25,8 +25,6 @@ const __filename = url.fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 export interface CreateServerResult {
-  app: express.Express;
-  webhookApp: express.Express;
   webServer: HttpServer | HttpsServer;
   webhookServer?: HttpServer | HttpsServer;
 }
@@ -96,7 +94,7 @@ export const createServer = async (
   webhookApp.use(express.json());
   webhookApp.use("/webhook", webhookRouter);
 
-  // Web server: HTTPS on serverPort when cert/key are set, otherwise HTTP.
+  // Web server: HTTPS on port when cert/key are set, otherwise HTTP.
   const webHasTls = config.tlsCertFile !== undefined && config.tlsKeyFile !== undefined;
   let webServer: HttpServer | HttpsServer;
   if (webHasTls) {
@@ -118,8 +116,6 @@ export const createServer = async (
   }
 
   return {
-    app,
-    webhookApp,
     webServer,
     webhookServer,
   };
@@ -128,9 +124,9 @@ export const createServer = async (
 if (!isTest) {
   createServer()
     .then(({ webServer, webhookServer }) => {
-      webServer.listen(serverPort, () => {
+      webServer.listen(port, () => {
         const scheme = config.tlsCertFile ? "https" : "http";
-        console.info(`Server available at: ${scheme}://localhost:${serverPort}`);
+        console.info(`Server available at: ${scheme}://localhost:${port}`);
       });
 
       if (webhookServer) {

--- a/apps/dashboard/src/server/server.ts
+++ b/apps/dashboard/src/server/server.ts
@@ -145,10 +145,3 @@ if (!isTest) {
       process.exit(1);
     });
 }
->>>>>>> f7b7c24 (feat(dashboard): add TLS termination for mutating webhook server)
-    })
-    .catch((e) => {
-      console.error("Failed to start server:", e);
-      process.exit(1);
-    });
-}

--- a/dockerfiles/Dockerfile.dashboard
+++ b/dockerfiles/Dockerfile.dashboard
@@ -76,7 +76,7 @@ COPY --from=builder --chown=node:node /app/apps/dashboard/drizzle.config.sqlite.
 
 USER node
 
-EXPOSE 3000
+EXPOSE 3000 8443
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
   CMD wget -qO- http://127.0.0.1:${PORT}/ >/dev/null 2>&1 || exit 1


### PR DESCRIPTION
## Summary

Adds TLS termination support so the Kubernetes API server can reach the mutating admission webhook over HTTPS, which is a hard requirement for `MutatingWebhookConfiguration`.

## Changes

- **Separate Express app for the webhook** — the webhook runs on a dedicated Express instance that only mounts `webhookRouter`, isolating it from the web server's auth, tRPC, and Vite middleware.
- **Separate TLS cert/key pairs** — the web server and webhook server each use their own cert/key:
  - `HERMEUM_TLS_CERT_FILE` / `HERMEUM_TLS_KEY_FILE` — web server (HTTPS on `HERMEUM_PORT` when both set, otherwise HTTP)
  - `HERMEUM_WEBHOOK_TLS_CERT_FILE` / `HERMEUM_WEBHOOK_TLS_KEY_FILE` — webhook server (HTTPS on `HERMEUM_WEBHOOK_PORT` when both set, otherwise HTTP)
- **No explicit TLS enable flag** — TLS is inferred from cert/key presence.
- **Webhook port** — `HERMEUM_WEBHOOK_PORT` (default `8443`).
- **Dockerfile** — `EXPOSE 3000 8443`.
- **Tests** — `server.test.ts` covers both TLS disabled (HTTP) and TLS enabled (HTTPS with self-signed certs via openssl) paths.

## Commits

1. `feat(dashboard): add TLS termination for mutating webhook server` — core implementation
2. `refactor(dashboard): rename dashboardServer to webServer` — naming
3. `refactor(dashboard): rename HERMEUM_SERVER_PORT to HERMEUM_PORT, remove app/webhookApp from return type` — cleanup

## Test plan

- [x] `pnpm --filter @hermeum/dashboard typecheck`
- [x] `pnpm --filter @hermeum/dashboard lint`
- [x] `pnpm --filter @hermeum/dashboard test` — 298/298 pass