### PR TITLE
fix(dashboard): mobile agent create/edit layout and thinking marker alignment

### DIFF
--- a/apps/dashboard/src/client/ui/components/agent-config-chat.tsx
+++ b/apps/dashboard/src/client/ui/components/agent-config-chat.tsx
@@ -6,6 +6,7 @@ import { ArrowUp, Check, LoaderCircle } from "lucide-react";
 
 import { Button } from "@hermeum/components/ui/button";
 import { Bubble, BubbleContent } from "@hermeum/components/ui/bubble";
+
 import { Marker, MarkerContent, MarkerIcon } from "@hermeum/components/ui/marker";
 import { Message, MessageContent } from "@hermeum/components/ui/message";
 import {
@@ -297,14 +298,18 @@ export function AgentConfigChat({
                   <MessageScrollerItem messageId="thinking">
                     <Message align="start">
                       <MessageContent>
-                        <Marker className="normal-case tracking-normal font-normal">
-                          <MarkerIcon>
-                            <LoaderCircle className="animate-spin" />
-                          </MarkerIcon>
-                          <MarkerContent className="normal-case tracking-normal">
-                            Thinking…
-                          </MarkerContent>
-                        </Marker>
+                        <Bubble variant="ghost" align="start">
+                          <BubbleContent>
+                            <Marker className="normal-case tracking-normal font-normal">
+                              <MarkerIcon>
+                                <LoaderCircle className="animate-spin" />
+                              </MarkerIcon>
+                              <MarkerContent className="normal-case tracking-normal">
+                                Thinking…
+                              </MarkerContent>
+                            </Marker>
+                          </BubbleContent>
+                        </Bubble>
                       </MessageContent>
                     </Message>
                   </MessageScrollerItem>

--- a/apps/dashboard/src/client/ui/routes/agents/$id/edit.tsx
+++ b/apps/dashboard/src/client/ui/routes/agents/$id/edit.tsx
@@ -16,6 +16,7 @@ import { AgentInputObjectSchema, AgentInputSchema } from "@/entities";
 import type { AgentInput } from "@/entities";
 import { AgentConfigChat } from "@/client/ui/components/agent-config-chat";
 import { CodeEditor } from "@/client/ui/components/code-editor";
+import { AgentEditorMobileTabs } from "../-components/agent-editor-mobile-tabs";
 
 const YAML_OPTIONS = { blockQuote: "literal", lineWidth: 0 } as const;
 
@@ -158,35 +159,32 @@ function EditAgentPage() {
         </h1>
       </div>
 
-      {/* Mobile: static stacked layout (config on top, chat at bottom) */}
-      <div className="flex min-h-0 flex-1 flex-col gap-6 lg:hidden">
-        <div className="flex min-h-0 flex-1 flex-col">{configPane}</div>
-        <div className="flex min-h-0 flex-1 flex-col">
-          <AgentConfigChat {...editChatProps} />
-        </div>
-      </div>
+      {/* Mobile: tabbed full-height layout */}
+      <AgentEditorMobileTabs
+        chat={<AgentConfigChat {...editChatProps} />}
+        config={configPane}
+      />
 
       {/* Desktop: resizable side-by-side layout */}
-      <ResizablePanelGroup
-        orientation="horizontal"
-        className="hidden min-h-0 flex-1 lg:flex"
-      >
-        {/* Chat pane */}
-        <ResizablePanel defaultSize="50%" minSize="25%" className="min-h-0">
-          <div className="flex h-full min-h-0 flex-col pr-3">
-            <AgentConfigChat {...editChatProps} />
-          </div>
-        </ResizablePanel>
-        <ResizableHandle
-          withHandle
-          className="bg-transparent [&>div]:opacity-0 [&>div]:transition-opacity hover:[&>div]:opacity-100"
-        />
+      <div className="hidden min-h-0 flex-1 flex-col lg:flex">
+        <ResizablePanelGroup orientation="horizontal" className="h-full min-h-0 flex-1">
+          {/* Chat pane */}
+          <ResizablePanel defaultSize="50%" minSize="25%" className="min-h-0">
+            <div className="flex h-full min-h-0 flex-col pr-3">
+              <AgentConfigChat {...editChatProps} />
+            </div>
+          </ResizablePanel>
+          <ResizableHandle
+            withHandle
+            className="bg-transparent [&>div]:opacity-0 [&>div]:transition-opacity hover:[&>div]:opacity-100"
+          />
 
-        {/* Config pane */}
-        <ResizablePanel defaultSize="50%" minSize="25%" className="min-h-0">
-          <div className="flex h-full min-h-0 flex-col pl-3">{configPane}</div>
-        </ResizablePanel>
-      </ResizablePanelGroup>
+          {/* Config pane */}
+          <ResizablePanel defaultSize="50%" minSize="25%" className="min-h-0">
+            <div className="flex h-full min-h-0 flex-col pl-3">{configPane}</div>
+          </ResizablePanel>
+        </ResizablePanelGroup>
+      </div>
     </div>
   );
 }

--- a/apps/dashboard/src/client/ui/routes/agents/-components/agent-editor-mobile-tabs.tsx
+++ b/apps/dashboard/src/client/ui/routes/agents/-components/agent-editor-mobile-tabs.tsx
@@ -1,0 +1,33 @@
+import { ReactNode, useState } from "react";
+import {
+  Tabs,
+  TabsList,
+  TabsTrigger,
+} from "@hermeum/components/ui/tabs";
+
+interface AgentEditorMobileTabsProps {
+  chat: ReactNode;
+  config: ReactNode;
+}
+
+// Mobile-only layout: the editor and chat each get a full tab so they can
+// use the whole viewport instead of being squeezed into a 50/50 stack.
+export function AgentEditorMobileTabs({ chat, config }: AgentEditorMobileTabsProps) {
+  const [tab, setTab] = useState<"chat" | "config">("config");
+
+  return (
+    <Tabs
+      value={tab}
+      onValueChange={(v) => setTab(v as "chat" | "config")}
+      className="flex min-h-0 flex-1 flex-col lg:hidden"
+    >
+      <TabsList className="shrink-0">
+        <TabsTrigger value="config">Config</TabsTrigger>
+        <TabsTrigger value="chat">Chat</TabsTrigger>
+      </TabsList>
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        {tab === "chat" ? chat : config}
+      </div>
+    </Tabs>
+  );
+}

--- a/apps/dashboard/src/client/ui/routes/agents/-components/agent-editor-mobile-tabs.tsx
+++ b/apps/dashboard/src/client/ui/routes/agents/-components/agent-editor-mobile-tabs.tsx
@@ -25,8 +25,9 @@ export function AgentEditorMobileTabs({ chat, config }: AgentEditorMobileTabsPro
         <TabsTrigger value="config">Config</TabsTrigger>
         <TabsTrigger value="chat">Chat</TabsTrigger>
       </TabsList>
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-        {tab === "chat" ? chat : config}
+      <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
+        <div className={tab === "chat" ? "flex min-h-0 flex-1 flex-col" : "hidden"}>{chat}</div>
+        <div className={tab === "config" ? "flex min-h-0 flex-1 flex-col" : "hidden"}>{config}</div>
       </div>
     </Tabs>
   );

--- a/apps/dashboard/src/client/ui/routes/agents/new.tsx
+++ b/apps/dashboard/src/client/ui/routes/agents/new.tsx
@@ -17,6 +17,7 @@ import { AgentInputObjectSchema, AgentInputSchema } from "@/entities";
 import type { AgentInput, Template } from "@/entities";
 import { AgentConfigChat } from "@/client/ui/components/agent-config-chat";
 import { CodeEditor } from "@/client/ui/components/code-editor";
+import { AgentEditorMobileTabs } from "./-components/agent-editor-mobile-tabs";
 
 const YAML_OPTIONS = { blockQuote: "literal", lineWidth: 0 } as const;
 
@@ -102,7 +103,12 @@ function NewAgentPage() {
       const visible = templates ?? [];
       return (
         <div className="flex min-h-0 flex-1 flex-col gap-3">
-          <h2 className="shrink-0 text-base font-medium">Start with templates</h2>
+          <div className="flex shrink-0 items-center justify-between gap-2">
+            <h2 className="text-base font-medium">Start with templates</h2>
+            <Button size="sm" variant="outline" onClick={() => setView({ mode: "edit" })}>
+              Create manually
+            </Button>
+          </div>
           <div className="grid min-h-0 flex-1 auto-rows-min grid-cols-1 gap-3 overflow-y-auto p-px sm:grid-cols-2">
             {visible.map((template) => (
               <Card
@@ -188,35 +194,32 @@ function NewAgentPage() {
     <div className="flex h-full min-h-0 flex-col gap-4 p-6">
       <h1 className="shrink-0 text-2xl font-semibold tracking-tight">Create agent</h1>
 
-      {/* Mobile: static stacked layout (config on top, chat at bottom) */}
-      <div className="flex min-h-0 flex-1 flex-col gap-6 lg:hidden">
-        <div className="flex min-h-0 flex-1 flex-col">{configPane}</div>
-        <div className="flex min-h-0 flex-1 flex-col">
-          <AgentConfigChat getConfig={getConfig} onConfigUpdate={handleConfigUpdate} />
-        </div>
-      </div>
+      {/* Mobile: tabbed full-height layout */}
+      <AgentEditorMobileTabs
+        chat={<AgentConfigChat getConfig={getConfig} onConfigUpdate={handleConfigUpdate} />}
+        config={configPane}
+      />
 
       {/* Desktop: resizable side-by-side layout */}
-      <ResizablePanelGroup
-        orientation="horizontal"
-        className="hidden min-h-0 flex-1 lg:flex"
-      >
-        {/* Chat pane */}
-        <ResizablePanel defaultSize="50%" minSize="25%" className="min-h-0">
-          <div className="flex h-full min-h-0 flex-col pr-3">
-            <AgentConfigChat getConfig={getConfig} onConfigUpdate={handleConfigUpdate} />
-          </div>
-        </ResizablePanel>
-        <ResizableHandle
-          withHandle
-          className="bg-transparent [&>div]:opacity-0 [&>div]:transition-opacity hover:[&>div]:opacity-100"
-        />
+      <div className="hidden min-h-0 flex-1 flex-col lg:flex">
+        <ResizablePanelGroup orientation="horizontal" className="h-full min-h-0 flex-1">
+          {/* Chat pane */}
+          <ResizablePanel defaultSize="50%" minSize="25%" className="min-h-0">
+            <div className="flex h-full min-h-0 flex-col pr-3">
+              <AgentConfigChat getConfig={getConfig} onConfigUpdate={handleConfigUpdate} />
+            </div>
+          </ResizablePanel>
+          <ResizableHandle
+            withHandle
+            className="bg-transparent [&>div]:opacity-0 [&>div]:transition-opacity hover:[&>div]:opacity-100"
+          />
 
-        {/* Config pane */}
-        <ResizablePanel defaultSize="50%" minSize="25%" className="min-h-0">
-          <div className="flex h-full min-h-0 flex-col pl-3">{configPane}</div>
-        </ResizablePanel>
-      </ResizablePanelGroup>
+          {/* Config pane */}
+          <ResizablePanel defaultSize="50%" minSize="25%" className="min-h-0">
+            <div className="flex h-full min-h-0 flex-col pl-3">{configPane}</div>
+          </ResizablePanel>
+        </ResizablePanelGroup>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Fixes the broken mobile view of the agent create and edit pages, and aligns the thinking indicator with other assistant messages.

## Changes

- Replace the cramped 50/50 stacked mobile layout with a Config/Chat tab switcher.
- Render only the active tab panel while keeping both mounted so chat history persists across tab switches.
- Wrap the desktop resizable layout so it is fully hidden below the  breakpoint, preventing duplicated chat/editor panes from leaking through.
- Default to the Config tab so the save/create button is immediately visible.
- Add a 'Create manually' button in the new-agent template browser.
- Wrap the 'Thinking…' marker in a ghost bubble so it aligns with other assistant messages.