### PR TITLE
fix(dashboard): hide Home Assistant, Spotify, Yuanbao, and Computer Use toolsets from UI

### DIFF
--- a/apps/dashboard/src/entities/agent/toolsets.ts
+++ b/apps/dashboard/src/entities/agent/toolsets.ts
@@ -182,12 +182,13 @@ export const TOOLSET_IDS: readonly ToolsetId[] = [
   ToolsetId.Clarify,
   ToolsetId.Delegation,
   ToolsetId.Cronjob,
-  ToolsetId.HomeAssistant,
-  // Spotify, Yuanbao, and Computer Use are fundamentally unavailable in
-  // Hermeum (container runtime cannot host OAuth callbacks or drive a
-  // desktop). Commented out of TOOLSET_IDS to keep them invisible in the UI;
-  // the enum/metadata/availability logic remain so existing config or API
-  // payloads referencing these IDs still resolve cleanly.
+  // Home Assistant, Spotify, Yuanbao, and Computer Use are fundamentally
+  // unavailable in Hermeum (container runtime cannot reach a LAN smart-home
+  // hub, host OAuth callbacks, or drive a local desktop). Commented out of
+  // TOOLSET_IDS to keep them invisible in the UI; the enum/metadata/
+  // availability logic remain so existing config or API payloads referencing
+  // these IDs still resolve cleanly.
+  // ToolsetId.HomeAssistant,
   // ToolsetId.Spotify,
   ToolsetId.Discord,
   ToolsetId.DiscordAdmin,

--- a/apps/dashboard/src/entities/agent/toolsets.ts
+++ b/apps/dashboard/src/entities/agent/toolsets.ts
@@ -183,11 +183,16 @@ export const TOOLSET_IDS: readonly ToolsetId[] = [
   ToolsetId.Delegation,
   ToolsetId.Cronjob,
   ToolsetId.HomeAssistant,
-  ToolsetId.Spotify,
+  // Spotify, Yuanbao, and Computer Use are fundamentally unavailable in
+  // Hermeum (container runtime cannot host OAuth callbacks or drive a
+  // desktop). Commented out of TOOLSET_IDS to keep them invisible in the UI;
+  // the enum/metadata/availability logic remain so existing config or API
+  // payloads referencing these IDs still resolve cleanly.
+  // ToolsetId.Spotify,
   ToolsetId.Discord,
   ToolsetId.DiscordAdmin,
-  ToolsetId.Yuanbao,
-  ToolsetId.ComputerUse,
+  // ToolsetId.Yuanbao,
+  // ToolsetId.ComputerUse,
 ];
 
 export function deriveToolsetAvailability(id: ToolsetId, agent: Agent): ToolsetAvailability {


### PR DESCRIPTION
## Why

These four Hermes toolsets are fundamentally unavailable in Hermeum because the Hermes agent runtime is containerized:

- **Home Assistant** — requires reaching a LAN smart-home hub, which a container cannot access.
- **Spotify** — requires an OAuth callback flow the container runtime cannot host.
- **Computer Use** — requires local desktop access (cua-driver on macOS/Windows/Linux) that a container does not have.
- **Yuanbao** — only runs on the Yuanbao messaging platform, which Hermeum does not host.

## What

Comment out the four entries in `TOOLSET_IDS` (the ordered list the agent detail page maps over at `routes/agents/$id/index.tsx:132`), so they no longer render as badges in the Toolsets section.

The `ToolsetId` enum members, `TOOLSET_META` entries, and `deriveToolsetAvailability` switch cases are intentionally left in place so any existing config or API payloads that reference these IDs still resolve cleanly and the availability helper still reports `unavailable` with a reason if called directly.

## Verification

- `pnpm --filter @hermeum/dashboard test -- src/entities/agent.test.ts` → 173/173 pass
- `pnpm --filter @hermeum/dashboard lint` → clean (only pre-existing warnings)
- Typecheck errors present are pre-existing in `src/server/server.ts` / `ai-sdk/agent-config.ts` and unrelated to this change.