### PR TITLE
ci: add Cloudflare Pages deploy workflow for docs

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,0 +1,50 @@
+name: Docs Deploy
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: docs-deploy-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Build and deploy to Cloudflare Pages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build docs
+        run: pnpm --filter @hermeum/docs build
+
+      - name: Deploy to Cloudflare Pages
+        id: deploy
+        uses: cloudflare/wrangler-action@v4
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy apps/docs/build --project-name=hermeum-docs
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Print deployment URL
+        env:
+          DEPLOYMENT_URL: ${{ steps.deploy.outputs.deployment-url }}
+        run: echo "Deployed to $DEPLOYMENT_URL"


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that builds the Docusaurus docs (`@hermeum/docs`) and deploys the static output to Cloudflare Pages.

- Trigger: manual only (`workflow_dispatch`) — no automatic deploys on push.
- Uses `cloudflare/wrangler-action@v4` (replaces the archived `cloudflare/pages-action`) with `wrangler pages deploy apps/docs/build --project-name=hermeum-docs`.
- Job-level `permissions` scoped to `contents: read` + `deployments: write` per the wrangler-action example.
- Concurrency group cancels stale manual runs for the same ref.
- Prints the resulting `deployment-url` from the wrangler step output.

## Required repo secrets

| Secret | Value |
| --- | --- |
| `CLOUDFLARE_API_TOKEN` | Cloudflare API token with **Cloudflare Pages — Edit** permission |
| `CLOUDFLARE_ACCOUNT_ID` | Cloudflare account ID |

`GITHUB_TOKEN` is supplied automatically by Actions.

## Prerequisites

The `hermeum-docs` Pages project must already exist in the Cloudflare account (per `plans/docs-hosting-plan.md`). This workflow deploys into that existing project; it does not create it.

## Test plan

- [x] Add `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` secrets to the repo.
- [x] Confirm the `hermeum-docs` Pages project exists in Cloudflare.
- [x] Run the workflow via Actions → "Docs Deploy" → "Run workflow".
- [x] Verify the deployment URL printed in the logs resolves and serves `https://docs.hermeum.app`.