### PR TITLE
ci: add Docker image and Helm chart release workflows

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,40 @@
+name: Docker Publish
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  build-and-push:
+    permissions:
+      contents: read
+      packages: write
+    name: Build and Push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Build and push multi-platform image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: dockerfiles/Dockerfile.app
+          platforms: linux/arm64,linux/amd64
+          push: true
+          tags: |
+            ghcr.io/hermeum/hermeum:${{ github.ref_name }}
+            ghcr.io/hermeum/hermeum:latest

--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -1,0 +1,54 @@
+name: Helm Publish
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  publish-chart:
+    permissions:
+      contents: read
+      packages: write
+    name: Publish Helm chart
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Log in to GHCR OCI registry
+        run: |
+          echo "${{ secrets.GHCR_TOKEN }}" | helm registry login ghcr.io \
+            --username ${{ github.actor }} \
+            --password-stdin
+
+      - name: Read chart version
+        id: chart
+        working-directory: charts/hermeum
+        run: |
+          VERSION=$(helm show chart . | awk '/^version:/{print $2}')
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Check version not already published
+        env:
+          VERSION: ${{ steps.chart.outputs.version }}
+        run: |
+          set +e
+          helm pull "oci://ghcr.io/hermeum/charts/hermeum" --version "${VERSION}" --destination /tmp/probe 2>/tmp/probe-err
+          RC=$?
+          if [ ${RC} -eq 0 ]; then
+            echo "::error::Chart version ${VERSION} is already published to ghcr.io/hermeum/charts/hermeum. Bump Chart.yaml version before re-running."
+            exit 1
+          fi
+          echo "Version ${VERSION} is not yet published — proceeding."
+
+      - name: Package and publish Helm chart
+        run: |
+          helm dependency build charts/hermeum
+          helm package charts/hermeum --destination dist/
+          helm push dist/hermeum-*.tgz oci://ghcr.io/hermeum/charts

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,35 @@
+name: PR Title
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - edited
+      # - synchronize (if you use required Actions)
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          requireScope: false


### PR DESCRIPTION
## Summary

Add two independent, manually triggered release pipelines plus a PR title linter.

### `.github/workflows/docker-publish.yml`
Builds `dockerfiles/Dockerfile.app` for `linux/arm64` + `linux/amd64` and pushes to GHCR:
- `ghcr.io/hermeum/hermeum:${{ github.ref_name }}`
- `ghcr.io/hermeum/hermeum:latest`

Trigger: `workflow_dispatch` (run from a tag ref like `v1.2.3`).

### `.github/workflows/helm-publish.yml`
Packages `charts/hermeum` and pushes the OCI chart to `ghcr.io/hermeum/charts`:
- Runs `helm dependency build` to fetch the `hermes-agent-operator` dependency.
- Packages and pushes with **no version override** — `version` and `appVersion` are read from `Chart.yaml` as committed. Bump them in-repo before triggering.
- Includes a pre-publish probe (`helm pull`) that fails fast with a clear `::error::` if the `Chart.yaml` version already exists in the registry, since OCI chart artifacts are immutable.

Trigger: `workflow_dispatch`. Independent of the Docker pipeline so a chart release can be cut without rebuilding the image.

### `.github/workflows/pr-title.yml`
Lints PR titles (follow-on from prior commit on this branch).

## Notes
- Both release workflows use `secrets.GHCR_TOKEN` (PAT with `write:packages` scope) — required for pushing OCI Helm artifacts.
- No changes to `ci.yml`, `Chart.yaml`, `values.yaml`, or any application code. No `Makefile` introduced.
- GHCR Docker tags are mutable (`:latest` gets repointed each run); OCI chart versions are immutable (bump `Chart.yaml` `version` per release).