### PR TITLE
feat(ui): show available agent types and skills as UI pickers in the agent editor

### DIFF
--- a/apps/app/src/client/ui/routes/agents/$id/edit.tsx
+++ b/apps/app/src/client/ui/routes/agents/$id/edit.tsx
@@ -17,6 +17,7 @@ import type { AgentInput } from "@/entities";
 import { AgentConfigChat } from "@/client/ui/components/agent-config-chat";
 import { CodeEditor } from "@/client/ui/components/code-editor";
 import { AgentEditorMobileTabs } from "../-components/agent-editor-mobile-tabs";
+import { AgentPickerBar } from "../-components/agent-picker-bar";
 
 const YAML_OPTIONS = { blockQuote: "literal", lineWidth: 0 } as const;
 
@@ -81,6 +82,14 @@ function EditAgentPage() {
     setValidationError(null);
   }
 
+  // Merge a user-managed-field patch (agent type / skills) into the current
+  // draft.
+  function handlePickerChange(patch: { type?: string | undefined; skills?: string[] | undefined }) {
+    const current = getConfig();
+    if (current === undefined) return;
+    handleConfigUpdate({ ...current, ...patch });
+  }
+
   const editChatProps = {
     getConfig,
     onConfigUpdate: handleConfigUpdate,
@@ -117,6 +126,7 @@ function EditAgentPage() {
   const configPane: ReactNode = (
     <div className="flex min-h-0 flex-1 flex-col gap-2">
       <p className="shrink-0 text-sm font-medium">Agent config</p>
+      <AgentPickerBar config={getConfig()} onChange={handlePickerChange} />
       <div className="min-h-0 flex-1">
         <CodeEditor
           value={editorValue}

--- a/apps/app/src/client/ui/routes/agents/-components/agent-picker-bar.tsx
+++ b/apps/app/src/client/ui/routes/agents/-components/agent-picker-bar.tsx
@@ -103,8 +103,14 @@ function SkillsPicker({
     return () => clearTimeout(t);
   }, [input]);
 
+  // Search only while the picker is open — no requests at initialization, and
+  // reopening refetches against the live index. keepPreviousData keeps the
+  // last result set rendered (checkmarks stable) while a new query streams in.
   const { data: skills = [], isFetching } = useQuery(
-    trpc.skill.search.queryOptions({ query }, { placeholderData: keepPreviousData })
+    trpc.skill.search.queryOptions(
+      { query },
+      { enabled: open, placeholderData: keepPreviousData }
+    )
   );
 
   const selected = value ?? [];

--- a/apps/app/src/client/ui/routes/agents/-components/agent-picker-bar.tsx
+++ b/apps/app/src/client/ui/routes/agents/-components/agent-picker-bar.tsx
@@ -1,8 +1,7 @@
 import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { Check, Plus, X } from "lucide-react";
+import { Check, Plus } from "lucide-react";
 
-import { Badge } from "@hermeum/components/ui/badge";
 import { Button } from "@hermeum/components/ui/button";
 import { Input } from "@hermeum/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@hermeum/components/ui/popover";
@@ -106,13 +105,8 @@ function SkillsPicker({
     }
   }
 
-  function remove(identifier: string) {
-    const next = selected.filter((s) => s !== identifier);
-    onChange(next.length > 0 ? next : undefined);
-  }
-
   return (
-    <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
+    <div className="flex min-w-0 flex-1 items-center gap-1.5">
       <span className="text-xs font-semibold tracking-widest text-muted-foreground uppercase">
         Skills
       </span>
@@ -127,7 +121,7 @@ function SkillsPicker({
           }
         >
           <Plus />
-          Add skill
+          {selected.length > 0 ? `Skills (${selected.length})` : "Add skill"}
         </PopoverTrigger>
         <PopoverContent align="start" className="flex w-80 flex-col gap-1 p-1">
           <Input
@@ -169,23 +163,6 @@ function SkillsPicker({
           </ScrollArea>
         </PopoverContent>
       </Popover>
-      {selected.map((identifier) => (
-        <Badge
-          key={identifier}
-          render={
-            <button
-              type="button"
-              aria-label={`Remove skill ${identifier}`}
-              onClick={() => remove(identifier)}
-              className="cursor-pointer font-mono"
-            />
-          }
-          className="max-w-48 gap-0.5 truncate font-mono text-[0.6875rem] normal-case tracking-normal"
-        >
-          <span className="truncate">{identifier}</span>
-          <X />
-        </Badge>
-      ))}
     </div>
   );
 }

--- a/apps/app/src/client/ui/routes/agents/-components/agent-picker-bar.tsx
+++ b/apps/app/src/client/ui/routes/agents/-components/agent-picker-bar.tsx
@@ -1,0 +1,209 @@
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Check, Plus, X } from "lucide-react";
+
+import { Badge } from "@hermeum/components/ui/badge";
+import { Button } from "@hermeum/components/ui/button";
+import { Input } from "@hermeum/components/ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@hermeum/components/ui/popover";
+import { ScrollArea } from "@hermeum/components/ui/scroll-area";
+import { useTRPC } from "@/router";
+import type { AgentInput } from "@/entities";
+
+const MAX_SKILLS = 20;
+
+// Popover listing the configured agent types (key + description).
+// Single-select: picking a type replaces the current one; picking the
+// selected type again clears it. Returns the picked key via `onChange`
+// (undefined = cleared).
+function AgentTypePicker({
+  value,
+  onChange,
+}: {
+  value: string | undefined;
+  onChange: (key: string | undefined) => void;
+}) {
+  const trpc = useTRPC();
+  const { data: agentTypes = [] } = useQuery(trpc.agentType.list.queryOptions());
+
+  const selected = agentTypes.find((t) => t.key === value);
+
+  return (
+    <div className="flex items-center gap-1.5">
+      <span className="text-xs font-semibold tracking-widest text-muted-foreground uppercase">
+        Type
+      </span>
+      <Popover>
+        <PopoverTrigger
+          render={
+            <Button
+              variant="outline"
+              size="xs"
+              className="h-auto px-2 py-1 font-mono text-xs normal-case tracking-normal"
+            />
+          }
+        >
+          {selected ? selected.key : <span className="text-muted-foreground">None</span>}
+        </PopoverTrigger>
+        <PopoverContent align="start" className="flex flex-col gap-0.5 p-1">
+          {agentTypes.length === 0 ? (
+            <p className="px-2 py-1.5 text-xs opacity-80">No agent types configured.</p>
+          ) : (
+            agentTypes.map((t) => (
+              <button
+                key={t.key}
+                type="button"
+                className="flex w-full items-start gap-2 rounded-none px-2 py-1.5 text-left text-xs hover:bg-background/20"
+                onClick={() => onChange(value === t.key ? undefined : t.key)}
+              >
+                <Check
+                  className={`mt-0.5 size-3 shrink-0 ${value === t.key ? "" : "invisible"}`}
+                />
+                <span className="min-w-0">
+                  <span className="font-mono">{t.key}</span>
+                  {t.description && (
+                    <span className="block opacity-80">{t.description}</span>
+                  )}
+                </span>
+              </button>
+            ))
+          )}
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}
+
+// Searchable multi-select popover over the curated Hermes skills index.
+// Selected skills are also rendered as dismissible badges next to the trigger.
+function SkillsPicker({
+  value,
+  onChange,
+}: {
+  value: string[] | undefined;
+  onChange: (skills: string[] | undefined) => void;
+}) {
+  const trpc = useTRPC();
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const { data: skills = [] } = useQuery(trpc.skill.list.queryOptions());
+
+  const selected = value ?? [];
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (q === "") return skills;
+    return skills.filter((s) =>
+      [s.name, s.identifier, s.description].some((field) => field.toLowerCase().includes(q))
+    );
+  }, [skills, search]);
+
+  function toggle(identifier: string) {
+    if (selected.includes(identifier)) {
+      const next = selected.filter((s) => s !== identifier);
+      onChange(next.length > 0 ? next : undefined);
+    } else if (selected.length < MAX_SKILLS) {
+      onChange([...selected, identifier]);
+    }
+  }
+
+  function remove(identifier: string) {
+    const next = selected.filter((s) => s !== identifier);
+    onChange(next.length > 0 ? next : undefined);
+  }
+
+  return (
+    <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
+      <span className="text-xs font-semibold tracking-widest text-muted-foreground uppercase">
+        Skills
+      </span>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger
+          render={
+            <Button
+              variant="outline"
+              size="xs"
+              className="h-auto px-2 py-1 text-xs normal-case tracking-normal"
+            />
+          }
+        >
+          <Plus />
+          Add skill
+        </PopoverTrigger>
+        <PopoverContent align="start" className="flex w-80 flex-col gap-1 p-1">
+          <Input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search skills…"
+            className="h-7 border-b-foreground/30 text-xs placeholder:opacity-70"
+          />
+          <ScrollArea className="max-h-64">
+            <div className="flex flex-col gap-0.5">
+              {filtered.length === 0 ? (
+                <p className="px-2 py-1.5 text-xs opacity-80">
+                  {skills.length === 0 ? "Skill index unavailable." : "No matching skills."}
+                </p>
+              ) : (
+                filtered.map((s) => (
+                  <button
+                    key={s.identifier}
+                    type="button"
+                    className="flex w-full items-start gap-2 rounded-none px-2 py-1.5 text-left text-xs hover:bg-background/20"
+                    title={s.identifier}
+                    onClick={() => toggle(s.identifier)}
+                  >
+                    <Check
+                      className={`mt-0.5 size-3 shrink-0 ${
+                        selected.includes(s.identifier) ? "" : "invisible"
+                      }`}
+                    />
+                    <span className="min-w-0">
+                      <span className="font-mono">{s.name}</span>
+                      {s.description && (
+                        <span className="block opacity-80">{s.description}</span>
+                      )}
+                    </span>
+                  </button>
+                ))
+              )}
+            </div>
+          </ScrollArea>
+        </PopoverContent>
+      </Popover>
+      {selected.map((identifier) => (
+        <Badge
+          key={identifier}
+          render={
+            <button
+              type="button"
+              aria-label={`Remove skill ${identifier}`}
+              onClick={() => remove(identifier)}
+              className="cursor-pointer font-mono"
+            />
+          }
+          className="max-w-48 gap-0.5 truncate font-mono text-[0.6875rem] normal-case tracking-normal"
+        >
+          <span className="truncate">{identifier}</span>
+          <X />
+        </Badge>
+      ))}
+    </div>
+  );
+}
+
+// Bar rendered above the agent config editor. Edits the draft's user-managed
+// fields (`type`, `skills`) directly; the YAML editor and chat stay in sync
+// through the same `onChange` path as hand edits.
+export function AgentPickerBar({
+  config,
+  onChange,
+}: {
+  config: AgentInput | undefined;
+  onChange: (patch: { type?: string | undefined; skills?: string[] | undefined }) => void;
+}) {
+  return (
+    <div className="flex shrink-0 flex-wrap items-center gap-x-4 gap-y-1.5">
+      <AgentTypePicker value={config?.type} onChange={(type) => onChange({ type })} />
+      <SkillsPicker value={config?.skills} onChange={(skills) => onChange({ skills })} />
+    </div>
+  );
+}

--- a/apps/app/src/client/ui/routes/agents/-components/agent-picker-bar.tsx
+++ b/apps/app/src/client/ui/routes/agents/-components/agent-picker-bar.tsx
@@ -1,15 +1,18 @@
-import { useMemo, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
-import { Check, Plus } from "lucide-react";
+import { useEffect, useState } from "react";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { Check, LoaderCircle, Plus } from "lucide-react";
 
 import { Button } from "@hermeum/components/ui/button";
 import { Input } from "@hermeum/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@hermeum/components/ui/popover";
-import { ScrollArea } from "@hermeum/components/ui/scroll-area";
 import { useTRPC } from "@/router";
 import type { AgentInput } from "@/entities";
 
 const MAX_SKILLS = 20;
+
+// Debounce window for the skills search input, so typing a keyword doesn't
+// fire a request per keystroke.
+const SEARCH_DEBOUNCE_MS = 300;
 
 // Popover listing the configured agent types (key + description).
 // Single-select: picking a type replaces the current one; picking the
@@ -44,11 +47,12 @@ function AgentTypePicker({
         >
           {selected ? selected.key : <span className="text-muted-foreground">None</span>}
         </PopoverTrigger>
-        <PopoverContent align="start" className="flex flex-col gap-0.5 p-1">
+        <PopoverContent align="start" className="w-fit min-w-48 p-1">
           {agentTypes.length === 0 ? (
             <p className="px-2 py-1.5 text-xs opacity-80">No agent types configured.</p>
           ) : (
-            agentTypes.map((t) => (
+            <div className={`flex flex-col gap-0.5 ${LIST_MAX_H}`}>
+            {agentTypes.map((t) => (
               <button
                 key={t.key}
                 type="button"
@@ -65,7 +69,8 @@ function AgentTypePicker({
                   )}
                 </span>
               </button>
-            ))
+            ))}
+            </div>
           )}
         </PopoverContent>
       </Popover>
@@ -73,8 +78,10 @@ function AgentTypePicker({
   );
 }
 
-// Searchable multi-select popover over the curated Hermes skills index.
-// Selected skills are also rendered as dismissible badges next to the trigger.
+// Keyword-search multi-select popover over the curated Hermes skills index.
+// Searches server-side on typed keywords (debounced) rather than listing the
+// whole index at open; an empty query shows the featured list. Selections
+// made from earlier searches stay selected via checkmarks.
 function SkillsPicker({
   value,
   onChange,
@@ -84,17 +91,20 @@ function SkillsPicker({
 }) {
   const trpc = useTRPC();
   const [open, setOpen] = useState(false);
-  const [search, setSearch] = useState("");
-  const { data: skills = [] } = useQuery(trpc.skill.list.queryOptions());
+  const [input, setInput] = useState("");
+  const [query, setQuery] = useState("");
+
+  // Debounce the raw input into the actual search keyword.
+  useEffect(() => {
+    const t = setTimeout(() => setQuery(input.trim()), SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(t);
+  }, [input]);
+
+  const { data: skills = [], isFetching } = useQuery(
+    trpc.skill.search.queryOptions({ query }, { placeholderData: keepPreviousData })
+  );
 
   const selected = value ?? [];
-  const filtered = useMemo(() => {
-    const q = search.trim().toLowerCase();
-    if (q === "") return skills;
-    return skills.filter((s) =>
-      [s.name, s.identifier, s.description].some((field) => field.toLowerCase().includes(q))
-    );
-  }, [skills, search]);
 
   function toggle(identifier: string) {
     if (selected.includes(identifier)) {
@@ -105,12 +115,20 @@ function SkillsPicker({
     }
   }
 
+  function handleOpenChange(nextOpen: boolean) {
+    setOpen(nextOpen);
+    if (!nextOpen) {
+      setInput("");
+      setQuery("");
+    }
+  }
+
   return (
     <div className="flex min-w-0 flex-1 items-center gap-1.5">
       <span className="text-xs font-semibold tracking-widest text-muted-foreground uppercase">
         Skills
       </span>
-      <Popover open={open} onOpenChange={setOpen}>
+      <Popover open={open} onOpenChange={handleOpenChange}>
         <PopoverTrigger
           render={
             <Button
@@ -123,21 +141,21 @@ function SkillsPicker({
           <Plus />
           {selected.length > 0 ? `Skills (${selected.length})` : "Add skill"}
         </PopoverTrigger>
-        <PopoverContent align="start" className="flex w-80 flex-col gap-1 p-1">
+        <PopoverContent align="start" className="flex w-80 flex-col p-1">
           <Input
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            placeholder="Search skills…"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder="Search skills by keyword…"
             className="h-7 border-b-foreground/30 text-xs placeholder:opacity-70"
           />
-          <ScrollArea className="max-h-64">
+          <div className="relative mt-1 max-h-64 overflow-y-auto">
             <div className="flex flex-col gap-0.5">
-              {filtered.length === 0 ? (
+              {!isFetching && skills.length === 0 ? (
                 <p className="px-2 py-1.5 text-xs opacity-80">
-                  {skills.length === 0 ? "Skill index unavailable." : "No matching skills."}
+                  {query === "" ? "Skill index unavailable." : "No matching skills."}
                 </p>
               ) : (
-                filtered.map((s) => (
+                skills.map((s) => (
                   <button
                     key={s.identifier}
                     type="button"
@@ -160,7 +178,12 @@ function SkillsPicker({
                 ))
               )}
             </div>
-          </ScrollArea>
+            {isFetching && (
+              <div className="flex justify-center py-2">
+                <LoaderCircle className="size-3 animate-spin text-muted-foreground" />
+              </div>
+            )}
+          </div>
         </PopoverContent>
       </Popover>
     </div>

--- a/apps/app/src/client/ui/routes/agents/-components/agent-picker-bar.tsx
+++ b/apps/app/src/client/ui/routes/agents/-components/agent-picker-bar.tsx
@@ -10,6 +10,9 @@ import type { AgentInput } from "@/entities";
 
 const MAX_SKILLS = 20;
 
+// Max height of the scrollable item list inside a picker popover.
+const LIST_MAX_H = "max-h-64 overflow-y-auto";
+
 // Debounce window for the skills search input, so typing a keyword doesn't
 // fire a request per keystroke.
 const SEARCH_DEBOUNCE_MS = 300;

--- a/apps/app/src/client/ui/routes/agents/new.tsx
+++ b/apps/app/src/client/ui/routes/agents/new.tsx
@@ -18,6 +18,7 @@ import type { AgentInput, Template } from "@/entities";
 import { AgentConfigChat } from "@/client/ui/components/agent-config-chat";
 import { CodeEditor } from "@/client/ui/components/code-editor";
 import { AgentEditorMobileTabs } from "./-components/agent-editor-mobile-tabs";
+import { AgentPickerBar } from "./-components/agent-picker-bar";
 
 const YAML_OPTIONS = { blockQuote: "literal", lineWidth: 0 } as const;
 
@@ -75,6 +76,15 @@ function NewAgentPage() {
 
   function handleUseTemplate(template: Template) {
     handleConfigUpdate(template.agentInput);
+  }
+
+  // Merge a user-managed-field patch (agent type / skills) into the current
+  // draft. No-op when editing hasn't started — pickers appear once a draft
+  // exists.
+  function handlePickerChange(patch: { type?: string | undefined; skills?: string[] | undefined }) {
+    const current = getConfig();
+    if (current === undefined) return;
+    handleConfigUpdate({ ...current, ...patch });
   }
 
   function handleCreate() {
@@ -167,6 +177,7 @@ function NewAgentPage() {
     return (
       <div className="flex min-h-0 flex-1 flex-col gap-2">
         <p className="shrink-0 text-sm font-medium">Agent config</p>
+        <AgentPickerBar config={getConfig()} onChange={handlePickerChange} />
         <div className="min-h-0 flex-1">
           <CodeEditor
             value={editorValue}

--- a/apps/app/src/entities/agent-type.ts
+++ b/apps/app/src/entities/agent-type.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+// Agent type entity: the key format for configured agent types and the
+// picker-facing summary shape. Agent types are defined in Hermeum's own
+// configuration (see hermeum-config.ts); agents reference them by `type` key.
+
+export const AgentTypeKeySchema = z
+  .string()
+  .min(1)
+  .max(128, "Agent type key exceeds maximum length of 128 characters")
+  .regex(
+    /^[a-z0-9]+(-[a-z0-9]+)*$/,
+    'Agent type key must be a slug: lowercase letters, digits, and hyphens (e.g. "email-triage").'
+  );
+
+export type AgentTypeKey = z.infer<typeof AgentTypeKeySchema>;
+
+export const AgentTypeSummarySchema = z.object({
+  key: AgentTypeKeySchema,
+  description: z.string().optional(),
+});
+
+export type AgentTypeSummary = z.infer<typeof AgentTypeSummarySchema>;

--- a/apps/app/src/entities/agent.test.ts
+++ b/apps/app/src/entities/agent.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from "vitest";
 import { z } from "zod";
 
-import { AgentInputObjectSchema, AgentInputSchema, SkillSchema, isApiServerEnabled, getApiServerPort, isWebhookEnabled, getWebhookPort, isTeamsEnabled, getTeamsPort, ToolsetId, deriveToolsetAvailability, PlatformId, derivePlatformAvailability, type Agent } from "./agent";
+import { AgentInputObjectSchema, AgentInputSchema, isApiServerEnabled, getApiServerPort, isWebhookEnabled, getWebhookPort, isTeamsEnabled, getTeamsPort, ToolsetId, deriveToolsetAvailability, PlatformId, derivePlatformAvailability, type Agent } from "./agent";
+import { SkillIdentifierSchema } from "./skill";
 
 function makeInput(overrides: Record<string, unknown> = {}) {
   return {
@@ -598,7 +599,7 @@ describe("AgentInputSchema crons validation", () => {
     expect(result.success).toBe(false);
   });
 
-  it("accepts loose skill strings that would fail the strict top-level SkillSchema", () => {
+  it("accepts loose skill strings that would fail the strict top-level SkillIdentifierSchema", () => {
     const result = AgentInputSchema.safeParse({
       crons: [makeCron({ skills: ["bad skill!"] })],
     });
@@ -632,7 +633,7 @@ describe("AgentInputObjectSchema as LLM structured-output schema", () => {
   });
 });
 
-describe("SkillSchema identifier formats", () => {
+describe("SkillIdentifierSchema identifier formats", () => {
   // https://hermes-agent.nousresearch.com/docs/user-guide/features/skills#supported-hub-sources
 
   const valid: string[] = [
@@ -657,7 +658,7 @@ describe("SkillSchema identifier formats", () => {
   ];
 
   it.each(valid)("accepts %s", (identifier) => {
-    expect(SkillSchema.safeParse(identifier).success).toBe(true);
+    expect(SkillIdentifierSchema.safeParse(identifier).success).toBe(true);
   });
 
   const invalid: string[] = [
@@ -681,17 +682,17 @@ describe("SkillSchema identifier formats", () => {
   ];
 
   it.each(invalid)("rejects %s", (identifier) => {
-    const result = SkillSchema.safeParse(identifier);
+    const result = SkillIdentifierSchema.safeParse(identifier);
     expect(result.success).toBe(false);
   });
 
   it("rejects a skill exceeding 128 characters", () => {
-    const result = SkillSchema.safeParse("a".repeat(129));
+    const result = SkillIdentifierSchema.safeParse("a".repeat(129));
     expect(result.success).toBe(false);
   });
 
   it("accepts a 128-character skill", () => {
-    const result = SkillSchema.safeParse("a".repeat(128));
+    const result = SkillIdentifierSchema.safeParse("a".repeat(128));
     expect(result.success).toBe(true);
   });
 });

--- a/apps/app/src/entities/agent/schema.ts
+++ b/apps/app/src/entities/agent/schema.ts
@@ -2,6 +2,11 @@ import { z } from "zod";
 
 import { ConfigSchema } from "../hermes-config";
 import { EnvVarSchema } from "../shared-env-set";
+import { AgentTypeKeySchema } from "../agent-type";
+import {
+  SkillIdentifiersSchema,
+  SkillIdentifier,
+} from "../skill";
 
 import { isApiServerEnabled, isTeamsEnabled, isWebhookEnabled } from "./platform";
 
@@ -78,180 +83,7 @@ instructions (those belong elsewhere in the config).
 
 export type Soul = z.infer<typeof SoulSchema>;
 
-// https://hermes-agent.nousresearch.com/docs/user-guide/features/skills#supported-hub-sources
-const SKILL_SOURCE_PREFIXES = [
-  "official/",
-  "skills-sh/",
-  "browse-sh/",
-  "clawhub/",
-  "lobehub/",
-  "claude-marketplace/",
-] as const;
-
-const SKILL_NAMESPACE_PREFIXES = ["npm:", "pack:"] as const;
-
-const SIMPLE_SLUG_RE = /^[a-zA-Z][a-zA-Z0-9_-]*$/;
-const PATH_SEGMENT_RE = /^[a-zA-Z0-9.][a-zA-Z0-9._-]*$/;
-
-function isHttpUrl(value: string): boolean {
-  try {
-    const url = new URL(value);
-    return url.protocol === "http:" || url.protocol === "https:";
-  } catch {
-    return false;
-  }
-}
-
-function validateSkillIdentifier(s: string, ctx: z.RefinementCtx): void {
-  if (s.length === 0) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: "Skill identifier cannot be empty.",
-      path: [],
-    });
-    return;
-  }
-
-  // Prefixed namespace forms: "npm:@scope/pkg", "pack:./local/skill"
-  const nsPrefix = SKILL_NAMESPACE_PREFIXES.find((p) => s.startsWith(p));
-  if (nsPrefix !== undefined) {
-    const rest = s.slice(nsPrefix.length);
-    if (rest.length === 0) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: `Skill cannot be a bare "${nsPrefix}" prefix — a package identifier must follow.`,
-        path: [],
-      });
-    } else if (!/^[^\s]+$/.test(rest)) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: `Skill "${s}" has whitespace in the package specifier after "${nsPrefix}".`,
-        path: [],
-      });
-    }
-    return;
-  }
-
-  // URL form: "well-known:<url>" or a bare http(s) URL
-  if (s.startsWith("well-known:")) {
-    const rest = s.slice("well-known:".length);
-    if (!isHttpUrl(rest)) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message:
-          'well-known: skills must be followed by a valid http(s) URL, e.g. ' +
-          '"well-known:https://mintlify.com/docs/.well-known/skills/mintlify".',
-        path: [],
-      });
-    }
-    return;
-  }
-
-  if (s.startsWith("http://") || s.startsWith("https://")) {
-    if (!isHttpUrl(s)) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "Direct-URL skills must be valid http(s) URLs.",
-        path: [],
-      });
-    }
-    return;
-  }
-
-  // Source-prefixed path forms: "official/...", "skills-sh/...", etc.
-  const srcPrefix = SKILL_SOURCE_PREFIXES.find((p) => s.startsWith(p));
-  if (srcPrefix !== undefined) {
-    const rest = s.slice(srcPrefix.length);
-    if (rest.length === 0) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message:
-          `Skill cannot be a bare "${srcPrefix}" prefix — at least two path segments must follow, ` +
-          `e.g. "${srcPrefix}category/skill-name".`,
-        path: [],
-      });
-      return;
-    }
-    const segments = rest.split("/");
-    if (segments.length < 2) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message:
-          `Skill "${s}" needs at least two path segments after "${srcPrefix}", ` +
-          `e.g. "${srcPrefix}category/skill-name".`,
-        path: [],
-      });
-      return;
-    }
-    const bad = segments.find((seg) => !PATH_SEGMENT_RE.test(seg));
-    if (bad !== undefined) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message:
-          `Skill "${s}" has an invalid path segment "${bad}" after "${srcPrefix}". ` +
-          'Segments must start with an alphanumeric character (or "." for hidden dirs) and may contain alphanumerics, ".", "-", and "_".',
-        path: [],
-      });
-    }
-    return;
-  }
-
-  // GitHub-style path: "owner/repo/..." — ≥2 non-empty segments
-  if (s.includes("/")) {
-    if (s.startsWith("/") || s.endsWith("/")) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: 'Skill paths must not start or end with "/", e.g. "openai/skills/k8s".',
-        path: [],
-      });
-      return;
-    }
-    const segments = s.split("/");
-    const bad = segments.find((seg) => !PATH_SEGMENT_RE.test(seg));
-    if (bad !== undefined) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message:
-          `Skill "${s}" has an invalid path segment "${bad}". ` +
-          'Segments must start with an alphanumeric character (or "." for hidden dirs) and may contain alphanumerics, ".", "-", and "_".',
-        path: [],
-      });
-      return;
-    }
-    // ≥2 well-formed segments is a valid GitHub-style install path
-    return;
-  }
-
-  // Simple slug — the only no-slash form we accept
-  if (SIMPLE_SLUG_RE.test(s)) return;
-
-  ctx.addIssue({
-    code: z.ZodIssueCode.custom,
-    message:
-      `Skill "${s}" is not a recognized identifier format. Expected a simple slug ("axolotl"), ` +
-      'a namespace prefix ("npm:@scope/pkg"), a hub-source path ("official/category/skill-name", ' +
-      '"skills-sh/owner/repo/skill", "browse-sh/host/task-id"), a GitHub path ("openai/skills/k8s"), ' +
-      'a well-known endpoint ("well-known:https://example.com/.well-known/skills/x"), or a direct URL ' +
-      '("https://example.com/SKILL.md").',
-    path: [],
-  });
-}
-
-export const SkillSchema = z
-  .string()
-  .min(1)
-  .max(128, "Skill exceeds maximum length of 128 characters")
-  .superRefine(validateSkillIdentifier);
-
-export type Skill = string;
-
-export const SkillsSchema = z
-  .array(SkillSchema)
-  .max(20)
-  .optional()
-  .describe("Skill identifiers to install.");
-
-export type Skills = z.infer<typeof SkillsSchema>;
+export type Skill = SkillIdentifier;
 
 export const PluginsSchema = z
   .array(z.string())
@@ -450,11 +282,11 @@ export const AgentInputObjectSchema = z.object({
     .string()
     .optional()
     .describe("One or two sentences describing what the agent does."),
-  type: z.string().optional().describe("Agent type key from the configured agent types."),
+  type: AgentTypeKeySchema.optional().describe("Agent type key from the configured agent types."),
   soul: SoulSchema,
   config: ConfigSchema,
   env: EnvSchema,
-  skills: SkillsSchema,
+  skills: SkillIdentifiersSchema,
   plugins: PluginsSchema,
   packages: PackagesSchema,
   crons: CronsSchema,

--- a/apps/app/src/entities/hermeum-config.ts
+++ b/apps/app/src/entities/hermeum-config.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { TemplateSchema } from "./template";
+import { AgentTypeKeySchema } from "./agent-type";
 
 export const JsonPatchOpSchema = z.object({
   op: z.enum(["add", "remove", "replace", "move", "copy", "test"]),
@@ -27,16 +28,16 @@ export const MutatingWebhookJsonPatchSchema = z
 
 export type MutatingWebhookJsonPatch = z.infer<typeof MutatingWebhookJsonPatchSchema>;
 
-export const AgentTypeSchema = z.object({
+export const AgentTypeConfigSchema = z.object({
   description: z.string().optional(),
   mutatingWebhookJsonPatch: MutatingWebhookJsonPatchSchema,
 });
 
-export type AgentType = z.infer<typeof AgentTypeSchema>;
+export type AgentTypeConfig = z.infer<typeof AgentTypeConfigSchema>;
 
 export const HermeumConfigSchema = z
   .object({
-    agentTypes: z.record(z.string(), AgentTypeSchema).optional(),
+    agentTypes: z.record(AgentTypeKeySchema, AgentTypeConfigSchema).optional(),
     templates: z.array(TemplateSchema),
   })
   .superRefine((data, ctx) => {

--- a/apps/app/src/entities/index.ts
+++ b/apps/app/src/entities/index.ts
@@ -1,5 +1,7 @@
 export * from "./auth";
 export * from "./agent";
+export * from "./agent-type";
+export * from "./skill";
 export * from "./template";
 export * from "./hermeum-config";
 export * from "./shared-env-set";

--- a/apps/app/src/entities/skill.ts
+++ b/apps/app/src/entities/skill.ts
@@ -1,0 +1,190 @@
+import { z } from "zod";
+
+// Skill entity: identifier validation (shared by agent configs), plus the
+// picker-facing summary shape the skill index adaptor projects entries to.
+// The raw index entry stays infra-internal (snake_case, upstream-shaped).
+
+// https://hermes-agent.nousresearch.com/docs/user-guide/features/skills#supported-hub-sources
+const SKILL_SOURCE_PREFIXES = [
+  "official/",
+  "skills-sh/",
+  "browse-sh/",
+  "clawhub/",
+  "lobehub/",
+  "claude-marketplace/",
+] as const;
+
+const SKILL_NAMESPACE_PREFIXES = ["npm:", "pack:"] as const;
+
+const SIMPLE_SLUG_RE = /^[a-zA-Z][a-zA-Z0-9_-]*$/;
+const PATH_SEGMENT_RE = /^[a-zA-Z0-9.][a-zA-Z0-9._-]*$/;
+
+function isHttpUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function validateSkillIdentifier(s: string, ctx: z.RefinementCtx): void {
+  if (s.length === 0) {
+    ctx.addIssue({
+      code: "custom",
+      message: "Skill identifier cannot be empty.",
+      path: [],
+    });
+    return;
+  }
+
+  // Prefixed namespace forms: "npm:@scope/pkg", "pack:./local/skill"
+  const nsPrefix = SKILL_NAMESPACE_PREFIXES.find((p) => s.startsWith(p));
+  if (nsPrefix !== undefined) {
+    const rest = s.slice(nsPrefix.length);
+    if (rest.length === 0) {
+      ctx.addIssue({
+        code: "custom",
+        message: `Skill cannot be a bare "${nsPrefix}" prefix — a package identifier must follow.`,
+        path: [],
+      });
+    } else if (!/^[^\s]+$/.test(rest)) {
+      ctx.addIssue({
+        code: "custom",
+        message: `Skill "${s}" has whitespace in the package specifier after "${nsPrefix}".`,
+        path: [],
+      });
+    }
+    return;
+  }
+
+  // URL form: "well-known:<url>" or a bare http(s) URL
+  if (s.startsWith("well-known:")) {
+    const rest = s.slice("well-known:".length);
+    if (!isHttpUrl(rest)) {
+      ctx.addIssue({
+        code: "custom",
+        message:
+          'well-known: skills must be followed by a valid http(s) URL, e.g. ' +
+          '"well-known:https://mintlify.com/docs/.well-known/skills/mintlify".',
+        path: [],
+      });
+    }
+    return;
+  }
+
+  if (s.startsWith("http://") || s.startsWith("https://")) {
+    if (!isHttpUrl(s)) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Direct-URL skills must be valid http(s) URLs.",
+        path: [],
+      });
+    }
+    return;
+  }
+
+  // Source-prefixed path forms: "official/...", "skills-sh/...", etc.
+  const srcPrefix = SKILL_SOURCE_PREFIXES.find((p) => s.startsWith(p));
+  if (srcPrefix !== undefined) {
+    const rest = s.slice(srcPrefix.length);
+    if (rest.length === 0) {
+      ctx.addIssue({
+        code: "custom",
+        message:
+          `Skill cannot be a bare "${srcPrefix}" prefix — at least two path segments must follow, ` +
+          `e.g. "${srcPrefix}category/skill-name".`,
+        path: [],
+      });
+      return;
+    }
+    const segments = rest.split("/");
+    if (segments.length < 2) {
+      ctx.addIssue({
+        code: "custom",
+        message:
+          `Skill "${s}" needs at least two path segments after "${srcPrefix}", ` +
+          `e.g. "${srcPrefix}category/skill-name".`,
+        path: [],
+      });
+      return;
+    }
+    const bad = segments.find((seg) => !PATH_SEGMENT_RE.test(seg));
+    if (bad !== undefined) {
+      ctx.addIssue({
+        code: "custom",
+        message:
+          `Skill "${s}" has an invalid path segment "${bad}" after "${srcPrefix}". ` +
+          'Segments must start with an alphanumeric character (or "." for hidden dirs) and may contain alphanumerics, ".", "-", and "_".',
+        path: [],
+      });
+    }
+    return;
+  }
+
+  // GitHub-style path: "owner/repo/..." — ≥2 non-empty segments
+  if (s.includes("/")) {
+    if (s.startsWith("/") || s.endsWith("/")) {
+      ctx.addIssue({
+        code: "custom",
+        message: 'Skill paths must not start or end with "/", e.g. "openai/skills/k8s".',
+        path: [],
+      });
+      return;
+    }
+    const segments = s.split("/");
+    const bad = segments.find((seg) => !PATH_SEGMENT_RE.test(seg));
+    if (bad !== undefined) {
+      ctx.addIssue({
+        code: "custom",
+        message:
+          `Skill "${s}" has an invalid path segment "${bad}". ` +
+          'Segments must start with an alphanumeric character (or "." for hidden dirs) and may contain alphanumerics, ".", "-", and "_".',
+        path: [],
+      });
+      return;
+    }
+    // ≥2 well-formed segments is a valid GitHub-style install path
+    return;
+  }
+
+  // Simple slug — the only no-slash form we accept
+  if (SIMPLE_SLUG_RE.test(s)) return;
+
+  ctx.addIssue({
+    code: "custom",
+    message:
+      `Skill "${s}" is not a recognized identifier format. Expected a simple slug ("axolotl"), ` +
+      'a namespace prefix ("npm:@scope/pkg"), a hub-source path ("official/category/skill-name", ' +
+      '"skills-sh/owner/repo/skill", "browse-sh/host/task-id"), a GitHub path ("openai/skills/k8s"), ' +
+      'a well-known endpoint ("well-known:https://example.com/.well-known/skills/x"), or a direct URL ' +
+      '("https://example.com/SKILL.md").',
+    path: [],
+  });
+}
+
+export const SkillIdentifierSchema = z
+  .string()
+  .min(1)
+  .max(128, "Skill exceeds maximum length of 128 characters")
+  .superRefine(validateSkillIdentifier);
+
+export type SkillIdentifier = string;
+
+export const SkillIdentifiersSchema = z
+  .array(SkillIdentifierSchema)
+  .max(20)
+  .optional()
+  .describe("Skill identifiers to install.");
+
+export type SkillIdentifiers = z.infer<typeof SkillIdentifiersSchema>;
+
+// Picker-facing projection of a skill index entry: only the fields the UI
+// renders, camelCase. The infra adaptor maps its raw upstream entries to this.
+export const SkillSummarySchema = z.object({
+  name: z.string(),
+  identifier: z.string(),
+  description: z.string(),
+});
+
+export type SkillSummary = z.infer<typeof SkillSummarySchema>;

--- a/apps/app/src/server/infras/hermes-skill-index.ts
+++ b/apps/app/src/server/infras/hermes-skill-index.ts
@@ -1,4 +1,6 @@
-import { SkillIndexAdaptor, SkillSearchResult } from "../usecases/adaptors/skill-index";
+import { SkillSummary } from "@/entities";
+
+import { SkillIndexAdaptor } from "../usecases/adaptors/skill-index";
 
 const INDEX_URL = "https://hermes-agent.nousresearch.com/docs/api/skills-index.json";
 const CACHE_TTL_MS = 6 * 3600 * 1000;
@@ -58,13 +60,13 @@ export class HermesSkillIndex implements SkillIndexAdaptor {
     return this.#cache.skills;
   }
 
-  async searchSkills(query: string, limit = 25): Promise<SkillSearchResult[]> {
+  async searchSkills(query: string, limit = 25): Promise<SkillSummary[]> {
     const skills = await this.#loadIndex();
     if (skills.length === 0) {
       return [];
     }
 
-    const toResult = (entry: SkillIndexEntry): SkillSearchResult => ({
+    const toResult = (entry: SkillIndexEntry): SkillSummary => ({
       name: entry.name,
       identifier: entry.identifier,
       description: entry.description,
@@ -75,7 +77,7 @@ export class HermesSkillIndex implements SkillIndexAdaptor {
       return skills.slice(0, limit).map(toResult);
     }
 
-    const results: SkillSearchResult[] = [];
+    const results: SkillSummary[] = [];
     for (const s of skills) {
       const haystack = [
         s.name,

--- a/apps/app/src/server/routers/trpc/agent-type.ts
+++ b/apps/app/src/server/routers/trpc/agent-type.ts
@@ -1,0 +1,11 @@
+import { AgentTypeSummary } from "@/entities";
+import { AgentTypeUseCase } from "@/server/usecases/agent-type";
+import { protectedProcedure, t } from "./shared.js";
+
+const usecase = new AgentTypeUseCase();
+
+export const agentTypeRouter = t.router({
+  list: protectedProcedure.query((): Promise<AgentTypeSummary[]> => {
+    return usecase.list();
+  }),
+});

--- a/apps/app/src/server/routers/trpc/index.ts
+++ b/apps/app/src/server/routers/trpc/index.ts
@@ -1,13 +1,17 @@
 import { createExpressMiddleware } from "@trpc/server/adapters/express";
 import { t, createTRPContext } from "./shared.js";
 import { agentRouter } from "./agent.js";
+import { agentTypeRouter } from "./agent-type.js";
 import { sharedEnvSetRouter } from "./shared-env-set.js";
+import { skillRouter } from "./skill.js";
 import { templateRouter } from "./template.js";
 
 export const appRouter = t.router({
   agent: agentRouter,
+  agentType: agentTypeRouter,
   template: templateRouter,
   sharedEnvSet: sharedEnvSetRouter,
+  skill: skillRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/apps/app/src/server/routers/trpc/skill.ts
+++ b/apps/app/src/server/routers/trpc/skill.ts
@@ -7,9 +7,14 @@ import { protectedProcedure, t } from "./shared.js";
 const usecase = new SkillUseCase();
 
 export const skillRouter = t.router({
-  list: protectedProcedure
-    .input(z.object({ limit: z.number().int().min(1).max(100).optional() }).optional())
+  search: protectedProcedure
+    .input(
+      z.object({
+        query: z.string(),
+        limit: z.number().int().min(1).max(100).optional(),
+      })
+    )
     .query(({ input }): Promise<SkillSummary[]> => {
-      return usecase.list(input?.limit);
+      return usecase.search(input.query, input.limit);
     }),
 });

--- a/apps/app/src/server/routers/trpc/skill.ts
+++ b/apps/app/src/server/routers/trpc/skill.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+import { SkillSummary } from "@/entities";
+import { SkillUseCase } from "@/server/usecases/skill";
+import { protectedProcedure, t } from "./shared.js";
+
+const usecase = new SkillUseCase();
+
+export const skillRouter = t.router({
+  list: protectedProcedure
+    .input(z.object({ limit: z.number().int().min(1).max(100).optional() }).optional())
+    .query(({ input }): Promise<SkillSummary[]> => {
+      return usecase.list(input?.limit);
+    }),
+});

--- a/apps/app/src/server/usecases/adaptors/skill-index.ts
+++ b/apps/app/src/server/usecases/adaptors/skill-index.ts
@@ -1,9 +1,5 @@
-export interface SkillSearchResult {
-  name: string;
-  identifier: string;
-  description: string;
-}
+import { SkillSummary } from "@/entities";
 
 export interface SkillIndexAdaptor {
-  searchSkills(query: string, limit?: number): Promise<SkillSearchResult[]>;
+  searchSkills(query: string, limit?: number): Promise<SkillSummary[]>;
 }

--- a/apps/app/src/server/usecases/agent-type.ts
+++ b/apps/app/src/server/usecases/agent-type.ts
@@ -1,0 +1,14 @@
+import { AgentTypeSummary } from "@/entities";
+import { BaseUseCase, HermeumConfigLoadable } from "@/server/usecases/mixin";
+
+export class AgentTypeUseCase extends HermeumConfigLoadable(BaseUseCase) {
+  async list(): Promise<AgentTypeSummary[]> {
+    const { agentTypes } = await this.loadHermeumConfig();
+    return agentTypes
+      ? Object.entries(agentTypes).map(([key, t]) => ({
+          key,
+          ...(t.description !== undefined ? { description: t.description } : {}),
+        }))
+      : [];
+  }
+}

--- a/apps/app/src/server/usecases/chat.test.ts
+++ b/apps/app/src/server/usecases/chat.test.ts
@@ -20,7 +20,8 @@ vi.mock("@/server/libs/config", () => ({
 import { ChatUseCase, AGENT_CONFIG_CHAT_SYSTEM_PROMPT } from "./chat";
 import type { File, FileAdaptor } from "./adaptors/file";
 import type { Runtime } from "./adaptors/runtime";
-import type { SkillIndexAdaptor, SkillSearchResult } from "./adaptors/skill-index";
+import type { SkillIndexAdaptor } from "./adaptors/skill-index";
+import type { SkillSummary } from "@/entities";
 import type { HermeumConfig, SharedEnvSet } from "@/entities";
 
 type Doc = { content: string; data?: Record<string, unknown> };
@@ -91,7 +92,7 @@ function makeFiles(
 
 const callOptions = {} as ToolExecutionOptions;
 
-function makeSkillIndex(results: SkillSearchResult[] = []): SkillIndexAdaptor {
+function makeSkillIndex(results: SkillSummary[] = []): SkillIndexAdaptor {
   return {
     searchSkills: vi.fn().mockResolvedValue(results),
   } as unknown as SkillIndexAdaptor;
@@ -214,7 +215,7 @@ describe("ChatUseCase.getAgentConfigContext", () => {
   });
 
   it("delegates searchSkills to the injected skill index adaptor", async () => {
-    const results: SkillSearchResult[] = [
+    const results: SkillSummary[] = [
       { name: "git-pr-review", identifier: "openai/skills/skills/git-pr-review", description: "Review PRs." },
     ];
     const skillIndex = makeSkillIndex(results);

--- a/apps/app/src/server/usecases/skill.ts
+++ b/apps/app/src/server/usecases/skill.ts
@@ -2,9 +2,9 @@ import { SkillSummary } from "@/entities";
 import { BaseUseCase } from "./mixin";
 
 export class SkillUseCase extends BaseUseCase {
-  // Empty query returns the featured/full list from the index (trust-filtered
-  // and cached by the adaptor).
-  async list(limit?: number): Promise<SkillSummary[]> {
-    return this.skillIndex.searchSkills("", limit);
+  // Keyword search over the curated index. An empty query returns the
+  // featured/full list (trust-filtered and cached by the adaptor).
+  async search(query: string, limit?: number): Promise<SkillSummary[]> {
+    return this.skillIndex.searchSkills(query, limit);
   }
 }

--- a/apps/app/src/server/usecases/skill.ts
+++ b/apps/app/src/server/usecases/skill.ts
@@ -1,0 +1,10 @@
+import { SkillSummary } from "@/entities";
+import { BaseUseCase } from "./mixin";
+
+export class SkillUseCase extends BaseUseCase {
+  // Empty query returns the featured/full list from the index (trust-filtered
+  // and cached by the adaptor).
+  async list(limit?: number): Promise<SkillSummary[]> {
+    return this.skillIndex.searchSkills("", limit);
+  }
+}


### PR DESCRIPTION
## Summary
- Add `AgentPickerBar` above the agent config editor (new + edit routes): an agent-type single-select popover and a keyword-search multi-select skills popover, so users can see and pick from what's actually available instead of only the chatbot choosing
- Picker selections write into the draft YAML directly, keeping editor, chat, and pickers in sync
- New entities: `agent-type.ts` (`AgentTypeKeySchema` strict-slug key, `AgentTypeSummary`) and `skill.ts` (`SkillIdentifierSchema` renamed from `SkillSchema`, `SkillIdentifiersSchema` from `SkillsSchema`, `SkillSummary`)
- New tRPC procedures: `agentType.list` and `skill.search` (server-side keyword search over the trust-filtered Hermes skills index)
- Chat capabilities unchanged (`listAgentTypes`, `searchSkills`, `updateAgentConfig` all intact)

## UI details
- Skills search is live (debounced 300ms, server-side), gated to run only while the popover is open — no requests at page load
- Selection count shows on the trigger when the popover is closed; checkmarks inside the list
- Popover lists capped at max-h-64 with native scroll, so they no longer stretch the page

## Test plan
- [x] `pnpm --filter @hermeum/app typecheck` (no new errors)
- [x] `pnpm --filter @hermeum/app lint` (no new warnings)
- [x] `pnpm --filter @hermeum/app test` — 310/310 passing
- [ ] Manual: pick a type/skill on /agents/new and /agents/$id/edit, confirm the YAML editor updates and chat stays in sync