### PR TITLE
feat(dashboard): add HERMEUM_OPENAI_API_KEY env var

### DIFF
--- a/apps/dashboard/src/server/libs/config.ts
+++ b/apps/dashboard/src/server/libs/config.ts
@@ -48,6 +48,10 @@ export const ConfigSchema = z.object({
     .url()
     .optional()
     .describe("Override the OpenAI API base URL (HERMEUM_OPENAI_BASE_URL)."),
+  openaiApiKey: z
+    .string()
+    .optional()
+    .describe("API key for the OpenAI-compatible API used by the AI config generator (HERMEUM_OPENAI_API_KEY)."),
   logLevel: z
     .enum(["debug", "info", "warn", "error"])
     .default("info")
@@ -130,6 +134,7 @@ export const config = ConfigSchema.parse({
   hermesImageTag: process.env.HERMEUM_HERMES_IMAGE_TAG,
   openaiModel: process.env.HERMEUM_OPENAI_MODEL,
   openaiBaseUrl: process.env.HERMEUM_OPENAI_BASE_URL,
+  openaiApiKey: process.env.HERMEUM_OPENAI_API_KEY,
   logLevel: process.env.HERMEUM_LOG_LEVEL,
   agentIngressScheme: process.env.HERMEUM_AGENT_INGRESS_SCHEME,
   agentIngressBaseHostname: process.env.HERMEUM_AGENT_INGRESS_BASE_HOSTNAME,

--- a/apps/dashboard/src/server/routers/ai-sdk/agent-config.ts
+++ b/apps/dashboard/src/server/routers/ai-sdk/agent-config.ts
@@ -38,7 +38,8 @@ function model() {
     );
   }
   const baseURL = config.openaiBaseUrl ? { baseURL: config.openaiBaseUrl } : {};
-  openai ??= createOpenAI(baseURL);
+  const apiKey = config.openaiApiKey ? { apiKey: config.openaiApiKey } : {};
+  openai ??= createOpenAI({ ...baseURL, ...apiKey });
   return openai(config.openaiModel);
 }
 

--- a/apps/dashboard/src/server/routers/ai-sdk/agent-config.ts
+++ b/apps/dashboard/src/server/routers/ai-sdk/agent-config.ts
@@ -28,6 +28,9 @@ const ChatRequestSchema = z.object({
 
 // Lazy: built on first use so the dashboard boots without any AI config
 // and fails with a clear error only when the feature is called.
+// Hermeum uses OpenAI for the AI config generator for consistent output
+// quality across runs; HERMEUM_OPENAI_BASE_URL lets it point at an
+// OpenAI-compatible endpoint.
 let openai: ReturnType<typeof createOpenAI> | undefined;
 
 function model() {

--- a/charts/hermeum/templates/deployment.yaml
+++ b/charts/hermeum/templates/deployment.yaml
@@ -155,7 +155,7 @@ spec:
                   key: openai-base-url
             {{- end }}
             {{- if .Values.secrets.openaiApiKey }}
-            - name: OPENAI_API_KEY
+            - name: HERMEUM_OPENAI_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ include "hermeum.secretName" . }}

--- a/charts/hermeum/values.yaml
+++ b/charts/hermeum/values.yaml
@@ -94,7 +94,7 @@ config:
     # tls block with this secret; when unset, no tls block is emitted.
     tlsSecretName: ""
 
-# ── Sensitive env (HERMEUM_* + BETTER_AUTH_* + OPENAI_API_KEY → Secret) ──────
+# ── Sensitive env (HERMEUM_* + BETTER_AUTH_* → Secret) ─────────────────────
 secrets:
   # REQUIRED when no existingSecret is set. Connection URL for the dashboard
   # database (HERMEUM_DATABASE_URL). For sqlite use "file:/var/lib/hermeum/db.sqlite".
@@ -110,12 +110,14 @@ secrets:
   smtpUrl: ""
   # Optional — override the OpenAI API base URL (HERMEUM_OPENAI_BASE_URL).
   openaiBaseUrl: ""
-  # Optional — API key for the AI config generator (mapped to OPENAI_API_KEY).
+  # Optional — API key for the OpenAI-compatible API used by the AI config
+  # generator (mapped to HERMEUM_OPENAI_API_KEY).
   openaiApiKey: ""
   # Use an existing Secret instead of templating one. When set, the chart
   # reads databaseUrl / betterAuthSecret / betterAuthUrl / smtpUrl /
   # openaiBaseUrl / openaiApiKey from the following keys: database-url,
-  # better-auth-secret, better-auth-url, smtp-url, openai-base-url, openai-api-key.
+  # better-auth-secret, better-auth-url, smtp-url, openai-base-url,
+  # openai-api-key.
   existingSecret: ""
 
 # ── agentConfig override (ConfigMap mounted at config.configPath) ───────


### PR DESCRIPTION
## Summary

Add a `HERMEUM_OPENAI_API_KEY` env var for the OpenAI API key used by the AI config generator, consistent with the existing `HERMEUM_OPENAI_MODEL` and `HERMEUM_OPENAI_BASE_URL` vars. Previously the dashboard relied on the bare `OPENAI_API_KEY` env var defaulting through the `@ai-sdk/openai` client.

## Changes

- **`apps/dashboard/src/server/libs/config.ts`** — new optional `openaiApiKey` zod field sourced from `process.env.HERMEUM_OPENAI_API_KEY`.
- **`apps/dashboard/src/server/routers/ai-sdk/agent-config.ts`** — pass `apiKey` into `createOpenAI()` when set.
- **`charts/hermeum/templates/deployment.yaml`** — env var name on the secret ref changed from `OPENAI_API_KEY` to `HERMEUM_OPENAI_API_KEY`.
- **`charts/hermeum/values.yaml`** — comment updates (header line and `secrets.openaiApiKey` description). The `secrets.openaiApiKey` value knob and the K8s Secret key (`openai-api-key`) are unchanged, so existing deployments keep working.

## Notes

- The agent-side `OPENAI_API_KEY` (used by agents with `provider: openai-api` per `apps/dashboard/docs/hermes-config/model.md`) is unrelated and untouched.
- Typecheck shows 2 pre-existing errors in `server.ts` / `agent-config.ts:85` that exist on `main` and are not introduced by this change. Lint is clean (only pre-existing warnings).