### PR TITLE
feat(dashboard): support mobile view

### DIFF
--- a/apps/dashboard/src/client/ui/components/app-sidebar.tsx
+++ b/apps/dashboard/src/client/ui/components/app-sidebar.tsx
@@ -11,6 +11,7 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
+  useSidebar,
 } from "@hermeum/components/ui/sidebar";
 import {
   DropdownMenu,
@@ -34,12 +35,13 @@ const resourceNavItems = [
 
 export function AppSidebar({ session }: { session: Session | null | undefined }) {
   const pathname = useRouterState({ select: (s) => s.location.pathname });
+  const { setOpenMobile } = useSidebar();
   const email = session?.user?.email ?? "";
   const name = session?.user?.name ?? email;
   const initial = email.charAt(0).toUpperCase();
 
   return (
-    <Sidebar collapsible="none">
+    <Sidebar>
       <SidebarHeader>
         <div className="flex items-center gap-2.5 px-2 py-1">
           <span className="font-semibold text-sm">Hermeum</span>
@@ -52,7 +54,11 @@ export function AppSidebar({ session }: { session: Session | null | undefined })
           <SidebarMenu>
             {agentNavItems.map(({ to, label, icon: Icon }) => (
               <SidebarMenuItem key={to}>
-                <SidebarMenuButton render={<Link to={to} />} isActive={pathname.startsWith(to)}>
+                <SidebarMenuButton
+                  render={<Link to={to} />}
+                  isActive={pathname.startsWith(to)}
+                  onClick={() => setOpenMobile(false)}
+                >
                   <Icon />
                   {label}
                 </SidebarMenuButton>
@@ -68,6 +74,7 @@ export function AppSidebar({ session }: { session: Session | null | undefined })
                 <SidebarMenuButton
                   render={<a href={to} target="_blank" rel="noopener noreferrer" />}
                   isActive={pathname.startsWith(to)}
+                  onClick={() => setOpenMobile(false)}
                 >
                   <Icon />
                   {label}

--- a/apps/dashboard/src/client/ui/routes/__root.tsx
+++ b/apps/dashboard/src/client/ui/routes/__root.tsx
@@ -11,6 +11,7 @@ import { AppSidebar } from "@/client/ui/components/app-sidebar";
 import {
   SidebarInset,
   SidebarProvider,
+  SidebarTrigger,
 } from "@hermeum/components/ui/sidebar";
 
 interface RouterContext {
@@ -43,6 +44,9 @@ function RootLayout() {
     <SidebarProvider className="h-svh">
       <AppSidebar session={session} />
       <SidebarInset className="min-h-0 overflow-y-auto">
+        <header className="flex h-14 items-center px-4 md:hidden">
+          <SidebarTrigger />
+        </header>
         <Outlet />
       </SidebarInset>
       <Toaster />

--- a/apps/dashboard/src/client/ui/routes/agents/$id/index.tsx
+++ b/apps/dashboard/src/client/ui/routes/agents/$id/index.tsx
@@ -276,7 +276,7 @@ function AgentDetailPage() {
   return (
     <div className="flex flex-col gap-6 p-6">
       {/* Header */}
-      <div className="flex items-start justify-between gap-4">
+      <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
         <div className="flex flex-col gap-0.5">
           <div className="flex items-center gap-3">
             <h1 className="text-2xl font-bold">{agent.name ?? agent.id}</h1>

--- a/apps/dashboard/src/client/ui/routes/agents/index.tsx
+++ b/apps/dashboard/src/client/ui/routes/agents/index.tsx
@@ -97,7 +97,7 @@ function DashboardPage() {
 
   return (
     <div className="space-y-6 p-6">
-      <div className="flex items-start justify-between">
+      <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
         <div>
           <h1 className="text-2xl font-semibold tracking-tight">Agents</h1>
           <p className="mt-1 text-sm text-muted-foreground">Create and manage autonomous agents.</p>

--- a/apps/dashboard/src/client/ui/routes/shared-env-sets/$id.tsx
+++ b/apps/dashboard/src/client/ui/routes/shared-env-sets/$id.tsx
@@ -93,7 +93,7 @@ function SharedEnvSetDetailPage() {
 
   return (
     <div className="flex flex-col gap-6 p-6">
-      <div className="flex items-start justify-between gap-4">
+      <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
         <div className="flex flex-col gap-1">
           <div className="flex items-center gap-3">
             <h1 className="text-2xl font-bold">{envSet.name}</h1>

--- a/apps/dashboard/src/client/ui/routes/shared-env-sets/index.tsx
+++ b/apps/dashboard/src/client/ui/routes/shared-env-sets/index.tsx
@@ -102,7 +102,7 @@ function SharedEnvSetsPage() {
 
   return (
     <div className="space-y-6 p-6">
-      <div className="flex items-start justify-between">
+      <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
         <div>
           <h1 className="text-2xl font-semibold tracking-tight">Shared Env Sets</h1>
           <p className="mt-1 text-sm text-muted-foreground">


### PR DESCRIPTION
- Enable collapsible mobile sidebar
- Stack page headers vertically on mobile to prevent action buttons from squeezing titles/descriptions

Includes commits:
- 1e88c00 feat(dashboard): enable collapsible mobile sidebar
- 7c174fe fix(dashboard): stack page headers vertically on mobile