### PR TITLE
Refactor agent-config chat: tool descriptions over system prompt, add listAgentTypes

### DIFF
--- a/apps/dashboard/docs/hermes-config/slack.md
+++ b/apps/dashboard/docs/hermes-config/slack.md
@@ -13,11 +13,13 @@ Requires `SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`, and `SLACK_ALLOWED_USERS`
 env vars (see [Environment variables](#environment-variables)); without
 `SLACK_ALLOWED_USERS` the gateway denies all messages by default.
 
-Using Slack also requires configuration on the Slack side (app creation,
-socket mode, scopes, event subscriptions). Follow the official Hermes
-Agent guide at
-https://hermes-agent.nousresearch.com/docs/user-guide/messaging/slack
-to complete that setup.
+**You must configure Slack on the Slack side before this gateway will
+work** — app creation, Socket Mode, OAuth scopes, and event
+subscriptions. This is not optional. Complete that setup by following
+the official Hermes Agent guide at
+https://hermes-agent.nousresearch.com/docs/user-guide/messaging/slack.
+The `config.yaml` knobs below assume the Slack-side setup is already
+done; without it, no messages will flow.
 
 Slack config lives in **two** `config.yaml` locations — keep them
 straight, they are not interchangeable:

--- a/apps/dashboard/docs/hermes-config/teams.md
+++ b/apps/dashboard/docs/hermes-config/teams.md
@@ -12,11 +12,13 @@ publicly reachable endpoint — either a dev tunnel (local dev) or a real
 domain (production). Unlike Slack's Socket Mode, Teams is an HTTP-webhook
 platform.
 
-Using Teams also requires configuration on the Teams side (bot
-registration, messaging endpoint, app installation). Follow the official
-Hermes Agent guide at
-https://hermes-agent.nousresearch.com/docs/user-guide/messaging/teams
-to complete that setup.
+**You must configure Microsoft Teams on the Azure/Teams side before this
+bot will work** — bot registration, messaging endpoint, and app
+installation. This is not optional. Complete that setup by following
+the official Hermes Agent guide at
+https://hermes-agent.nousresearch.com/docs/user-guide/messaging/teams.
+The env vars and `config.yaml` knobs below assume the Teams-side setup
+is already done; without it, the webhook will receive no messages.
 
 ## Configuration
 

--- a/apps/dashboard/src/routeTree.gen.ts
+++ b/apps/dashboard/src/routeTree.gen.ts
@@ -9,29 +9,24 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './client/ui/routes/__root'
-import { Route as SigninRouteImport } from './client/ui/routes/signin'
 import { Route as IndexRouteImport } from './client/ui/routes/index'
-import { Route as SharedEnvSetsIndexRouteImport } from './client/ui/routes/shared-env-sets/index'
+import { Route as SigninRouteImport } from './client/ui/routes/signin'
 import { Route as AgentsIndexRouteImport } from './client/ui/routes/agents/index'
-import { Route as SharedEnvSetsIdRouteImport } from './client/ui/routes/shared-env-sets/$id'
-import { Route as AgentsNewRouteImport } from './client/ui/routes/agents/new'
 import { Route as AgentsIdRouteImport } from './client/ui/routes/agents/$id'
+import { Route as AgentsNewRouteImport } from './client/ui/routes/agents/new'
+import { Route as SharedEnvSetsIndexRouteImport } from './client/ui/routes/shared-env-sets/index'
+import { Route as SharedEnvSetsIdRouteImport } from './client/ui/routes/shared-env-sets/$id'
 import { Route as AgentsIdIndexRouteImport } from './client/ui/routes/agents/$id/index'
 import { Route as AgentsIdEditRouteImport } from './client/ui/routes/agents/$id/edit'
 
-const SigninRoute = SigninRouteImport.update({
-  id: '/signin',
-  path: '/signin',
-  getParentRoute: () => rootRouteImport,
-} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
-const SharedEnvSetsIndexRoute = SharedEnvSetsIndexRouteImport.update({
-  id: '/shared-env-sets/',
-  path: '/shared-env-sets/',
+const SigninRoute = SigninRouteImport.update({
+  id: '/signin',
+  path: '/signin',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AgentsIndexRoute = AgentsIndexRouteImport.update({
@@ -39,9 +34,9 @@ const AgentsIndexRoute = AgentsIndexRouteImport.update({
   path: '/agents/',
   getParentRoute: () => rootRouteImport,
 } as any)
-const SharedEnvSetsIdRoute = SharedEnvSetsIdRouteImport.update({
-  id: '/shared-env-sets/$id',
-  path: '/shared-env-sets/$id',
+const AgentsIdRoute = AgentsIdRouteImport.update({
+  id: '/agents/$id',
+  path: '/agents/$id',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AgentsNewRoute = AgentsNewRouteImport.update({
@@ -49,9 +44,14 @@ const AgentsNewRoute = AgentsNewRouteImport.update({
   path: '/agents/new',
   getParentRoute: () => rootRouteImport,
 } as any)
-const AgentsIdRoute = AgentsIdRouteImport.update({
-  id: '/agents/$id',
-  path: '/agents/$id',
+const SharedEnvSetsIndexRoute = SharedEnvSetsIndexRouteImport.update({
+  id: '/shared-env-sets/',
+  path: '/shared-env-sets/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const SharedEnvSetsIdRoute = SharedEnvSetsIdRouteImport.update({
+  id: '/shared-env-sets/$id',
+  path: '/shared-env-sets/$id',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AgentsIdIndexRoute = AgentsIdIndexRouteImport.update({
@@ -145,13 +145,6 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/signin': {
-      id: '/signin'
-      path: '/signin'
-      fullPath: '/signin'
-      preLoaderRoute: typeof SigninRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/': {
       id: '/'
       path: '/'
@@ -159,11 +152,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/shared-env-sets/': {
-      id: '/shared-env-sets/'
-      path: '/shared-env-sets'
-      fullPath: '/shared-env-sets/'
-      preLoaderRoute: typeof SharedEnvSetsIndexRouteImport
+    '/signin': {
+      id: '/signin'
+      path: '/signin'
+      fullPath: '/signin'
+      preLoaderRoute: typeof SigninRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/agents/': {
@@ -173,11 +166,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AgentsIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/shared-env-sets/$id': {
-      id: '/shared-env-sets/$id'
-      path: '/shared-env-sets/$id'
-      fullPath: '/shared-env-sets/$id'
-      preLoaderRoute: typeof SharedEnvSetsIdRouteImport
+    '/agents/$id': {
+      id: '/agents/$id'
+      path: '/agents/$id'
+      fullPath: '/agents/$id'
+      preLoaderRoute: typeof AgentsIdRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/agents/new': {
@@ -187,11 +180,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AgentsNewRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/agents/$id': {
-      id: '/agents/$id'
-      path: '/agents/$id'
-      fullPath: '/agents/$id'
-      preLoaderRoute: typeof AgentsIdRouteImport
+    '/shared-env-sets/': {
+      id: '/shared-env-sets/'
+      path: '/shared-env-sets'
+      fullPath: '/shared-env-sets/'
+      preLoaderRoute: typeof SharedEnvSetsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/shared-env-sets/$id': {
+      id: '/shared-env-sets/$id'
+      path: '/shared-env-sets/$id'
+      fullPath: '/shared-env-sets/$id'
+      preLoaderRoute: typeof SharedEnvSetsIdRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/agents/$id/': {

--- a/apps/dashboard/src/server/usecases/chat.test.ts
+++ b/apps/dashboard/src/server/usecases/chat.test.ts
@@ -97,33 +97,24 @@ function makeSkillIndex(results: SkillSearchResult[] = []): SkillIndexAdaptor {
   } as unknown as SkillIndexAdaptor;
 }
 
-// Expected empty-list footer appended to the instructions when there are no
-// shared env sets (matches buildSharedEnvSetList's header-only emission).
-const EMPTY_SHARED_ENV_SET_BLOCK =
-  "Available shared env sets (attach via the `sharedEnvSets` field with " +
-  "these ids; read env var names with `readSharedEnvSet` before attaching " +
-  "to avoid collisions with the agent's own `env`):\n";
+// Expected body appended to the readSharedEnvSet tool description when no
+// shared env sets exist (matches buildSharedEnvSetList's none-sentinel
+// emission).
+const EMPTY_SHARED_ENV_SET_BLOCK = "Available shared env sets: none";
 
 describe("ChatUseCase.getAgentConfigContext", () => {
-  it("uses the base system prompt when no agent types are configured", async () => {
+  it("uses the bare system prompt (no appended lists) when nothing is configured", async () => {
     const useCase = new ChatUseCase(makeRuntime(), makeFiles({}, undefined));
 
     const { instructions } = await useCase.getAgentConfigContext();
 
-    // The base prompt is always followed by the available-documents block and
-    // the available-shared-env-sets block, even when there are no docs, no
-    // sets, and no agent types.
-    expect(instructions).toContain(AGENT_CONFIG_CHAT_SYSTEM_PROMPT);
-    expect(instructions).toBe(
-      AGENT_CONFIG_CHAT_SYSTEM_PROMPT +
-        "\n\n" +
-        "Available documents (read with `readDocument` before writing any config section you're not fully sure about):\n" +
-        "\n\n" +
-        EMPTY_SHARED_ENV_SET_BLOCK
-    );
+    // The doc/shared-env-set lists now live in their tool descriptions, and
+    // agent types are returned by the listAgentTypes tool, so the prompt is
+    // just the base system prompt with nothing appended.
+    expect(instructions).toBe(AGENT_CONFIG_CHAT_SYSTEM_PROMPT);
   });
 
-  it("appends the configured agent types to the instructions", async () => {
+  it("returns the configured agent types via the listAgentTypes tool, not the instructions", async () => {
     const useCase = new ChatUseCase(
       makeRuntime(),
       makeFiles(
@@ -135,11 +126,30 @@ describe("ChatUseCase.getAgentConfigContext", () => {
       )
     );
 
-    const { instructions } = await useCase.getAgentConfigContext();
+    const { instructions, tools } = await useCase.getAgentConfigContext();
 
-    expect(instructions).toContain(AGENT_CONFIG_CHAT_SYSTEM_PROMPT);
-    expect(instructions).toContain("- pr-review: Reviews pull requests");
-    expect(instructions).toContain("- plain");
+    // Agent types are no longer appended to the prompt.
+    expect(instructions).not.toContain("pr-review");
+    expect(instructions).not.toContain("Reviews pull requests");
+
+    expect(tools.listAgentTypes).toBeDefined();
+    expect(tools.listAgentTypes?.execute).toBeDefined();
+    const result = await tools.listAgentTypes!.execute!({}, callOptions);
+    expect(result).toEqual({
+      agentTypes: [
+        { key: "pr-review", description: "Reviews pull requests" },
+        { key: "plain" },
+      ],
+    });
+  });
+
+  it("returns an empty agentTypes array when none are configured", async () => {
+    const useCase = new ChatUseCase(makeRuntime(), makeFiles({}, undefined));
+
+    const { tools } = await useCase.getAgentConfigContext();
+
+    const result = await tools.listAgentTypes!.execute!({}, callOptions);
+    expect(result).toEqual({ agentTypes: [] });
   });
 
   it("notes the missing draft when no current config is given", async () => {
@@ -170,7 +180,7 @@ describe("ChatUseCase.getAgentConfigContext", () => {
     expect(tools.updateAgentConfig!.execute).toBeUndefined();
   });
 
-  it("exposes a client-side readAgentConfig tool", async () => {
+  it("exposes a client-side readAgentConfig tool and instructs the model to use it when stale", async () => {
     const useCase = new ChatUseCase(makeRuntime(), makeFiles());
 
     const { tools } = await useCase.getAgentConfigContext();
@@ -180,17 +190,12 @@ describe("ChatUseCase.getAgentConfigContext", () => {
     // No execute: the tool runs on the client, which returns the latest
     // editor draft and reports it back.
     expect(tools.readAgentConfig!.execute).toBeUndefined();
+    // The stale-draft guidance lives in the tool description now, not the
+    // system prompt.
+    expect(tools.readAgentConfig!.description).toContain("stale");
   });
 
-  it("instructs the model to call readAgentConfig when the draft may be stale", async () => {
-    const useCase = new ChatUseCase(makeRuntime(), makeFiles());
-
-    const { instructions } = await useCase.getAgentConfigContext();
-
-    expect(instructions).toContain("readAgentConfig");
-  });
-
-  it("does not expose a listDocuments tool (the list is embedded in the prompt)", async () => {
+  it("does not expose a listDocuments tool (the list is embedded in the readDocument description)", async () => {
     const useCase = new ChatUseCase(makeRuntime(), makeFiles());
 
     const { tools } = await useCase.getAgentConfigContext();
@@ -232,7 +237,7 @@ describe("ChatUseCase.getAgentConfigContext", () => {
     expect(skillIndex.searchSkills).toHaveBeenCalledWith("kubernetes", 25);
   });
 
-  it("embeds the available documents in the instructions with frontmatter descriptions", async () => {
+  it("embeds the available documents in the readDocument description with frontmatter descriptions", async () => {
     const useCase = new ChatUseCase(
       makeRuntime(),
       makeFiles({
@@ -241,14 +246,15 @@ describe("ChatUseCase.getAgentConfigContext", () => {
       })
     );
 
-    const { instructions } = await useCase.getAgentConfigContext();
+    const { tools } = await useCase.getAgentConfigContext();
 
-    expect(instructions).toContain("- model: Model configuration");
-    expect(instructions).toContain("- webhook");
-    expect(instructions).not.toContain("- webhook:");
+    const description = tools.readDocument!.description ?? "";
+    expect(description).toContain("- model: Model configuration");
+    expect(description).toContain("- webhook");
+    expect(description).not.toContain("- webhook:");
   });
 
-  it("groups documents by category alphabetically, then uncategorized last", async () => {
+  it("groups documents by category alphabetically, then uncategorized last, in the readDocument description", async () => {
     const useCase = new ChatUseCase(
       makeRuntime(),
       makeFiles({
@@ -266,14 +272,15 @@ describe("ChatUseCase.getAgentConfigContext", () => {
       })
     );
 
-    const { instructions } = await useCase.getAgentConfigContext();
+    const { tools } = await useCase.getAgentConfigContext();
+    const description = tools.readDocument!.description ?? "";
 
     // Categories are surfaced in alphabetical order, uncategorized trailing.
-    const coreIdx = instructions.indexOf("core:");
-    const platformsIdx = instructions.indexOf("platforms:");
-    const runtimeIdx = instructions.indexOf("runtime:");
-    const toolsIdx = instructions.indexOf("tools:");
-    const uncategorizedIdx = instructions.indexOf("Uncategorized:");
+    const coreIdx = description.indexOf("core:");
+    const platformsIdx = description.indexOf("platforms:");
+    const runtimeIdx = description.indexOf("runtime:");
+    const toolsIdx = description.indexOf("tools:");
+    const uncategorizedIdx = description.indexOf("Uncategorized:");
     expect(coreIdx).toBeGreaterThanOrEqual(0);
     expect(platformsIdx).toBeGreaterThan(coreIdx);
     expect(runtimeIdx).toBeGreaterThan(platformsIdx);
@@ -281,11 +288,20 @@ describe("ChatUseCase.getAgentConfigContext", () => {
     expect(uncategorizedIdx).toBeGreaterThan(toolsIdx);
 
     // Known category blocks contain their grouped docs.
-    expect(instructions).toContain("core:\n- model: Model configuration");
-    expect(instructions).toContain("tools:\n- browser: Browser automation\n- web-search: Web search");
-    expect(instructions).toContain("platforms:\n- webhooks: Webhook routes");
-    expect(instructions).toContain("runtime:\n- observability: Observability");
-    expect(instructions).toContain("Uncategorized:\n- draft");
+    expect(description).toContain("core:\n- model: Model configuration");
+    expect(description).toContain("tools:\n- browser: Browser automation\n- web-search: Web search");
+    expect(description).toContain("platforms:\n- webhooks: Webhook routes");
+    expect(description).toContain("runtime:\n- observability: Observability");
+    expect(description).toContain("Uncategorized:\n- draft");
+  });
+
+  it("emits the none sentinel in the readDocument description when no docs exist", async () => {
+    const useCase = new ChatUseCase(makeRuntime(), makeFiles());
+
+    const { tools } = await useCase.getAgentConfigContext();
+
+    const description = tools.readDocument!.description ?? "";
+    expect(description).toContain("Available documents: none");
   });
 
   it("reads multiple documents in one call", async () => {
@@ -343,16 +359,17 @@ describe("ChatUseCase.getAgentConfigContext", () => {
     expect(files.readFile).not.toHaveBeenCalled();
   });
 
-  it("emits only the shared-env-sets header when none exist", async () => {
+  it("emits the none sentinel in the readSharedEnvSet description when no sets exist", async () => {
     const useCase = new ChatUseCase(makeRuntime(), makeFiles());
 
-    const { instructions } = await useCase.getAgentConfigContext();
+    const { tools } = await useCase.getAgentConfigContext();
 
-    expect(instructions).toContain(EMPTY_SHARED_ENV_SET_BLOCK);
-    expect(instructions).not.toContain("- set-1");
+    const description = tools.readSharedEnvSet!.description ?? "";
+    expect(description).toContain(EMPTY_SHARED_ENV_SET_BLOCK);
+    expect(description).not.toContain("- set-1");
   });
 
-  it("embeds the available shared env sets in the instructions by id", async () => {
+  it("embeds the available shared env sets in the readSharedEnvSet description by id", async () => {
     const runtime = makeRuntime([
       makeSharedEnvSet({
         id: "db-creds",
@@ -364,15 +381,16 @@ describe("ChatUseCase.getAgentConfigContext", () => {
     ]);
     const useCase = new ChatUseCase(runtime, makeFiles());
 
-    const { instructions } = await useCase.getAgentConfigContext();
+    const { tools } = await useCase.getAgentConfigContext();
+    const description = tools.readSharedEnvSet!.description ?? "";
 
     // Lines lead with the id (the draft's `sharedEnvSets` field wants ids),
     // carry the human name, and append the description when present.
-    expect(instructions).toContain("- db-creds: Database Credentials — Postgres connection vars");
-    expect(instructions).toContain("- api-keys: API Keys");
+    expect(description).toContain("- db-creds: Database Credentials — Postgres connection vars");
+    expect(description).toContain("- api-keys: API Keys");
     // The db-creds ordering must come before api-keys (runtime returns them
     // in the given order, which is preserved).
-    expect(instructions.indexOf("db-creds")).toBeLessThan(instructions.indexOf("api-keys"));
+    expect(description.indexOf("db-creds")).toBeLessThan(description.indexOf("api-keys"));
   });
 
   it("filters out archived shared env sets before listing them", async () => {
@@ -382,10 +400,11 @@ describe("ChatUseCase.getAgentConfigContext", () => {
     ]);
     const useCase = new ChatUseCase(runtime, makeFiles());
 
-    const { instructions } = await useCase.getAgentConfigContext();
+    const { tools } = await useCase.getAgentConfigContext();
+    const description = tools.readSharedEnvSet!.description ?? "";
 
-    expect(instructions).toContain("- live: Live");
-    expect(instructions).not.toContain("- gone");
+    expect(description).toContain("- live: Live");
+    expect(description).not.toContain("- gone");
     // listSharedEnvSets is asked for non-archived sets only.
     expect(runtime.listSharedEnvSets).toHaveBeenCalledWith({ archived: false });
   });

--- a/apps/dashboard/src/server/usecases/chat.ts
+++ b/apps/dashboard/src/server/usecases/chat.ts
@@ -94,9 +94,7 @@ export class ChatUseCase extends HermeumConfigLoadable(BaseUseCase) {
       description:
         "Read one or more Hermes agent configuration documents by name. " +
         "Pass every document you need in a single call to minimize " +
-        "round-trips, and read up on any config section you are not fully " +
-        "sure about BEFORE writing it into the draft. Don't guess at field " +
-        "semantics that a document can settle.\n\n" + docList,
+        "round-trips.\n\n" + docList,
       inputSchema: z.object({
         names: z.array(z.string()).min(1).describe("Document names from the list above."),
       }),
@@ -251,8 +249,8 @@ export class ChatUseCase extends HermeumConfigLoadable(BaseUseCase) {
 
 // Behavioral rules for the agent-config chat. Tool-specific guidance (when to
 // call `readDocument`, `readSharedEnvSet`, `readAgentConfig`,
-// `updateAgentConfig`, and the available doc/shared-env-set lists) lives in the
-// tool `description` fields, not here, so the model sees each tool's usage
+// `updateAgentConfig`, and the available doc/shared-env-set lists) lives in
+// the tool `description` fields, not here, so the model sees each tool's usage
 // rules alongside its definition.
 export const AGENT_CONFIG_CHAT_SYSTEM_PROMPT = `\
 You help a user workshop the definition of a new autonomous agent through
@@ -262,4 +260,10 @@ it in an editor and may change it by hand between messages.
 After a config update, reply with one short sentence noting what changed
 plus a brief question about what to refine next (e.g. the tone, the scope,
 or the tools setup). Ask at most one question at a time, and keep all replies
-concise.`;
+concise.
+
+Note 
+- Never guess at field semantics. When you're not fully sure about a config
+section, settle it with the documentation before writing it into the draft.
+
+`;

--- a/apps/dashboard/src/server/usecases/chat.ts
+++ b/apps/dashboard/src/server/usecases/chat.ts
@@ -24,19 +24,22 @@ export interface AgentConfigContext {
 
 export class ChatUseCase extends HermeumConfigLoadable(BaseUseCase) {
   // Everything the chat route needs for an agent-config conversation turn:
-  // the system prompt (with the available doc list and configured agent types
-  // appended), a context block describing the current draft, and the
-  // client-side tool the model uses to apply config changes.
+  // the system prompt, a context block describing the current draft, and the
+  // tool set the model uses to read docs/shared env sets, list agent types,
+  // search skills, and apply config changes. The available documents and
+  // shared env sets are embedded in their respective tool descriptions (not
+  // the system prompt) so the model sees them right at the tool definition.
   async getAgentConfigContext(currentConfig?: AgentInput): Promise<AgentConfigContext> {
     const ctx: AgentConfigContext = {
-      instructions: await this.buildInstructions(),
+      instructions: AGENT_CONFIG_CHAT_SYSTEM_PROMPT,
       prompt:
         currentConfig === undefined
           ? "There is no agent config draft yet."
           : "Current agent config draft as JSON:\n\n" + JSON.stringify(currentConfig, null, 2),
       tools: {
-        readDocument: this.buildReadDocumentTool(),
-        readSharedEnvSet: this.buildReadSharedEnvSetTool(),
+        readDocument: await this.buildReadDocumentTool(),
+        readSharedEnvSet: await this.buildReadSharedEnvSetTool(),
+        listAgentTypes: await this.buildListAgentTypesTool(),
         searchSkills: tool({
           description:
             "Search the Hermes Skills Index for an installable agent skill " +
@@ -81,18 +84,21 @@ export class ChatUseCase extends HermeumConfigLoadable(BaseUseCase) {
     return ctx;
   }
 
-  // Server-executed tool that lets the model pull a Hermes agent configuration
-  // document on demand. The list of available documents is embedded in the
-  // system prompt up front, so the model can plan a single batched call
-  // without first calling a list tool.
-  private buildReadDocumentTool(): ToolSet[string] {
+  // Server-executed tool that lets the model pull Hermes agent configuration
+  // documents on demand. The list of available documents is built here and
+  // embedded in the description up front, so the model can plan a single
+  // batched call without first calling a list tool.
+  private async buildReadDocumentTool(): Promise<ToolSet[string]> {
+    const docList = await this.buildDocumentList();
     return tool({
       description:
-        "Read one or more Hermes agent configuration documents by name " +
-        "(names are listed in the system prompt). Pass every document you " +
-        "need in a single call to minimize round-trips.",
+        "Read one or more Hermes agent configuration documents by name. " +
+        "Pass every document you need in a single call to minimize " +
+        "round-trips, and read up on any config section you are not fully " +
+        "sure about BEFORE writing it into the draft. Don't guess at field " +
+        "semantics that a document can settle.\n\n" + docList,
       inputSchema: z.object({
-        names: z.array(z.string()).min(1).describe("Document names listed in the system prompt."),
+        names: z.array(z.string()).min(1).describe("Document names from the list above."),
       }),
       execute: async ({ names }) => {
         const documents = await Promise.all(
@@ -103,7 +109,7 @@ export class ChatUseCase extends HermeumConfigLoadable(BaseUseCase) {
             return file === null
               ? {
                   name,
-                  error: `Document "${name}" not found. Use the names listed in the system prompt.`,
+                  error: `Document "${name}" not found. Use the names listed in the tool description.`,
                 }
               : { name, content: file.content };
           })
@@ -115,20 +121,21 @@ export class ChatUseCase extends HermeumConfigLoadable(BaseUseCase) {
   }
 
   // Server-executed tool that lets the model inspect the env var names inside
-  // one or more shared env sets (ids are listed in the system prompt). The
-  // values are never surfaced — shared env sets only carry env var names; the
-  // values live in Kubernetes Secrets the agent loads via `envFrom`. Batch
-  // every id you need into a single call to minimize round-trips.
-  private buildReadSharedEnvSetTool(): ToolSet[string] {
+  // one or more shared env sets (ids are listed in the description). The values
+  // are never surfaced — shared env sets only carry env var names; the values
+  // live in Kubernetes Secrets the agent loads via `envFrom`. Batch every id
+  // you need into a single call to minimize round-trips.
+  private async buildReadSharedEnvSetTool(): Promise<ToolSet[string]> {
+    const sharedEnvSetList = await this.buildSharedEnvSetList();
     return tool({
       description:
-        "Read the env var names inside one or more shared env sets by id " +
-        "(ids are listed in the system prompt). Use this before attaching a " +
-        "set to avoid name collisions with the agent's own `env`, or to " +
-        "confirm a needed var is present. Pass every id you need in a single " +
-        "call to minimize round-trips.",
+        "Read the env var names inside one or more shared env sets by id. " +
+        "Use this before attaching a set to avoid name collisions with the " +
+        "agent's own `env`, or to confirm a needed var is present. Pass every " +
+        "id you need in a single call to minimize round-trips. To attach a " +
+        "set, add its id to the draft's `sharedEnvSets` array.\n\n" + sharedEnvSetList,
       inputSchema: z.object({
-        ids: z.array(z.string()).min(1).describe("Shared env set ids listed in the system prompt."),
+        ids: z.array(z.string()).min(1).describe("Shared env set ids from the list above."),
       }),
       execute: async ({ ids }) => {
         const sharedEnvSets = await Promise.all(
@@ -137,7 +144,7 @@ export class ChatUseCase extends HermeumConfigLoadable(BaseUseCase) {
             if (set === null || set.archived) {
               return {
                 id,
-                error: `Shared env set "${id}" not found. Use the ids listed in the system prompt.`,
+                error: `Shared env set "${id}" not found. Use the ids listed in the tool description.`,
               };
             }
             return { id, envVars: set.envVars.map(({ name }) => ({ name })) };
@@ -149,41 +156,44 @@ export class ChatUseCase extends HermeumConfigLoadable(BaseUseCase) {
     });
   }
 
-  private async buildInstructions(): Promise<string> {
-    const [docList, sharedEnvSetList, { agentTypes }] = await Promise.all([
-      this.buildDocumentList(),
-      this.buildSharedEnvSetList(),
-      this.loadHermeumConfig(),
-    ]);
-
-    let instructions = AGENT_CONFIG_CHAT_SYSTEM_PROMPT + "\n\n" + docList + "\n\n" + sharedEnvSetList;
-
-    if (agentTypes) {
-      const lines = Object.entries(agentTypes).map(
-        ([key, t]) => `- ${key}${t.description ? `: ${t.description}` : ""}`
-      );
-      instructions +=
-        "\n\nAgent types (optional — set `type` only if the request clearly " +
-        "matches one; otherwise omit):\n" +
-        lines.join("\n");
-    }
-    return instructions;
+  // Server-executed tool that returns the configured agent types the draft's
+  // `type` field can be set to. The types are loaded here once per turn at
+  // context-build time, so execute is a cheap synchronous lookup. Returns an
+  // empty array when no agent types are configured.
+  private async buildListAgentTypesTool(): Promise<ToolSet[string]> {
+    const { agentTypes } = await this.loadHermeumConfig();
+    const entries = agentTypes
+      ? Object.entries(agentTypes).map(([key, t]) => ({
+          key,
+          ...(t.description !== undefined ? { description: t.description } : {}),
+        }))
+      : [];
+    return tool({
+      description:
+        "List the configured agent types the draft's `type` field can be set " +
+        "to. Set `type` only when the request clearly matches one of these; " +
+        "otherwise omit it.",
+      inputSchema: z.object({}),
+      execute: async () => {
+        this.logger.debug("listed agent types", { count: entries.length });
+        return { agentTypes: entries };
+      },
+    });
   }
 
   // Build the "Available documents:" block listing every Hermes config doc the
-  // model can request via `readDocument`. Embedded up front so the model can
-  // skip the list-tool round-trip and batch-read directly. Docs are grouped
-  // under their frontmatter `category` (categories discovered dynamically from
-  // the docs themselves, surfaced alphabetically); docs with no `category`
-  // field are grouped together in a trailing `Uncategorized` block. When no
-  // docs exist, only the header is emitted.
+  // model can request via `readDocument`. Embedded in the tool description so
+  // the model can skip a list-tool round-trip and batch-read directly. Docs are
+  // grouped under their frontmatter `category` (categories discovered
+  // dynamically from the docs themselves, surfaced alphabetically); docs with
+  // no `category` field are grouped together in a trailing `Uncategorized`
+  // block. When no docs exist, a `none` sentinel is emitted.
   private async buildDocumentList(): Promise<string> {
     const files = (await this.files.listFiles(DOCS_PATH)).filter((file) =>
       file.path.endsWith(".md")
     );
     if (files.length === 0) {
-      return "Available documents (read with `readDocument` before writing any " +
-        "config section you're not fully sure about):\n";
+      return "Available documents: none";
     }
 
     const lineFor = ({ name, data }: File) =>
@@ -197,16 +207,13 @@ export class ChatUseCase extends HermeumConfigLoadable(BaseUseCase) {
       if (category === undefined) {
         uncategorized.push(file);
         continue;
-      } 
-
+      }
       const bucket = categories.get(category) ?? [];
       bucket.push(file);
       categories.set(category, bucket);
     }
 
-    const orderedCategories = [...categories.keys()].sort((a, b) =>
-      a.localeCompare(b)
-    );
+    const orderedCategories = [...categories.keys()].sort((a, b) => a.localeCompare(b));
 
     const blocks: string[] = [];
     for (const category of orderedCategories) {
@@ -217,65 +224,42 @@ export class ChatUseCase extends HermeumConfigLoadable(BaseUseCase) {
       blocks.push(`${UNCATEGORIZED_LABEL}:\n${uncategorized.map(lineFor).join("\n")}`);
     }
 
-    return "Available documents (read with `readDocument` before writing any " +
-      "config section you're not fully sure about):\n" +
-      blocks.join("\n\n");
+    return "Available documents:\n" + blocks.join("\n\n");
   }
 
   // Build the "Available shared env sets:" block listing every non-archived
   // shared env set the model can attach via the `sharedEnvSets` field. The id
   // (not the human name) is what the draft's `sharedEnvSets` array expects, so
-  // each line leads with the id. Embedded up front so the model can attach a
-  // set without first calling a list tool; env var names inside a set are
-  // fetched on demand via `readSharedEnvSet` to keep the prompt lean. When no
-  // sets exist, only the header is emitted.
+  // each line leads with the id. Embedded in the tool description up front so
+  // the model can attach a set without first calling a list tool; env var names
+  // inside a set are fetched on demand via `readSharedEnvSet` to keep the
+  // description lean. When no sets exist, a `none` sentinel is emitted.
   private async buildSharedEnvSetList(): Promise<string> {
     const sets = (await this.runtime.listSharedEnvSets({ archived: false })).filter(
       (set) => !set.archived
     );
-    const header =
-      "Available shared env sets (attach via the `sharedEnvSets` field with " +
-      "these ids; read env var names with `readSharedEnvSet` before attaching " +
-      "to avoid collisions with the agent's own `env`):";
     if (sets.length === 0) {
-      return header + "\n";
+      return "Available shared env sets: none";
     }
     const lines = sets.map((set) => {
       const tail = set.description ? ` — ${set.description}` : "";
       return `- ${set.id}: ${set.name}${tail}`;
     });
-    return header + "\n" + lines.join("\n");
+    return "Available shared env sets:\n" + lines.join("\n");
   }
 }
 
-// Field semantics live in the tool input schema's .describe() texts; this
-// prompt carries the conversational behavior and cross-field rules instead.
-// The available documents and configured agent types are appended at runtime.
+// Behavioral rules for the agent-config chat. Tool-specific guidance (when to
+// call `readDocument`, `readSharedEnvSet`, `readAgentConfig`,
+// `updateAgentConfig`, and the available doc/shared-env-set lists) lives in the
+// tool `description` fields, not here, so the model sees each tool's usage
+// rules alongside its definition.
 export const AGENT_CONFIG_CHAT_SYSTEM_PROMPT = `\
 You help a user workshop the definition of a new autonomous agent through
 conversation. The current draft is shown to you as JSON; the user also sees
 it in an editor and may change it by hand between messages.
 
-Detailed documentation about the config fields is available through the
-\`readDocument\` tool — the names of the available documents are listed below.
-Batch every document you need into a single call, and read up on any config
-section you are not fully sure about BEFORE writing it into the draft. Don't
-guess at field semantics that a document can settle.
-
-The available shared env sets are listed below by id. To attach one, add its
-id to the draft's \`sharedEnvSets\` array. If you need to see the env var names
-inside a set (e.g. to avoid collisions with the agent's own \`env\` or to
-confirm a needed var is present), call \`readSharedEnvSet\` with the ids
-first. Don't attach a set blindly when its contents matter.
-
-The draft shown in this conversation may be stale because the user can hand-edit
-the config in their editor between messages. Call \`readAgentConfig\` to fetch
-the latest draft before making any change that depends on the current state of
-fields you haven't just written yourself.
-
-Whenever the draft should change, call the \`updateAgentConfig\` tool with the
-FULL updated definition — keep every field not affected by the change
-unchanged. After a config update, reply with one short sentence noting what
-changed plus a brief question about what to refine next (e.g. the tone, the
-scope, or the tools setup). Ask at most one question at a time, and keep all
-replies concise.`;
+After a config update, reply with one short sentence noting what changed
+plus a brief question about what to refine next (e.g. the tone, the scope,
+or the tools setup). Ask at most one question at a time, and keep all replies
+concise.`;


### PR DESCRIPTION
## Summary

Refactors the agent-config chat use case so tool-specific guidance lives alongside each tool definition instead of in the system prompt, and adds a new `listAgentTypes` tool.

## Changes

- **Move doc list + shared-env-set list into tool descriptions.** The available-documents and available-shared-env-sets blocks are now embedded in the `readDocument` / `readSharedEnvSet` tool `description` fields (each `build*Tool` method is async and fetches its own data), so the model sees each list right at the tool definition. Empty lists emit a `none` sentinel instead of a bare header.
- **Strip tool-usage guidance from the system prompt.** `AGENT_CONFIG_CHAT_SYSTEM_PROMPT` now carries only the conversational intro, the general `never guess at field semantics` behavioral rule, and the reply-style rule. The `readDocument`/`readSharedEnvSet`/`readAgentConfig`/`updateAgentConfig` mechanics (batch calls, stale-draft fetch, full-config updates) live in each tool's `description`.
- **Add `listAgentTypes` server-executed tool.** Captures `agentTypes` once per turn at context-build time and returns `{ agentTypes: [{ key, description? }] }` (empty array when none configured), replacing the agent-types block previously appended to the prompt.
- **Tests repointed** to assert the lists/agent-types now surface via `tools.readDocument.description`, `tools.readSharedEnvSet.description`, and `tools.listAgentTypes.execute`, and that the prompt is just the base system prompt.

## Commits

- `4bda39d` refactor(dashboard): move doc/env-set lists into tool descriptions, add listAgentTypes tool
- `f90945c` refactor(dashboard): move read-before-write rule into system prompt
- `40677d9` docs(hermes-config): make Slack/Teams platform-side setup prescriptive
- `4f1af08` chore: regenerate routeTree.gen.ts

## Verification

- `pnpm --filter @hermeum/dashboard test -- src/server/usecases/chat.test.ts` — 23 passed
- `pnpm --filter @hermeum/dashboard lint` — clean (only preexisting warnings)
- `pnpm --filter @hermeum/dashboard typecheck` — 3 preexisting errors in unrelated files (`server.ts`, `routers/ai-sdk/agent-config.ts`), confirmed present on `main`