### PR TITLE
fix(dashboard): agent-config chat skips optional fields + slack allow_bots enum

### DIFF
--- a/apps/dashboard/src/client/ui/components/agent-config-chat.tsx
+++ b/apps/dashboard/src/client/ui/components/agent-config-chat.tsx
@@ -298,18 +298,14 @@ export function AgentConfigChat({
                   <MessageScrollerItem messageId="thinking">
                     <Message align="start">
                       <MessageContent>
-                        <Bubble variant="ghost" align="start">
-                          <BubbleContent>
-                            <Marker className="normal-case tracking-normal font-normal">
-                              <MarkerIcon>
-                                <LoaderCircle className="animate-spin" />
-                              </MarkerIcon>
-                              <MarkerContent className="normal-case tracking-normal">
-                                Thinking…
-                              </MarkerContent>
-                            </Marker>
-                          </BubbleContent>
-                        </Bubble>
+                        <Marker className="normal-case tracking-normal font-normal">
+                          <MarkerIcon>
+                            <LoaderCircle className="animate-spin" />
+                          </MarkerIcon>
+                          <MarkerContent className="normal-case tracking-normal">
+                            Thinking…
+                          </MarkerContent>
+                        </Marker>
                       </MessageContent>
                     </Message>
                   </MessageScrollerItem>

--- a/apps/dashboard/src/entities/hermes-config/slack.ts
+++ b/apps/dashboard/src/entities/hermes-config/slack.ts
@@ -27,9 +27,9 @@ export const SlackSchema = z
       .optional()
       .describe("Slack channel IDs the bot may respond in."),
     allow_bots: z
-      .boolean()
+      .enum(["none", "mentions", "all"])
       .optional()
-      .describe("Allow other bots to trigger this bot (default false)."),
+      .describe("Allow other bots to trigger this bot: 'none' (default), 'mentions', or 'all'."),
     channel_prompts: z
       .record(z.string(), z.string())
       .optional()

--- a/apps/dashboard/src/routeTree.gen.ts
+++ b/apps/dashboard/src/routeTree.gen.ts
@@ -9,29 +9,24 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './client/ui/routes/__root'
-import { Route as SigninRouteImport } from './client/ui/routes/signin'
 import { Route as IndexRouteImport } from './client/ui/routes/index'
-import { Route as SharedEnvSetsIndexRouteImport } from './client/ui/routes/shared-env-sets/index'
+import { Route as SigninRouteImport } from './client/ui/routes/signin'
 import { Route as AgentsIndexRouteImport } from './client/ui/routes/agents/index'
-import { Route as SharedEnvSetsIdRouteImport } from './client/ui/routes/shared-env-sets/$id'
-import { Route as AgentsNewRouteImport } from './client/ui/routes/agents/new'
 import { Route as AgentsIdRouteImport } from './client/ui/routes/agents/$id'
+import { Route as AgentsNewRouteImport } from './client/ui/routes/agents/new'
+import { Route as SharedEnvSetsIndexRouteImport } from './client/ui/routes/shared-env-sets/index'
+import { Route as SharedEnvSetsIdRouteImport } from './client/ui/routes/shared-env-sets/$id'
 import { Route as AgentsIdIndexRouteImport } from './client/ui/routes/agents/$id/index'
 import { Route as AgentsIdEditRouteImport } from './client/ui/routes/agents/$id/edit'
 
-const SigninRoute = SigninRouteImport.update({
-  id: '/signin',
-  path: '/signin',
-  getParentRoute: () => rootRouteImport,
-} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
-const SharedEnvSetsIndexRoute = SharedEnvSetsIndexRouteImport.update({
-  id: '/shared-env-sets/',
-  path: '/shared-env-sets/',
+const SigninRoute = SigninRouteImport.update({
+  id: '/signin',
+  path: '/signin',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AgentsIndexRoute = AgentsIndexRouteImport.update({
@@ -39,9 +34,9 @@ const AgentsIndexRoute = AgentsIndexRouteImport.update({
   path: '/agents/',
   getParentRoute: () => rootRouteImport,
 } as any)
-const SharedEnvSetsIdRoute = SharedEnvSetsIdRouteImport.update({
-  id: '/shared-env-sets/$id',
-  path: '/shared-env-sets/$id',
+const AgentsIdRoute = AgentsIdRouteImport.update({
+  id: '/agents/$id',
+  path: '/agents/$id',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AgentsNewRoute = AgentsNewRouteImport.update({
@@ -49,9 +44,14 @@ const AgentsNewRoute = AgentsNewRouteImport.update({
   path: '/agents/new',
   getParentRoute: () => rootRouteImport,
 } as any)
-const AgentsIdRoute = AgentsIdRouteImport.update({
-  id: '/agents/$id',
-  path: '/agents/$id',
+const SharedEnvSetsIndexRoute = SharedEnvSetsIndexRouteImport.update({
+  id: '/shared-env-sets/',
+  path: '/shared-env-sets/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const SharedEnvSetsIdRoute = SharedEnvSetsIdRouteImport.update({
+  id: '/shared-env-sets/$id',
+  path: '/shared-env-sets/$id',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AgentsIdIndexRoute = AgentsIdIndexRouteImport.update({
@@ -145,13 +145,6 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/signin': {
-      id: '/signin'
-      path: '/signin'
-      fullPath: '/signin'
-      preLoaderRoute: typeof SigninRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/': {
       id: '/'
       path: '/'
@@ -159,11 +152,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/shared-env-sets/': {
-      id: '/shared-env-sets/'
-      path: '/shared-env-sets'
-      fullPath: '/shared-env-sets/'
-      preLoaderRoute: typeof SharedEnvSetsIndexRouteImport
+    '/signin': {
+      id: '/signin'
+      path: '/signin'
+      fullPath: '/signin'
+      preLoaderRoute: typeof SigninRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/agents/': {
@@ -173,11 +166,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AgentsIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/shared-env-sets/$id': {
-      id: '/shared-env-sets/$id'
-      path: '/shared-env-sets/$id'
-      fullPath: '/shared-env-sets/$id'
-      preLoaderRoute: typeof SharedEnvSetsIdRouteImport
+    '/agents/$id': {
+      id: '/agents/$id'
+      path: '/agents/$id'
+      fullPath: '/agents/$id'
+      preLoaderRoute: typeof AgentsIdRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/agents/new': {
@@ -187,11 +180,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AgentsNewRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/agents/$id': {
-      id: '/agents/$id'
-      path: '/agents/$id'
-      fullPath: '/agents/$id'
-      preLoaderRoute: typeof AgentsIdRouteImport
+    '/shared-env-sets/': {
+      id: '/shared-env-sets/'
+      path: '/shared-env-sets'
+      fullPath: '/shared-env-sets/'
+      preLoaderRoute: typeof SharedEnvSetsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/shared-env-sets/$id': {
+      id: '/shared-env-sets/$id'
+      path: '/shared-env-sets/$id'
+      fullPath: '/shared-env-sets/$id'
+      preLoaderRoute: typeof SharedEnvSetsIdRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/agents/$id/': {

--- a/apps/dashboard/src/server/usecases/chat.ts
+++ b/apps/dashboard/src/server/usecases/chat.ts
@@ -263,6 +263,8 @@ or the tools setup). Ask at most one question at a time, and keep all replies
 concise.
 
 Note 
+- Only write fields the user has asked for or that are strictly required. Skip
+every optional field unless the user requests it.
 - Never guess at field semantics. When you're not fully sure about a config
 section, settle it with the documentation before writing it into the draft.
 


### PR DESCRIPTION
## Summary

- **agent-config chat prompt**: instruct the model to write only fields the user asked for or that are strictly required, skipping optional fields until explicitly requested. Prevents the bot from emitting `<fill-me-...>` placeholders for unrequested config.
- **slack schema**: change `allow_bots` from `z.boolean()` to `z.enum(["none","mentions","all"])` to match upstream Hermes semantics.
- **routeTree.gen.ts**: regen after route reordering.

## Commits
- 48e58b2 fix(dashboard): unwrap thinking marker for consistency with tool markers
- 494a015 fix(dashboard): instruct agent-config chat to skip optional fields unless requested
- c083e57 fix(dashboard): align slack allow_bots schema with enum values
- bbf7b9b chore(dashboard): regen routeTree

## Verification
- `pnpm --filter @hermeum/dashboard lint` — clean (only pre-existing warnings)
- `pnpm --filter @hermeum/dashboard typecheck` — pre-existing errors in `src/server/server.ts` and `src/server/routers/ai-sdk/agent-config.ts` only; no new errors introduced