### PR TITLE
refactor(dashboard): rename HERMEUM_AGENT_CONFIG_PATH to HERMEUM_CONFIG_PATH

### DIFF
--- a/apps/dashboard/src/server/libs/config.ts
+++ b/apps/dashboard/src/server/libs/config.ts
@@ -4,10 +4,10 @@ import { z } from "zod";
 loadEnv();
 
 export const ConfigSchema = z.object({
-  agentConfigPath: z
+  configPath: z
     .string()
     .default("./agent-config.yaml")
-    .describe("Path to the agent templates config file (HERMEUM_AGENT_CONFIG_PATH)."),
+    .describe("Path to the hermeum config file (HERMEUM_CONFIG_PATH)."),
   hermesDocsPath: z
     .string()
     .default("./docs/hermes-config")
@@ -119,7 +119,7 @@ export const ConfigSchema = z.object({
 });
 
 export const config = ConfigSchema.parse({
-  agentConfigPath: process.env.HERMEUM_AGENT_CONFIG_PATH,
+  configPath: process.env.HERMEUM_CONFIG_PATH,
   hermesDocsPath: process.env.HERMEUM_HERMES_DOCS_PATH,
   databaseDialect: process.env.HERMEUM_DATABASE_DIALECT,
   databaseUrl: process.env.HERMEUM_DATABASE_URL,

--- a/apps/dashboard/src/server/usecases/agent.test.ts
+++ b/apps/dashboard/src/server/usecases/agent.test.ts
@@ -11,7 +11,7 @@ vi.mock("../infras/console-logger", () => ({
   })),
 }));
 vi.mock("@/server/libs/config", () => ({
-  config: { agentConfigPath: "./agent-config.yaml", hermesDocsPath: "./docs/hermes-config" },
+  config: { configPath: "./agent-config.yaml", hermesDocsPath: "./docs/hermes-config" },
 }));
 
 import { stringify } from "yaml";

--- a/apps/dashboard/src/server/usecases/chat.test.ts
+++ b/apps/dashboard/src/server/usecases/chat.test.ts
@@ -14,7 +14,7 @@ vi.mock("../infras/console-logger", () => ({
   })),
 }));
 vi.mock("@/server/libs/config", () => ({
-  config: { agentConfigPath: "./agent-config.yaml", hermesDocsPath: "./docs/hermes-config" },
+  config: { configPath: "./agent-config.yaml", hermesDocsPath: "./docs/hermes-config" },
 }));
 
 import { ChatUseCase, AGENT_CONFIG_CHAT_SYSTEM_PROMPT } from "./chat";

--- a/apps/dashboard/src/server/usecases/mixin.ts
+++ b/apps/dashboard/src/server/usecases/mixin.ts
@@ -40,7 +40,7 @@ export function HermeumConfigLoadable<TBase extends Constructor<{ files: FileAda
 
     async loadHermeumConfig(): Promise<HermeumConfig> {
       if (!this.#cachedHermeumConfig) {
-        const file = await this.files.readFile(config.agentConfigPath);
+        const file = await this.files.readFile(config.configPath);
         const raw = file === null ? { templates: [] } : parse(file.content);
         this.#cachedHermeumConfig = HermeumConfigSchema.parse(raw);
       }

--- a/charts/hermeum/templates/deployment.yaml
+++ b/charts/hermeum/templates/deployment.yaml
@@ -84,8 +84,8 @@ spec:
             {{- end }}
           env:
             # ── Non-sensitive (ConfigMap) ──
-            - name: HERMEUM_AGENT_CONFIG_PATH
-              value: {{ .Values.config.agentConfigPath | quote }}
+            - name: HERMEUM_CONFIG_PATH
+              value: {{ .Values.config.configPath | quote }}
             - name: HERMEUM_HERMES_DOCS_PATH
               value: {{ .Values.config.hermesDocsPath | quote }}
             - name: HERMEUM_DATABASE_DIALECT
@@ -213,10 +213,10 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
-            # agentConfig override mounted at HERMEUM_AGENT_CONFIG_PATH.
+            # agentConfig override mounted at HERMEUM_CONFIG_PATH.
             {{- if include "hermeum.hasAgentConfig" . }}
             - name: agent-config
-              mountPath: {{ .Values.config.agentConfigPath | quote }}
+              mountPath: {{ .Values.config.configPath | quote }}
               subPath: agent-config.yaml
               readOnly: true
             {{- end }}

--- a/charts/hermeum/values.schema.json
+++ b/charts/hermeum/values.schema.json
@@ -23,7 +23,7 @@
     "config": {
       "type": "object",
       "properties": {
-        "agentConfigPath": { "type": "string" },
+        "configPath": { "type": "string" },
         "hermesDocsPath": { "type": "string" },
         "databaseDialect": { "type": "string", "enum": ["sqlite", "postgres"] },
         "kubernetesNamespace": { "type": "string" },
@@ -52,7 +52,7 @@
         }
       },
       "required": [
-        "agentConfigPath",
+        "configPath",
         "hermesDocsPath",
         "databaseDialect",
         "kubernetesNamespace",

--- a/charts/hermeum/values.yaml
+++ b/charts/hermeum/values.yaml
@@ -35,9 +35,9 @@ operator:
 
 # ── Dashboard env (HERMEUM_*, non-sensitive → ConfigMap) ─────────────────────
 config:
-  # Path to the agent templates config file (HERMEUM_AGENT_CONFIG_PATH).
+  # Path to the hermeum config file (HERMEUM_CONFIG_PATH).
   # The chart mounts the agentConfig ConfigMap at this path when non-empty.
-  agentConfigPath: /app/agent-config.yaml
+  configPath: /app/agent-config.yaml
   # Path to the hermes-config docs directory (HERMEUM_HERMES_DOCS_PATH).
   # Shipped inside the image; override only if you mount custom docs.
   hermesDocsPath: /app/docs/hermes-config
@@ -118,7 +118,7 @@ secrets:
   # better-auth-secret, better-auth-url, smtp-url, openai-base-url, openai-api-key.
   existingSecret: ""
 
-# ── agentConfig override (ConfigMap mounted at config.agentConfigPath) ───────
+# ── agentConfig override (ConfigMap mounted at config.configPath) ───────
 # Full contents of agent-config.yaml. When empty, the image's bundled
 # agent-config.example.yaml is used as-is.
 #

--- a/dockerfiles/Dockerfile.dashboard
+++ b/dockerfiles/Dockerfile.dashboard
@@ -66,7 +66,7 @@ COPY --from=builder --chown=node:node /deploy/dist ./dist
 # Runtime data referenced by config.ts defaults.
 # agent-config.yaml is gitignored (instance-specific), so we ship the tracked
 # example as the runtime default. Operators override via a volume mount or
-# HERMEUM_AGENT_CONFIG_PATH.
+# HERMEUM_CONFIG_PATH.
 COPY --from=builder --chown=node:node /app/apps/dashboard/agent-config.example.yaml ./agent-config.yaml
 COPY --from=builder --chown=node:node /app/apps/dashboard/docs/hermes-config ./docs/hermes-config
 # Drizzle migrations + config for both dialects (postgres & sqlite).


### PR DESCRIPTION
## Summary

The existing `HERMEUM_AGENT_CONFIG_PATH` env var name confused users. Rename it and the related config field for clarity:

- `HERMEUM_AGENT_CONFIG_PATH` → `HERMEUM_CONFIG_PATH`
- `config.agentConfigPath` → `config.configPath`

## Changes

- `apps/dashboard/src/server/libs/config.ts` — schema field, env var read, and description (now "Path to the hermeum config file")
- `apps/dashboard/src/server/usecases/mixin.ts` — update `config.agentConfigPath` consumer
- `apps/dashboard/src/server/usecases/{agent,chat}.test.ts` — update mocked config
- `charts/hermeum/templates/deployment.yaml` — env var name, value reference, and mount path
- `charts/hermeum/values.yaml` — field name and comments
- `charts/hermeum/values.schema.json` — schema property name
- `dockerfiles/Dockerfile.dashboard` — comment reference

## Verification

- `pnpm --filter @hermeum/dashboard lint` — clean (only pre-existing warnings)
- `pnpm --filter @hermeum/dashboard test` — 298 passed
- Typecheck has 3 pre-existing errors in `agent-config.ts`/`server.ts` unrelated to this change