### PR TITLE
ci: trigger Cloudflare Pages build via deploy hook instead of building in GitHub Actions

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -9,42 +9,23 @@ concurrency:
 
 jobs:
   deploy:
-    name: Build and deploy to Cloudflare Pages
+    name: Trigger Cloudflare Pages build
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      deployments: write
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build docs
-        run: pnpm --filter @hermeum/docs build
-
-      - name: Deploy to Cloudflare Pages
-        id: deploy
-        uses: cloudflare/wrangler-action@v4
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy apps/docs/build --project-name=hermeum-docs
-          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Print deployment URL
+      - name: Trigger Cloudflare Pages deploy hook
         env:
-          DEPLOYMENT_URL: ${{ steps.deploy.outputs.deployment-url }}
-        run: echo "Deployed to $DEPLOYMENT_URL"
+          CLOUDFLARE_PAGES_DEPLOY_HOOK_URL: ${{ secrets.CLOUDFLARE_PAGES_DEPLOY_HOOK_URL }}
+        run: |
+          if [ -z "$CLOUDFLARE_PAGES_DEPLOY_HOOK_URL" ]; then
+            echo "::error::CLOUDFLARE_PAGES_DEPLOY_HOOK_URL secret is not set. Create a deploy hook in the Cloudflare dashboard (Pages > hermeum-docs > Settings > Builds & deployments > Deploy hooks) and add its URL as a repository secret." 
+            exit 1
+          fi
+
+          echo "Triggering Cloudflare Pages deploy hook..."
+          response=$(curl --fail --silent --show-error \
+            --request POST \
+            --url "$CLOUDFLARE_PAGES_DEPLOY_HOOK_URL" \
+            --header 'Content-Type: application/json')
+
+          echo "Cloudflare response: $response"
+          echo "✅ Cloudflare Pages build triggered. The deployment will be built and deployed on Cloudflare's infrastructure."


### PR DESCRIPTION
## Summary

- Replace the `wrangler-action`-based deploy (which built docs in GitHub Actions and uploaded the `dist`) with a **deploy-hook POST**, so Cloudflare pulls the repo and builds on its own infrastructure.
- Add a clear `::error::` message when the `CLOUDFLARE_PAGES_DEPLOY_HOOK_URL` secret is missing, explaining exactly where to create the hook and add it as a secret — replacing the cryptic `ERR_PNPM_ADDING_TO_ROOT` / `wrangler not found` failure chain.

## Why

The previous workflow ran `pnpm`/`wrangler` inside GitHub Actions to build `@hermeum/docs` and upload the output. That requires maintaining a working toolchain in CI and surfaced a confusing error when wrangler wasn\'t resolvable from the workspace root. Per the [wrangler-action README](https://github.com/cloudflare/wrangler-action), `wrangler-action` is the *alternative* to Cloudflare\'s built-in CI — for letting Cloudflare build it, a deploy hook is the intended mechanism.

## Setup required

1. Connect the GitHub repo to the `hermeum-docs` Pages project in the Cloudflare dashboard (Settings → Builds & deployments) so Cloudflare knows how to build it.
2. Create a deploy hook (Pages → `hermeum-docs` → Settings → Builds & deployments → Deploy hooks) and copy the URL.
3. Add the URL as the repository secret `CLOUDFLARE_PAGES_DEPLOY_HOOK_URL`.

## Test plan

- [x] Confirm `CLOUDFLARE_PAGES_DEPLOY_HOOK_URL` is set in repo secrets.
- [x] Trigger the workflow via `workflow_dispatch` and verify the hook POST succeeds.
- [x] Confirm a new Pages deployment appears in the Cloudflare dashboard and builds on Cloudflare\'s infra.