### PR TITLE
feat(dashboard): add image-gen, video-gen, and Discord hermes-config schemas + docs

### DIFF
--- a/apps/dashboard/docs/hermes-config/discord.md
+++ b/apps/dashboard/docs/hermes-config/discord.md
@@ -1,0 +1,91 @@
+---
+name: discord
+category: platforms
+description: Discord platform configuration (`discord`) — mention gating, auto-threading, channel allow/ignore lists, per-channel prompts, and DISCORD_BOT_TOKEN env var.
+---
+
+# Discord configuration (`config.discord`)
+
+Configures the Discord gateway adapter, which connects to Discord via
+the Gateway WebSocket and relays messages between server channels/DMs
+and the Hermes agent. Requires the `DISCORD_BOT_TOKEN` env var.
+
+**You must configure Discord on the Discord side before this gateway
+will work** — application creation, bot token, privileged gateway
+intents (Server Members + Message Content), and server invite. Complete
+that setup by following the official Hermes Agent guide at
+https://hermes-agent.nousresearch.com/docs/user-guide/messaging/discord.
+
+Most `discord.*` fields have a `DISCORD_*` env var mirror (e.g.
+`discord.require_mention` ↔ `DISCORD_REQUIRE_MENTION`); env vars
+override `config.yaml` when both are set.
+
+## Fields
+
+- `require_mention` — require `@mention` in server channels (default
+  `true`). DMs always respond regardless.
+- `thread_require_mention` — require `@mention` in threads too, for
+  multi-bot setups where every bot would otherwise fire on every
+  message (default `false`).
+- `auto_thread` — auto-create a thread per `@mention` in text channels
+  (default `true`). Channels in `free_response_channels` or
+  `no_thread_channels` bypass threading.
+- `reactions` — add emoji reactions during processing (👀 on start, ✅
+  on success, ❌ on error). Default `true`.
+- `free_response_channels` — channel IDs where the bot responds without
+  `@mention` (e.g. a dedicated bot channel). Skips auto-threading.
+- `ignored_channels` — channel IDs where the bot **never** responds,
+  even when `@mentioned`. Highest priority.
+- `no_thread_channels` — channel IDs where the bot replies inline
+  instead of auto-creating a thread. Only relevant when `auto_thread`
+  is `true`.
+- `channel_prompts` — per-channel ephemeral system prompts, keyed by
+  channel ID. Injected on every turn, not persisted to transcript.
+  Threads inherit the parent channel's prompt.
+- `allow_mentions` — what the bot is allowed to ping. Sub-fields:
+  `everyone` (default `false`), `roles` (default `false`), `users`
+  (default `true`), `replied_user` (default `true`).
+
+Additional knobs (`history_backfill`, `history_backfill_limit`,
+`voice_fx`, `missed_message_backfill`, etc.) pass through unchanged
+via `looseObject`; see the official guide for their semantics.
+
+## Environment variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `DISCORD_BOT_TOKEN` | Bot token from the Discord Developer Portal. Required. | _(required)_ |
+| `DISCORD_ALLOWED_USERS` | Comma-separated Discord user IDs allowed to interact. Without this **or** `DISCORD_ALLOWED_ROLES`, the gateway denies all users unless `DISCORD_ALLOW_ALL_USERS=true`. | _(conditional)_ |
+| `DISCORD_ALLOWED_ROLES` | Comma-separated Discord role IDs; members with any listed role are authorized (OR with `DISCORD_ALLOWED_USERS`). | _(none)_ |
+| `DISCORD_ALLOW_ALL_USERS` | Allow any Discord user to trigger the bot (trusted/private guilds only). | `false` |
+| `DISCORD_HOME_CHANNEL` | Channel ID for proactive messages (cron output, reminders). | _(none)_ |
+| `DISCORD_HOME_CHANNEL_NAME` | Display name for the home channel. | _(none)_ |
+
+`DISCORD_BOT_TOKEN` is a credential — set it via the `env:` block with
+`sensitive: true`, not in `config.yaml`.
+
+## Example
+
+```yaml
+config:
+  discord:
+    require_mention: true
+    auto_thread: true
+    free_response_channels:
+      - "123456789012345678"
+    ignored_channels:
+      - "987654321098765432"
+    channel_prompts:
+      "123456789012345678": |
+        This is a research channel. Prefer citations and concise synthesis.
+    allow_mentions:
+      everyone: false
+      roles: false
+      users: true
+env:
+  - name: DISCORD_BOT_TOKEN
+    value: your-bot-token-here
+    sensitive: true
+  - name: DISCORD_ALLOWED_USERS
+    value: "284102345871466496"
+```

--- a/apps/dashboard/docs/hermes-config/image-gen.md
+++ b/apps/dashboard/docs/hermes-config/image-gen.md
@@ -1,0 +1,50 @@
+---
+name: image-gen
+category: tools
+description: Image generation configuration (`config.image_gen`) — FAL.ai models, max parallel requests, and FAL_KEY env var.
+---
+
+# Image generation configuration (`config.image_gen`)
+
+Configures the `image_generate` tool, which lets the agent generate images
+from text prompts (and edit existing images on edit-capable models). It is
+backed by FAL.ai.
+
+The toolset auto-enables when `FAL_KEY` is set. Without it, the
+`image_generate` tool does not register.
+
+## Fields
+
+- `model` — FAL.ai model id. Default
+  `fal-ai/flux-2/klein/9b`. Eleven models are supported out of the box;
+  `fal-ai/flux-2-pro` (studio photorealism),
+  `fal-ai/z-image/turbo` (bilingual EN/CN),
+  `fal-ai/nano-banana-pro` (Gemini 3 Pro, reasoning depth),
+  `fal-ai/gpt-image-2` (SOTA text rendering + CJK),
+  `fal-ai/ideogram/v3` (best typography),
+  `fal-ai/recraft/v4/pro/text-to-image` (design / brand systems),
+  `fal-ai/qwen-image` (LLM-based, complex text),
+  `fal-ai/krea/v2/{medium,large}/text-to-image` (illustration / photorealism).
+- `max_parallel_requests` — concurrent images per tool-call batch
+  (default `4`). Hermes clamps it to at least one and to the global
+  tool-worker limit, so image providers receive bounded parallel requests
+  without allowing an image batch to bypass the agent's concurrency cap.
+
+## Environment variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `FAL_KEY` | FAL.ai API key. Required for image generation. Get one at [fal.ai](https://fal.ai/). | _(required)_ |
+
+## Example
+
+```yaml
+config:
+  image_gen:
+    model: fal-ai/flux-2/klein/9b
+    max_parallel_requests: 4
+env:
+  - name: FAL_KEY
+    value: fal-your-key-here
+    sensitive: true
+```

--- a/apps/dashboard/docs/hermes-config/video-gen.md
+++ b/apps/dashboard/docs/hermes-config/video-gen.md
@@ -1,0 +1,79 @@
+---
+name: video-gen
+category: tools
+description: Video generation configuration (`config.video_gen`) — provider plugins (xAI, FAL, DeepInfra), model families, and FAL_KEY / XAI_API_KEY env vars.
+---
+
+# Video generation configuration (`config.video_gen`)
+
+Configures the `video_generate` tool, which lets the agent generate video
+from a text prompt (text-to-video) or from a prompt plus a source image
+(image-to-video). Every backend is a provider plugin; the active provider
+is picked by `video_gen.provider` in `config.yaml`.
+
+This dashboard documents the **xAI** and **FAL** providers. DeepInfra
+and user-installed plugins are also supported and pass through unchanged;
+only xAI and FAL are covered here.
+
+The toolset auto-enables when **either** `FAL_KEY` **or** `XAI_API_KEY`
+is set. Without one of them, the `video_generate` tool does not register.
+
+## Unified surface (one tool, two modalities)
+
+The `video_generate` tool exposes two modalities through one parameter:
+
+- **Text-to-video** — call with `prompt` only. The provider routes to
+  its text-to-video endpoint.
+- **Image-to-video** — call with `prompt` + `image_url`. The provider
+  routes to its image-to-video endpoint.
+
+The provider picks the right endpoint internally based on whether
+`image_url` was passed; the agent never thinks about endpoints.
+
+## Fields
+
+- `provider` — active video-gen provider plugin id. Documented here:
+  `xai`, `fal`. Other bundled providers (e.g. `deepinfra`) and
+  user-installed plugins are also accepted. Default `fal` when
+  `FAL_KEY` is set, otherwise `xai` when `XAI_API_KEY` is set.
+  Selecting a provider without its required env var leaves the toolset
+  unavailable.
+- `model` — model **family** id (e.g. `veo3.1`, `kling-o3`,
+  `grok-imagine-video`). A family groups a text-to-video and an
+  image-to-video endpoint behind one user-facing name; the provider's
+  `generate()` routes within the family. Omit to use the provider's
+  `default_model()`.
+
+## Environment variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `FAL_KEY` | FAL.ai API key. Enables the `fal` provider. Get one at [fal.ai](https://fal.ai/). | _(required for `provider: fal`)_ |
+| `XAI_API_KEY` | Paid xAI (Grok) API key. Enables the `xai` provider (Grok Imagine video). | _(required for `provider: xai`)_ |
+
+## Example
+
+### FAL (Veo 3.1)
+
+```yaml
+config:
+  video_gen:
+    provider: fal
+    model: fal-ai/veo3.1
+env:
+  - name: FAL_KEY
+    value: fal-your-key-here
+    sensitive: true
+```
+
+### xAI (Grok Imagine)
+
+```yaml
+config:
+  video_gen:
+    provider: xai
+env:
+  - name: XAI_API_KEY
+    value: xai-your-key-here
+    sensitive: true
+```

--- a/apps/dashboard/src/entities/agent.test.ts
+++ b/apps/dashboard/src/entities/agent.test.ts
@@ -1123,6 +1123,62 @@ describe("derivePlatformAvailability", () => {
     });
   });
 
+  describe("discord", () => {
+    const discordEnv = [
+      { name: "DISCORD_BOT_TOKEN", value: "bot-token", sensitive: true },
+    ];
+
+    it("is unavailable when DISCORD_BOT_TOKEN is missing", () => {
+      const result = derivePlatformAvailability(PlatformId.Discord, makeAgent());
+      expect(result.status).toBe("unavailable");
+      expect(result.reason).toContain("DISCORD_BOT_TOKEN");
+    });
+
+    it("is available with no home when DISCORD_BOT_TOKEN is set", () => {
+      const result = derivePlatformAvailability(PlatformId.Discord, makeAgent({ env: discordEnv }));
+      expect(result).toEqual({ status: "available" });
+    });
+
+    it("never exposes endpoints — Discord uses the Gateway WebSocket", () => {
+      const result = derivePlatformAvailability(
+        PlatformId.Discord,
+        makeAgent({ endpoint: "https://a1.example.com", env: discordEnv })
+      );
+      expect(result.endpoints).toBeUndefined();
+    });
+
+    it("reports DISCORD_HOME_CHANNEL as home when set", () => {
+      const result = derivePlatformAvailability(
+        PlatformId.Discord,
+        makeAgent({ env: [...discordEnv, { name: "DISCORD_HOME_CHANNEL", value: "1234567890" }] })
+      );
+      expect(result).toEqual({ status: "available", home: "1234567890" });
+    });
+
+    it("appends DISCORD_HOME_CHANNEL_NAME when set", () => {
+      const result = derivePlatformAvailability(
+        PlatformId.Discord,
+        makeAgent({
+          env: [
+            ...discordEnv,
+            { name: "DISCORD_HOME_CHANNEL", value: "1234567890" },
+            { name: "DISCORD_HOME_CHANNEL_NAME", value: "bot-updates" },
+          ],
+        })
+      );
+      expect(result).toEqual({ status: "available", home: "1234567890 (bot-updates)" });
+    });
+
+    it("is unavailable when config.discord is present but no env credentials", () => {
+      // config.discord holds behavior knobs only; credentials come from env.
+      const result = derivePlatformAvailability(
+        PlatformId.Discord,
+        makeAgent({ config: { discord: { require_mention: true } } })
+      );
+      expect(result.status).toBe("unavailable");
+    });
+  });
+
   describe("teams", () => {
     const teamsCredsEnv = [
       { name: "TEAMS_CLIENT_ID", value: "cid" },

--- a/apps/dashboard/src/entities/agent/platform.ts
+++ b/apps/dashboard/src/entities/agent/platform.ts
@@ -88,6 +88,7 @@ export enum PlatformId {
   ApiServer = "api-server",
   Webhook = "webhook",
   Slack = "slack",
+  Discord = "discord",
   Teams = "teams",
 }
 
@@ -145,6 +146,10 @@ const PLATFORM_META: Record<PlatformId, PlatformMeta> = {
     label: "Slack",
     description: "Slack bot relayed through the gateway (Socket Mode).",
   },
+  [PlatformId.Discord]: {
+    label: "Discord",
+    description: "Discord bot relayed through the gateway (WebSocket).",
+  },
   [PlatformId.Teams]: {
     label: "Teams",
     description: "Microsoft Teams bot relayed through the gateway (HTTPS webhook).",
@@ -164,6 +169,7 @@ export const PLATFORM_IDS: readonly PlatformId[] = [
   PlatformId.ApiServer,
   PlatformId.Webhook,
   PlatformId.Slack,
+  PlatformId.Discord,
   PlatformId.Teams,
 ];
 
@@ -211,6 +217,20 @@ export function derivePlatformAvailability(id: PlatformId, agent: Agent): Platfo
       }
       const home = env.find((v) => v.name === "SLACK_HOME_CHANNEL")?.value;
       const homeName = env.find((v) => v.name === "SLACK_HOME_CHANNEL_NAME")?.value;
+      if (home) {
+        return { status: "available", home: homeName ? `${home} (${homeName})` : home };
+      }
+      return { status: "available" };
+    }
+    case PlatformId.Discord: {
+      const hasToken = env.some(
+        (v) => v.name === "DISCORD_BOT_TOKEN" && v.value.trim() !== "",
+      );
+      if (!hasToken) {
+        return { status: "unavailable", reason: "Missing env var: DISCORD_BOT_TOKEN." };
+      }
+      const home = env.find((v) => v.name === "DISCORD_HOME_CHANNEL")?.value;
+      const homeName = env.find((v) => v.name === "DISCORD_HOME_CHANNEL_NAME")?.value;
       if (home) {
         return { status: "available", home: homeName ? `${home} (${homeName})` : home };
       }

--- a/apps/dashboard/src/entities/hermes-config/discord.ts
+++ b/apps/dashboard/src/entities/hermes-config/discord.ts
@@ -1,0 +1,57 @@
+import { z } from "zod";
+
+// https://hermes-agent.nousresearch.com/docs/user-guide/messaging/discord
+// Full field semantics: docs/hermes-config/discord.md
+// Only the essential fields are validated here; the rest pass through via
+// looseObject so users can configure whatever the Hermes agent supports.
+export const DiscordSchema = z
+  .looseObject({
+    require_mention: z
+      .boolean()
+      .optional()
+      .describe("Require @mention in server channels (default true). DMs always respond."),
+    thread_require_mention: z
+      .boolean()
+      .optional()
+      .describe("Require @mention in threads too — for multi-bot setups (default false)."),
+    auto_thread: z
+      .boolean()
+      .optional()
+      .describe("Auto-create a thread per @mention in text channels (default true)."),
+    reactions: z
+      .boolean()
+      .optional()
+      .describe("Add emoji reactions during processing (default true)."),
+    free_response_channels: z
+      .array(z.string())
+      .optional()
+      .describe("Channel IDs where the bot responds without @mention."),
+    ignored_channels: z
+      .array(z.string())
+      .optional()
+      .describe("Channel IDs where the bot never responds, even when @mentioned."),
+    no_thread_channels: z
+      .array(z.string())
+      .optional()
+      .describe("Channel IDs where the bot replies inline instead of auto-threading."),
+    channel_prompts: z
+      .record(z.string(), z.string())
+      .optional()
+      .describe("Per-channel ephemeral system prompts, keyed by channel ID."),
+    allow_mentions: z
+      .looseObject({
+        everyone: z.boolean().optional().describe("Allow @everyone / @here pings (default false)."),
+        roles: z.boolean().optional().describe("Allow @role pings (default false)."),
+        users: z.boolean().optional().describe("Allow @user pings (default true)."),
+        replied_user: z
+          .boolean()
+          .optional()
+          .describe("Reply-reference pings the original author (default true)."),
+      })
+      .optional()
+      .describe("What the bot is allowed to ping."),
+  })
+  .optional()
+  .describe("Discord platform configuration. Requires DISCORD_BOT_TOKEN env var.");
+
+export type Discord = z.infer<typeof DiscordSchema>;

--- a/apps/dashboard/src/entities/hermes-config/index.ts
+++ b/apps/dashboard/src/entities/hermes-config/index.ts
@@ -31,6 +31,7 @@ export {
 export { BrowserCloudProviderSchema, BrowserSchema, type BrowserCloudProvider, type Browser } from "./browser";
 export { XSearchSchema, type XSearch } from "./x-search";
 export { ImageGenSchema, type ImageGen } from "./image-gen";
+export { VideoGenSchema, type VideoGen } from "./video-gen";
 
 import { z } from "zod";
 import { ModelSchema } from "./model";
@@ -41,6 +42,7 @@ import { WebSchema } from "./web";
 import { BrowserSchema } from "./browser";
 import { XSearchSchema } from "./x-search";
 import { ImageGenSchema } from "./image-gen";
+import { VideoGenSchema } from "./video-gen";
 
 // Aggregator for the per-platform sub-schemas under config.platforms.*.
 // Each platform owns its own schema file (slack.ts, webhook.ts, teams.ts,
@@ -65,6 +67,7 @@ export const ConfigSchema = z
     browser: BrowserSchema,
     x_search: XSearchSchema,
     image_gen: ImageGenSchema,
+    video_gen: VideoGenSchema,
   })
   .optional()
   .describe(

--- a/apps/dashboard/src/entities/hermes-config/index.ts
+++ b/apps/dashboard/src/entities/hermes-config/index.ts
@@ -20,6 +20,7 @@ export {
 } from "./webhook";
 export { TeamsSchema, type Teams } from "./teams";
 export { SlackSchema, ChannelSkillBindingSchema, type Slack, type ChannelSkillBinding } from "./slack";
+export { DiscordSchema, type Discord } from "./discord";
 export {
   WebSearchBackendSchema,
   WebExtractBackendSchema,
@@ -38,6 +39,7 @@ import { ModelSchema } from "./model";
 import { WebhookSchema } from "./webhook";
 import { TeamsSchema } from "./teams";
 import { SlackSchema } from "./slack";
+import { DiscordSchema } from "./discord";
 import { WebSchema } from "./web";
 import { BrowserSchema } from "./browser";
 import { XSearchSchema } from "./x-search";
@@ -63,6 +65,7 @@ export const ConfigSchema = z
     model: ModelSchema,
     platforms: PlatformsSchema,
     slack: SlackSchema,
+    discord: DiscordSchema,
     web: WebSchema,
     browser: BrowserSchema,
     x_search: XSearchSchema,

--- a/apps/dashboard/src/entities/hermes-config/slack.ts
+++ b/apps/dashboard/src/entities/hermes-config/slack.ts
@@ -26,11 +26,10 @@ export const SlackSchema = z
       .array(z.string())
       .optional()
       .describe("Slack channel IDs the bot may respond in."),
-    unauthorized_dm_behavior: z
-      .literal("ignore")
-      .default("ignore")
+    allow_bots: z
+      .boolean()
       .optional()
-      .describe("Behavior for unauthorized DMs."),
+      .describe("Allow other bots to trigger this bot (default false)."),
     channel_prompts: z
       .record(z.string(), z.string())
       .optional()
@@ -39,6 +38,27 @@ export const SlackSchema = z
       .array(ChannelSkillBindingSchema)
       .optional()
       .describe("Skills to auto-load at session start per channel/DM."),
+    free_response_channels: z
+      .array(z.string())
+      .optional()
+      .describe("Channel IDs where the bot responds without @mention."),
+    reactions: z
+      .boolean()
+      .optional()
+      .describe("Emit reactions on receipt/completion (default true)."),
+    require_mention: z
+      .boolean()
+      .optional()
+      .describe("Require @mention in channels (default true). DMs always respond."),
+    strict_mention: z
+      .boolean()
+      .optional()
+      .describe("Only reply to explicit @mentions; disable auto-engage (default false)."),
+    unauthorized_dm_behavior: z
+      .literal("ignore")
+      .default("ignore")
+      .optional()
+      .describe("Behavior for unauthorized DMs."),
   })
   .optional()
   .describe("Slack platform configuration. Requires SLACK_* env vars.");

--- a/apps/dashboard/src/entities/hermes-config/video-gen.ts
+++ b/apps/dashboard/src/entities/hermes-config/video-gen.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+
+// https://hermes-agent.nousresearch.com/docs/developer-guide/video-gen-provider-plugin
+// Full field semantics: docs/hermes-config/video-gen.md
+// Only the essential fields are validated here; the rest pass through via
+// looseObject so users can configure whatever the Hermes agent supports.
+export const VideoGenSchema = z
+  .looseObject({
+    provider: z
+      .string()
+      .optional()
+      .describe("Active video-gen provider plugin id (e.g. fal, xai, deepinfra). Default fal."),
+    model: z
+      .string()
+      .optional()
+      .describe("Model family id (e.g. fal-ai/veo3.1, kling-o3). Falls back to the provider default."),
+  })
+  .optional()
+  .describe("Video generation configuration. Requires FAL_KEY or XAI_API_KEY.");
+
+export type VideoGen = z.infer<typeof VideoGenSchema>;


### PR DESCRIPTION
## Summary

Adds well-known Hermes configuration schemas and their accompanying docs for three toolsets/platforms that were previously missing typed config, plus expands the Slack schema to match.

## Changes

### Image generation
- **Doc:** `docs/hermes-config/image-gen.md` — FAL.ai models, `max_parallel_requests`, and the `FAL_KEY` env var. (Schema already existed in `image-gen.ts` with the 3 fields the docs define.)
- Nous Subscription / `use_gateway` references omitted — container runtime does not support OAuth.

### Video generation
- **Schema:** `entities/hermes-config/video-gen.ts` — `provider` (string: `fal`, `xai`, `deepinfra`, …) and `model` (family id). Provider is a free string so other bundled providers and user plugins pass validation; only xAI and FAL are documented.
- **Doc:** `docs/hermes-config/video-gen.md` — provider plugins, model families, env vars (`FAL_KEY` / `XAI_API_KEY`), text-to-video vs image-to-video routing.

### Discord (new message platform)
- **Schema:** `entities/hermes-config/discord.ts` — 9 essential fields: `require_mention`, `thread_require_mention`, `auto_thread`, `reactions`, `free_response_channels`, `ignored_channels`, `no_thread_channels`, `channel_prompts`, `allow_mentions`. `history_backfill`, `history_backfill_limit`, `voice_fx` and other niche knobs pass through via `looseObject`.
- **Platform:** `entities/agent/platform.ts` — added `PlatformId.Discord` with metadata, ordered-list entry, and a `derivePlatformAvailability` case gating on `DISCORD_BOT_TOKEN` and surfacing `DISCORD_HOME_CHANNEL` as `home`. Discord uses the Gateway WebSocket, so like Slack it has no ingress subpath.
- **Doc:** `docs/hermes-config/discord.md` — lean style (~95 lines): intro + setup-guide link, fields, credential env vars, one YAML example.
- **Tests:** 6 new `derivePlatformAvailability` cases in `agent.test.ts`.

### Slack schema expansion
- Added 5 behavioral knobs to `SlackSchema` to parallel Discord coverage: `require_mention`, `strict_mention`, `allow_bots`, `free_response_channels`, `reactions`. The remaining documented knobs (`mention_patterns`, `reply_prefix`, `reply_to_mode`) pass through via `looseObject`.

## Test plan
- [x] `pnpm --filter @hermeum/dashboard typecheck` — only pre-existing errors in `server.ts` / `agent-config.ts` (unrelated, present on `main`).
- [x] `pnpm --filter @hermeum/dashboard lint` — 0 errors (2 pre-existing warnings in unrelated files).
- [x] `pnpm --filter @hermeum/dashboard test` — 305 tests pass (6 new Discord platform-availability tests).