### PR TITLE
fix(app): update docs sidebar link to docs.hermeum.app and rename label to Docs

### DIFF
--- a/apps/app/src/client/ui/components/app-sidebar.tsx
+++ b/apps/app/src/client/ui/components/app-sidebar.tsx
@@ -30,7 +30,7 @@ const agentNavItems = [
 ];
 
 const resourceNavItems = [
-  { to: "https://github.com/hermeum/hermeum" as const, label: "Documentation", icon: BookOpen },
+  { to: "https://docs.hermeum.app" as const, label: "Docs", icon: BookOpen },
 ];
 
 export function AppSidebar({ session }: { session: Session | null | undefined }) {


### PR DESCRIPTION
Updates the Resources sidebar item to point to `https://docs.hermeum.app` (the new Docusaurus site) instead of the GitHub repo, and renames its label from "Documentation" to "Docs".