### PR TITLE
refactor(app): drop redundant file: strip in sqlite drizzle config

### DIFF
--- a/apps/app/drizzle.config.sqlite.ts
+++ b/apps/app/drizzle.config.sqlite.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   dialect: "sqlite",
   schema: ["./src/server/routers/better-auth/schema.sqlite.ts"],
   dbCredentials: {
-    url: process.env.HERMEUM_DATABASE_URL!.replace(/^file:(\/\/)?/, ""),
+    url: process.env.HERMEUM_DATABASE_URL!,
   },
   out: "./src/server/migrations/sqlite",
 });


### PR DESCRIPTION
drizzle-kit normalises `file:` URLs internally for its better-sqlite driver (`normaliseSQLiteUrl`, bin.cjs), so `drizzle.config.sqlite.ts` can pass `HERMEUM_DATABASE_URL` through unmodified instead of pre-stripping the scheme.

Verified `drizzle-kit push` with `HERMEUM_DATABASE_URL=file:./sqlite-push-check.db` creates the db at the intended path.

Note: the equivalent strip in `apps/app/src/server/routers/better-auth/auth.ts` must stay — better-sqlite3 has no URI-mode option and treats raw `file:` strings as literal filenames.