### PR TITLE
feat: support multiple JSON Patch candidates with test-op preconditions

### DIFF
--- a/apps/app/src/entities/hermeum-config.ts
+++ b/apps/app/src/entities/hermeum-config.ts
@@ -11,9 +11,25 @@ export const JsonPatchOpSchema = z.object({
 
 export type JsonPatchOp = z.infer<typeof JsonPatchOpSchema>;
 
+/**
+ * A JSON Patch is an array of ops. The `test` op acts as a precondition: when
+ * a patch begins with `test` ops, the webhook selects it only if all tests
+ * pass against the incoming object (first-match-wins), otherwise falls through
+ * to the next candidate (no-match = no mutation). A single flat array is the
+ * legacy shape (one unconditional candidate); an array of arrays declares
+ * multiple candidates evaluated in order.
+ */
+const JsonPatchArraySchema = z.array(JsonPatchOpSchema);
+
+export const MutatingWebhookJsonPatchSchema = z
+  .union([JsonPatchArraySchema, z.array(JsonPatchArraySchema)])
+  .transform((v) => (Array.isArray(v[0]) ? (v as JsonPatchOp[][]) : [v as JsonPatchOp[]]));
+
+export type MutatingWebhookJsonPatch = z.infer<typeof MutatingWebhookJsonPatchSchema>;
+
 export const AgentTypeSchema = z.object({
   description: z.string().optional(),
-  mutatingWebhookJsonPatch: z.array(JsonPatchOpSchema),
+  mutatingWebhookJsonPatch: MutatingWebhookJsonPatchSchema,
 });
 
 export type AgentType = z.infer<typeof AgentTypeSchema>;

--- a/apps/app/src/server/routers/webhook.ts
+++ b/apps/app/src/server/routers/webhook.ts
@@ -53,7 +53,7 @@ webhookRouter.post("/mutating", async (req, res) => {
   }
 
   const agent = mapHermesAgent(request.object);
-  const patch = await usecase.getmutatingWebhookJsonPatch(agent);
+  const patch = await usecase.getmutatingWebhookJsonPatch(agent, request.object);
 
   const response: AdmissionReview = {
     apiVersion: body.apiVersion,
@@ -61,7 +61,7 @@ webhookRouter.post("/mutating", async (req, res) => {
     response: {
       uid: request.uid,
       allowed: true,
-      ...(patch !== null && {
+      ...(patch !== null && patch.length > 0 && {
         patchType: "JSONPatch",
         patch: Buffer.from(JSON.stringify(patch)).toString("base64"),
       }),

--- a/apps/app/src/server/usecases/agent.test.ts
+++ b/apps/app/src/server/usecases/agent.test.ts
@@ -19,17 +19,24 @@ import { stringify } from "yaml";
 import { AgentUseCase } from "./agent";
 import type { FileAdaptor } from "./adaptors/file";
 import type { Runtime } from "./adaptors/runtime";
-import type { HermeumConfig, JsonPatchOp } from "@/entities";
+import type { JsonPatchOp } from "@/entities";
 import type { Agent, Context, SharedEnvSet } from "@/entities";
 
 // FileAdaptor serving the Hermeum config file the use case inherits loading for.
-function makeConfig(agentTypes?: HermeumConfig["agentTypes"]): FileAdaptor {
+// Accepts the legacy flat-array shape and the multi-candidate array-of-arrays
+// shape; HermeumConfigSchema.parse normalizes to JsonPatchOp[][] at runtime.
+type AgentTypeInput = {
+  description?: string;
+  mutatingWebhookJsonPatch: JsonPatchOp[] | JsonPatchOp[][];
+};
+
+function makeConfig(agentTypes?: Record<string, AgentTypeInput>): FileAdaptor {
   return {
     listFiles: vi.fn(),
     readFile: vi.fn().mockResolvedValue({
       path: "./config.yaml",
       name: "config",
-      content: stringify({ agentTypes, templates: [] } satisfies HermeumConfig),
+      content: stringify({ agentTypes, templates: [] }),
       data: {},
     }),
   };
@@ -176,6 +183,87 @@ describe("AgentUseCase.getmutatingWebhookJsonPatch", () => {
     expect(result).toHaveLength(2);
     expect(result![0]).not.toHaveProperty("value");
     expect(result![1]!.value).toBe("{{agentId}}");
+  });
+
+  it("returns the first candidate when no incomingObject is given (backwards compat)", async () => {
+    const candidates: JsonPatchOp[][] = [
+      [{ op: "test", path: "/spec/model", value: "x" }, { op: "add", path: "/a", value: 1 }],
+      [{ op: "add", path: "/b", value: 2 }],
+    ];
+    const useCase = new AgentUseCase(
+      makeRuntime(),
+      makeConfig({ t: { mutatingWebhookJsonPatch: candidates } })
+    );
+    const result = await useCase.getmutatingWebhookJsonPatch(makeAgent({ type: "t" }));
+    expect(result).toEqual(candidates[0]);
+  });
+
+  it("selects the first candidate whose test ops pass (first-match-wins)", async () => {
+    const candidates: JsonPatchOp[][] = [
+      [{ op: "test", path: "/spec/model", value: "gpt-4" }, { op: "add", path: "/a", value: 1 }],
+      [{ op: "test", path: "/spec/model", value: "claude" }, { op: "add", path: "/b", value: 2 }],
+    ];
+    const useCase = new AgentUseCase(
+      makeRuntime(),
+      makeConfig({ t: { mutatingWebhookJsonPatch: candidates } })
+    );
+    const incoming = { spec: { model: "claude" } };
+    const result = await useCase.getmutatingWebhookJsonPatch(
+      makeAgent({ type: "t" }),
+      incoming,
+    );
+    expect(result).toEqual(candidates[1]);
+  });
+
+  it("returns an empty patch when no candidate matches (no-op)", async () => {
+    const candidates: JsonPatchOp[][] = [
+      [{ op: "test", path: "/spec/model", value: "gpt-4" }, { op: "add", path: "/a", value: 1 }],
+      [{ op: "test", path: "/spec/model", value: "claude" }, { op: "add", path: "/b", value: 2 }],
+    ];
+    const useCase = new AgentUseCase(
+      makeRuntime(),
+      makeConfig({ t: { mutatingWebhookJsonPatch: candidates } })
+    );
+    const incoming = { spec: { model: "gemini" } };
+    const result = await useCase.getmutatingWebhookJsonPatch(
+      makeAgent({ type: "t" }),
+      incoming,
+    );
+    expect(result).toEqual([]);
+  });
+
+  it("matches a candidate with no test ops (unconditional fallback)", async () => {
+    const candidates: JsonPatchOp[][] = [
+      [{ op: "test", path: "/spec/model", value: "gpt-4" }, { op: "add", path: "/a", value: 1 }],
+      [{ op: "add", path: "/b", value: 2 }],
+    ];
+    const useCase = new AgentUseCase(
+      makeRuntime(),
+      makeConfig({ t: { mutatingWebhookJsonPatch: candidates } })
+    );
+    const incoming = { spec: { model: "anything" } };
+    const result = await useCase.getmutatingWebhookJsonPatch(
+      makeAgent({ type: "t" }),
+      incoming,
+    );
+    expect(result).toEqual(candidates[1]);
+  });
+
+  it("preserves test ops in the returned patch for K8s atomic re-assertion", async () => {
+    const candidates: JsonPatchOp[][] = [
+      [{ op: "test", path: "/spec/model", value: "gpt-4" }, { op: "add", path: "/a", value: 1 }],
+    ];
+    const useCase = new AgentUseCase(
+      makeRuntime(),
+      makeConfig({ t: { mutatingWebhookJsonPatch: candidates } })
+    );
+    const incoming = { spec: { model: "gpt-4" } };
+    const result = await useCase.getmutatingWebhookJsonPatch(
+      makeAgent({ type: "t" }),
+      incoming,
+    );
+    expect(result).toEqual(candidates[0]);
+    expect(result![0]!.op).toBe("test");
   });
 });
 

--- a/apps/app/src/server/usecases/agent.ts
+++ b/apps/app/src/server/usecases/agent.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { applyPatch } from "fast-json-patch";
 
 import { Agent, AgentInput, AgentInputSchema, Context, Env, JsonPatchOp } from "@/entities";
 
@@ -10,12 +11,21 @@ export const ListAgentsFilterSchema = z.object({
 export type ListAgentsFilter = z.infer<typeof ListAgentsFilterSchema>;
 
 export class AgentUseCase extends OwnershipGuarded(HermeumConfigLoadable(BaseUseCase)) {
-  async getmutatingWebhookJsonPatch(agent: Agent): Promise<JsonPatchOp[] | null> {
+  async getmutatingWebhookJsonPatch(
+    agent: Agent,
+    incomingObject?: unknown,
+  ): Promise<JsonPatchOp[] | null> {
     if (!agent.type) return null;
     const { agentTypes } = await this.loadHermeumConfig();
     const agentType = agentTypes?.[agent.type];
     if (!agentType) return null;
-    return agentType.mutatingWebhookJsonPatch;
+    // mutatingWebhookJsonPatch is normalized to JsonPatchOp[][] by the schema
+    // transform. When an incoming object is provided, select the first
+    // candidate whose `test` ops pass (first-match-wins); without one, return
+    // the first (only) candidate as-is for backwards compatibility.
+    const candidates = agentType.mutatingWebhookJsonPatch as unknown as JsonPatchOp[][];
+    if (incomingObject === undefined) return candidates[0] ?? null;
+    return this.selectPatch(candidates, incomingObject);
   }
 
   async listHermesAgents(ctx: Context, input?: ListAgentsFilter): Promise<Agent[]> {
@@ -138,5 +148,34 @@ export class AgentUseCase extends OwnershipGuarded(HermeumConfigLoadable(BaseUse
         throw new Error(`Shared env set "${id}" is archived`);
       }
     }
+  }
+
+  /**
+   * Evaluate the `test` ops in a candidate patch against a document.
+   * A candidate with no `test` ops always matches (unconditional).
+   *
+   * Uses `fast-json-patch`'s `applyPatch` with only the `test` ops. `test`
+   * ops do not mutate the document, so applying them to the original is safe.
+   * If any `test` fails, `applyPatch` throws `TEST_OPERATION_FAILED`, which we
+   * catch and treat as a non-match.
+   */
+  private candidateMatches(candidate: JsonPatchOp[], doc: unknown): boolean {
+    const testOps = candidate.filter((op) => op.op === "test");
+    if (testOps.length === 0) return true;
+    try {
+      applyPatch(doc, testOps, true);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Select the first candidate whose `test` ops all pass against the document
+   * (first-match-wins). Returns the matched candidate, or an empty array when
+   * no candidate matches (no-op / admit unchanged).
+   */
+  private selectPatch(candidates: JsonPatchOp[][], doc: unknown): JsonPatchOp[] {
+    return candidates.find((c) => this.candidateMatches(c, doc)) ?? [];
   }
 }

--- a/apps/docs/docs/operation/instance-config.md
+++ b/apps/docs/docs/operation/instance-config.md
@@ -71,13 +71,17 @@ agent's `type` field references. Each type has:
 | Field                     | Required | Description                                                                  |
 |---------------------------|----------|------------------------------------------------------------------------------|
 | `description`             | no       | Human-readable description; surfaced to the AI config generator so it can pick the right type. |
-| `mutatingWebhookJsonPatch`| yes      | A JSON-Patch ([RFC 6902](https://datatracker.ietf.org/doc/html/rfc6902)) applied to the `HermesAgent` CR on `CREATE`/`UPDATE`. |
+| `mutatingWebhookJsonPatch`| yes      | A JSON-Patch ([RFC 6902](https://datatracker.ietf.org/doc/html/rfc6902)) applied to the `HermesAgent` CR on `CREATE`/`UPDATE`. Accepts a flat `op` array (one candidate) or an array of arrays (multiple candidates; first match wins). |
 
 When Hermeum receives an admission review, it looks up
 `agentTypes[agent.type].mutatingWebhookJsonPatch` and returns it as the
-patch. The webhook is a no-op until at least one type has a non-empty patch.
-See [Mutating webhook](../mutating-webhook) for the certificate options and
-the end-to-end flow.
+patch. If multiple candidates are provided, Hermeum evaluates each
+candidate's [`test`](https://datatracker.ietf.org/doc/html/rfc6902#section-4.6)
+ops against the incoming object and returns the first one whose tests pass
+(first-match-wins); no match means no patch (no-op). The webhook is a no-op
+until at least one type has a non-empty patch. See
+[Mutating webhook](../mutating-webhook) for the certificate options, the
+end-to-end flow, and precondition examples.
 
 :::note
 Setting an agent's `type` requires `agentTypes` to be configured — Hermeum

--- a/apps/docs/docs/operation/mutating-webhook.md
+++ b/apps/docs/docs/operation/mutating-webhook.md
@@ -1,6 +1,6 @@
 ---
 title: Mutating admission webhook
-description: What the webhook does, mutatingWebhookJsonPatch, and certificate options.
+description: What the webhook does, mutatingWebhookJsonPatch, test-op preconditions, and certificate options.
 sidebar_label: Mutating webhook
 sidebar_position: 7
 displayed_sidebar: docsSidebar
@@ -14,7 +14,7 @@ infrastructure level** — so users can create an agent by describing what it
 should do, without having to understand the `HermesAgent` spec or hand-edit
 the fields an operator cares about. 
 
-Mechanically, the webhook applies that JSON-Patch to every `HermesAgent` on
+Mechanically, the webhook applies a JSON-Patch to every `HermesAgent` on
 `CREATE`/`UPDATE`. It is served by the Hermeum pod on a separate HTTPS port
 (`HERMEUM_WEBHOOK_PORT`, default `8443`) at `POST /webhook/mutating`, reached
 directly by the kube-apiserver — not through any ingress. 
@@ -28,10 +28,14 @@ and the `MutatingWebhookConfiguration` (if present) will fail closed.
 When the kube-apiserver sends an `AdmissionReview` for a `HermesAgent`, the
 webhook:
 
-1. Reads the incoming object's `spec.type`.
+1. Reads the incoming object's `type` (from the `hermeum.app/type`
+   annotation).
 2. Looks up `agentTypes[<type>].mutatingWebhookJsonPatch` in the loaded
-   instance config.
-3. Returns that JSON-Patch ([RFC 6902](https://datatracker.ietf.org/doc/html/rfc6902))
+   instance config — a list of candidate patches.
+3. If candidates begin with `test` ops, evaluates each candidate's `test`
+   ops against the incoming object and returns the **first** one whose tests
+   all pass (first-match-wins). If none match, no patch is returned.
+4. Returns that JSON-Patch ([RFC 6902](https://datatracker.ietf.org/doc/html/rfc6902))
    as the admission response's `patch`.
 
 If the type is unknown or has no `mutatingWebhookJsonPatch`, the webhook
@@ -45,7 +49,9 @@ Patches live in the instance config under
 [Instance config](../instance-config) for the schema and how to mount a
 custom `config.yaml` via `HERMEUM_CONFIG_PATH`).
 
-A common use is stamping an annotation that records the agent's type:
+The field accepts either a flat array (one candidate, the simplest form) or
+an array of arrays (multiple candidates evaluated in order). A single flat
+array is the most common case:
 
 ```yaml
 agentTypes:
@@ -57,11 +63,61 @@ agentTypes:
         value: my-type
 ```
 
+### Preconditions with `test` ops
+
+A candidate patch can begin with [`test`](https://datatracker.ietf.org/doc/html/rfc6902#section-4.6)
+ops to act as a precondition. Hermeum evaluates each candidate's `test` ops
+against the incoming `HermesAgent` object and selects the **first** candidate
+whose tests all pass. `test` ops that fail cause Hermeum to skip to the next
+candidate — they do **not** reject the admission (unlike a flat array of
+`test` ops, where a failing `test` would reject the whole request).
+
+To express conditional mutation, provide multiple candidates as an array of
+arrays:
+
+```yaml
+agentTypes:
+  replica-setter:
+    description: Sets replicas based on the agent's model.
+    mutatingWebhookJsonPatch:
+      # Candidate 1: only when spec.hermes.config.model.default is gpt-4
+      - - op: test
+          path: /spec/hermes/config/model/default
+          value: gpt-4
+        - op: add
+          path: /spec/replicas
+          value: 2
+      # Candidate 2: only when spec.hermes.config.model.default is claude
+      - - op: test
+          path: /spec/hermes/config/model/default
+          value: claude
+        - op: add
+          path: /spec/replicas
+          value: 3
+      # Candidate 3: unconditional fallback (no test ops)
+      - - op: add
+          path: /spec/replicas
+          value: 1
+```
+
+In this example, Hermeum returns the first candidate whose `test` op matches
+the incoming object. The last candidate has no `test` ops, so it always
+matches — acting as a default/fallback. If no candidate matches (and there
+is no unconditional fallback), the webhook returns no patch (no-op).
+
+The selected candidate — **including its `test` ops** — is returned to
+Kubernetes, which re-applies the full patch atomically. This gives defense in
+depth: the `test` ops are re-asserted by the kube-apiserver at apply time.
+
 Notes:
 
 - `path` uses JSON-Pointer; `/` is escaped as `~1` (so
   `/metadata/annotations/hermeum.app~1type` targets the
   `hermeum.app/type` annotation).
+- `test` ops compare the value at `path` against `value` using structural
+  deep-equality (objects and arrays are compared recursively).
+- A candidate with no `test` ops always matches — use this for an
+  unconditional fallback.
 - The patch is applied to the `HermesAgent` CR itself, not to the rendered
   StatefulSet. To mutate the agent pod, target fields the operator reads from
   the CR (e.g. `spec.env`, `spec.config`).


### PR DESCRIPTION
## Summary

The mutating webhook now supports **multiple candidate JSON patches** with `test` ops as preconditions, addressing the lack of a precondition mechanism in JSON Patch.

## How it works

`mutatingWebhookJsonPatch` accepts either a flat `JsonPatchOp[]` (legacy single candidate) or `JsonPatchOp[][]` (multiple candidates). The webhook:

1. Evaluates each candidate's `test` ops against the incoming `HermesAgent` object using `fast-json-patch`
2. Returns the **first** candidate whose tests all pass (first-match-wins)
3. If no candidate matches, returns an empty patch (admit unchanged — no-op)

The `test` ops are preserved in the returned patch so kube-apiserver re-asserts them atomically at apply time (defense in depth).

```yaml
agentTypes:
  replica-setter:
    mutatingWebhookJsonPatch:
      - - op: test
          path: /spec/hermes/config/model/default
          value: gpt-4
        - op: add
          path: /spec/replicas
          value: 2
      - - op: test
          path: /spec/hermes/config/model/default
          value: claude
        - op: add
          path: /spec/replicas
          value: 3
      - - op: add          # unconditional fallback
          path: /spec/replicas
          value: 1
```

## Changes

- **`apps/app/src/entities/hermeum-config.ts`** — `mutatingWebhookJsonPatch` now accepts a flat array or array-of-arrays via a Zod union with `.transform()` normalizing to `JsonPatchOp[][]`.
- **`apps/app/src/server/usecases/agent.ts`** — `getmutatingWebhookJsonPatch` takes an optional `incomingObject` param; evaluates candidates via `fast-json-patch`'s `applyPatch` (test ops only).
- **`apps/app/src/server/routers/webhook.ts`** — passes `request.object` to the usecase; gates patch output on non-empty.
- **`apps/app/src/server/usecases/agent.test.ts`** — 6 new tests covering backwards-compat, first-match-wins, no-match no-op, unconditional fallback, and test-op preservation.
- **Docs** — updated `mutating-webhook.md`, `instance-config.md`, `overview.md`, and `installation.md`.

## Decisions

- **No-match → no-op** (empty patch, admission allowed, object unmutated)
- **Backwards compat** — Zod union on the existing field name; flat arrays still work
- **First-match-wins** — order in config is significant
- **No new dependency** — `fast-json-patch` was already in `package.json` but unused

## Test plan

- [x] All 45 existing tests pass (`agent.test.ts` + `chat.test.ts`)
- [x] Lint clean on changed files
- [ ] Typecheck has 3 pre-existing errors unrelated to this change (`agent-config.ts`, `server.ts` — express/ai-sdk type mismatches)