### PR TITLE
docs: add README.md as project index

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,12 @@ agent you can chat with, deploy, and iterate on.
   team uses most.
 - **Shared env sets** — share credentials (such as API keys) across agents
   without re-entering them each time.
+- **Powered by Kubernetes** — agents run as `HermesAgent` custom resources, with
+  a mutating admission webhook that shapes each agent at creation time.
 
 ## Quick installation
+
+**Prerequisites:** a Kubernetes cluster and Helm 3.x.
 
 Hermeum ships as a Helm chart (`charts/hermeum`) for Kubernetes. The only
 hard-required value is `secrets.databaseUrl` (`HERMEUM_DATABASE_URL`).

--- a/README.md
+++ b/README.md
@@ -28,26 +28,28 @@ helm install hermeum oci://ghcr.io/hermeum/charts/hermeum \
 
 For Postgres (horizontal scaling), set `config.databaseDialect=postgres` and a
 Postgres `secrets.databaseUrl`. See the
-[Installation guide](apps/docs/docs/operation/installation.md) and the
+[Installation guide](https://docs.hermeum.app/operation/installation/) and the
 [chart README](charts/hermeum/README.md) for the full reference.
 
 ## Documentation
 
+Full documentation is published at <https://docs.hermeum.app>.
+
 | Document | Description |
 | --- | --- |
-| [What is Hermeum](apps/docs/docs/intro.md) | Overview of the platform and what an agent can do. |
-| [Getting started](apps/docs/docs/using-hermeum/getting-started.md) | Create, manage, and chat with your agents. |
-| [Creating an agent](apps/docs/docs/using-hermeum/creating-an-agent.md) | How to shape an agent's soul, models, and skills. |
-| [Messaging platforms](apps/docs/docs/using-hermeum/messaging-platforms.md) | Connect agents to Slack, Discord, Teams, and webhooks. |
-| [Shared env sets](apps/docs/docs/using-hermeum/shared-env-sets.md) | Reuse environment sets across agents. |
-| [Overview](apps/docs/docs/operation/overview.md) | Architecture and components for self-hosting. |
-| [Installation](apps/docs/docs/operation/installation.md) | Prerequisites, Helm install, database choice, upgrades. |
-| [Configuration reference](apps/docs/docs/operation/configuration-reference.md) | Full `HERMEUM_*` environment variable reference. |
-| [Instance config](apps/docs/docs/operation/instance-config.md) | `config.yaml` schema for templates and agent types. |
-| [Database](apps/docs/docs/operation/database.md) | SQLite vs Postgres, migrations, scaling. |
-| [Auth](apps/docs/docs/operation/auth.md) | Better Auth setup, secrets, email verification. |
-| [Mutating admission webhook](apps/docs/docs/operation/mutating-webhook.md) | Admission webhook behavior and TLS options. |
-| [Per-agent ingress and TLS](apps/docs/docs/operation/ingress-tls.md) | Ingress gateway and per-agent TLS. |
+| [What is Hermeum](https://docs.hermeum.app/) | Overview of the platform and what an agent can do. |
+| [Getting started](https://docs.hermeum.app/using-hermeum/getting-started/) | Create, manage, and chat with your agents. |
+| [Creating an agent](https://docs.hermeum.app/using-hermeum/creating-an-agent/) | How to shape an agent's soul, models, and skills. |
+| [Messaging platforms](https://docs.hermeum.app/using-hermeum/messaging-platforms/) | Connect agents to Slack, Discord, Teams, and webhooks. |
+| [Shared env sets](https://docs.hermeum.app/using-hermeum/shared-env-sets/) | Reuse environment sets across agents. |
+| [Overview](https://docs.hermeum.app/operation/overview/) | Architecture and components for self-hosting. |
+| [Installation](https://docs.hermeum.app/operation/installation/) | Prerequisites, Helm install, database choice, upgrades. |
+| [Configuration reference](https://docs.hermeum.app/operation/configuration-reference/) | Full `HERMEUM_*` environment variable reference. |
+| [Instance config](https://docs.hermeum.app/operation/instance-config/) | `config.yaml` schema for templates and agent types. |
+| [Database](https://docs.hermeum.app/operation/database/) | SQLite vs Postgres, migrations, scaling. |
+| [Auth](https://docs.hermeum.app/operation/auth/) | Better Auth setup, secrets, email verification. |
+| [Mutating admission webhook](https://docs.hermeum.app/operation/mutating-webhook/) | Admission webhook behavior and TLS options. |
+| [Per-agent ingress and TLS](https://docs.hermeum.app/operation/ingress-tls/) | Ingress gateway and per-agent TLS. |
 
 ## Contribution
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,58 @@
+# Hermeum
+
+Hermeum is a platform for creating **tailored AI agents** for your team. Every
+agent is built on top of the open-source
+[Hermes agent](https://hermes-agent.nousresearch.com/docs), so it inherits
+powerful built-in capabilities, while Hermeum gives you a simple way to shape,
+run, and manage it.
+
+Describe what you want your agent to do, and Hermeum turns that into a working
+agent you can chat with, deploy, and iterate on. An agent can answer questions,
+research topics, browse the web, chat through Slack, Discord, Microsoft Teams,
+or a custom webhook, run tasks on a schedule, and expose an OpenAI-compatible
+API for other apps to use.
+
+## Quick installation
+
+Hermeum ships as a Helm chart (`charts/hermeum`) for Kubernetes. The only
+hard-required value is `secrets.databaseUrl` (`HERMEUM_DATABASE_URL`).
+
+```bash
+helm install hermeum oci://ghcr.io/hermeum/charts/hermeum \
+  --namespace hermeum --create-namespace \
+  --set secrets.databaseUrl=file:/var/lib/hermeum/db.sqlite \
+  --set secrets.betterAuthSecret=$(openssl rand -base64 32) \
+  --set secrets.smtpUrl=smtps://user:pass@mail.example.com:465 \
+  --set secrets.openaiApiKey=sk-...
+```
+
+For Postgres (horizontal scaling), set `config.databaseDialect=postgres` and a
+Postgres `secrets.databaseUrl`. See the
+[Installation guide](apps/docs/docs/operation/installation.md) and the
+[chart README](charts/hermeum/README.md) for the full reference.
+
+## Documentation
+
+| Document | Description |
+| --- | --- |
+| [What is Hermeum](apps/docs/docs/intro.md) | Overview of the platform and what an agent can do. |
+| [Getting started](apps/docs/docs/using-hermeum/getting-started.md) | Create, manage, and chat with your agents. |
+| [Creating an agent](apps/docs/docs/using-hermeum/creating-an-agent.md) | How to shape an agent's soul, models, and skills. |
+| [Messaging platforms](apps/docs/docs/using-hermeum/messaging-platforms.md) | Connect agents to Slack, Discord, Teams, and webhooks. |
+| [Shared env sets](apps/docs/docs/using-hermeum/shared-env-sets.md) | Reuse environment sets across agents. |
+| [Overview](apps/docs/docs/operation/overview.md) | Architecture and components for self-hosting. |
+| [Installation](apps/docs/docs/operation/installation.md) | Prerequisites, Helm install, database choice, upgrades. |
+| [Configuration reference](apps/docs/docs/operation/configuration-reference.md) | Full `HERMEUM_*` environment variable reference. |
+| [Instance config](apps/docs/docs/operation/instance-config.md) | `config.yaml` schema for templates and agent types. |
+| [Database](apps/docs/docs/operation/database.md) | SQLite vs Postgres, migrations, scaling. |
+| [Auth](apps/docs/docs/operation/auth.md) | Better Auth setup, secrets, email verification. |
+| [Mutating admission webhook](apps/docs/docs/operation/mutating-webhook.md) | Admission webhook behavior and TLS options. |
+| [Per-agent ingress and TLS](apps/docs/docs/operation/ingress-tls.md) | Ingress gateway and per-agent TLS. |
+
+## Contribution
+
+TBU
+
+## License
+
+[AGPL-3.0-or-later](LICENSE)

--- a/README.md
+++ b/README.md
@@ -7,10 +7,16 @@ powerful built-in capabilities, while Hermeum gives you a simple way to shape,
 run, and manage it.
 
 Describe what you want your agent to do, and Hermeum turns that into a working
-agent you can chat with, deploy, and iterate on. An agent can answer questions,
-research topics, browse the web, chat through Slack, Discord, Microsoft Teams,
-or a custom webhook, run tasks on a schedule, and expose an OpenAI-compatible
-API for other apps to use.
+agent you can chat with, deploy, and iterate on.
+
+## Features
+
+- **Tailor an agent by chat** — describe what your agent should do in natural
+  language and Hermeum generates the configuration for you.
+- **Templates** — create reusable agent templates for the agent shapes your
+  team uses most.
+- **Shared env sets** — share credentials (such as API keys) across agents
+  without re-entering them each time.
 
 ## Quick installation
 
@@ -33,23 +39,25 @@ Postgres `secrets.databaseUrl`. See the
 
 ## Documentation
 
-Full documentation is published at <https://docs.hermeum.app>.
+Full documentation is published at [here](https://docs.hermeum.app).
 
-| Document | Description |
-| --- | --- |
-| [What is Hermeum](https://docs.hermeum.app/) | Overview of the platform and what an agent can do. |
-| [Getting started](https://docs.hermeum.app/using-hermeum/getting-started/) | Create, manage, and chat with your agents. |
-| [Creating an agent](https://docs.hermeum.app/using-hermeum/creating-an-agent/) | How to shape an agent's soul, models, and skills. |
-| [Messaging platforms](https://docs.hermeum.app/using-hermeum/messaging-platforms/) | Connect agents to Slack, Discord, Teams, and webhooks. |
-| [Shared env sets](https://docs.hermeum.app/using-hermeum/shared-env-sets/) | Reuse environment sets across agents. |
-| [Overview](https://docs.hermeum.app/operation/overview/) | Architecture and components for self-hosting. |
-| [Installation](https://docs.hermeum.app/operation/installation/) | Prerequisites, Helm install, database choice, upgrades. |
-| [Configuration reference](https://docs.hermeum.app/operation/configuration-reference/) | Full `HERMEUM_*` environment variable reference. |
-| [Instance config](https://docs.hermeum.app/operation/instance-config/) | `config.yaml` schema for templates and agent types. |
-| [Database](https://docs.hermeum.app/operation/database/) | SQLite vs Postgres, migrations, scaling. |
-| [Auth](https://docs.hermeum.app/operation/auth/) | Better Auth setup, secrets, email verification. |
-| [Mutating admission webhook](https://docs.hermeum.app/operation/mutating-webhook/) | Admission webhook behavior and TLS options. |
-| [Per-agent ingress and TLS](https://docs.hermeum.app/operation/ingress-tls/) | Ingress gateway and per-agent TLS. |
+
+| Document                                                                               | Description                                             |
+| -------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| [What is Hermeum](https://docs.hermeum.app/)                                           | Overview of the platform and what an agent can do.      |
+| [Getting started](https://docs.hermeum.app/using-hermeum/getting-started/)             | Create, manage, and chat with your agents.              |
+| [Creating an agent](https://docs.hermeum.app/using-hermeum/creating-an-agent/)         | How to shape an agent's soul, models, and skills.       |
+| [Messaging platforms](https://docs.hermeum.app/using-hermeum/messaging-platforms/)     | Connect agents to Slack, Discord, Teams, and webhooks.  |
+| [Shared env sets](https://docs.hermeum.app/using-hermeum/shared-env-sets/)             | Reuse environment sets across agents.                   |
+| [Overview](https://docs.hermeum.app/operation/overview/)                               | Architecture and components for self-hosting.           |
+| [Installation](https://docs.hermeum.app/operation/installation/)                       | Prerequisites, Helm install, database choice, upgrades. |
+| [Configuration reference](https://docs.hermeum.app/operation/configuration-reference/) | Full `HERMEUM_*` environment variable reference.        |
+| [Instance config](https://docs.hermeum.app/operation/instance-config/)                 | `config.yaml` schema for templates and agent types.     |
+| [Database](https://docs.hermeum.app/operation/database/)                               | SQLite vs Postgres, migrations, scaling.                |
+| [Auth](https://docs.hermeum.app/operation/auth/)                                       | Better Auth setup, secrets, email verification.         |
+| [Mutating admission webhook](https://docs.hermeum.app/operation/mutating-webhook/)     | Admission webhook behavior and TLS options.             |
+| [Per-agent ingress and TLS](https://docs.hermeum.app/operation/ingress-tls/)           | Ingress gateway and per-agent TLS.                      |
+
 
 ## Contribution
 


### PR DESCRIPTION
## Summary

Adds a concise root `README.md` that acts as an index into the existing documentation.

## Sections

- **Hermeum** — short description of the platform, built on the open-source Hermes agent.
- **Features** — core features: tailor an agent by chat, templates, shared env sets, and powered by Kubernetes (mutating admission webhook).
- **Quick installation** — Helm install with prerequisites (Kubernetes + Helm 3.x), SQLite example, and a pointer to the full Installation guide.
- **Documentation** — table linking the core docs published at https://docs.hermeum.app.
- **Contribution** — TBU.
- **License** — AGPL-3.0-or-later.

The README intentionally stays brief; deeper setup and references live in the linked docs and the chart README.