### PR TITLE
feat(chart): default secrets.databaseUrl to the bundled sqlite path

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,14 @@ agent you can chat with, deploy, and iterate on.
 
 **Prerequisites:** a Kubernetes cluster and Helm 3.x.
 
-Hermeum ships as a Helm chart (`charts/hermeum`) for Kubernetes. The only
-hard-required value is `secrets.databaseUrl` (`HERMEUM_DATABASE_URL`).
+Hermeum ships as a Helm chart (`charts/hermeum`) for Kubernetes. It installs
+with sensible defaults — `HERMEUM_DATABASE_URL` defaults to the bundled sqlite
+path (`file:/var/lib/hermeum/db.sqlite`). For production you'll also want to set
+`secrets.betterAuthSecret`, `secrets.smtpUrl`, and `secrets.openaiApiKey`.
 
 ```bash
 helm install hermeum oci://ghcr.io/hermeum/charts/hermeum \
   --namespace hermeum --create-namespace \
-  --set secrets.databaseUrl=file:/var/lib/hermeum/db.sqlite \
   --set secrets.betterAuthSecret=$(openssl rand -base64 32) \
   --set secrets.smtpUrl=smtps://user:pass@mail.example.com:465 \
   --set secrets.openaiApiKey=sk-...

--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ agent you can chat with, deploy, and iterate on.
 **Prerequisites:** a Kubernetes cluster and Helm 3.x.
 
 Hermeum ships as a Helm chart (`charts/hermeum`) for Kubernetes. It installs
-with sensible defaults — `HERMEUM_DATABASE_URL` defaults to the bundled sqlite
-path (`file:/var/lib/hermeum/db.sqlite`). For production you'll also want to set
+with sensible defaults; for production you'll want to set
 `secrets.betterAuthSecret`, `secrets.smtpUrl`, and `secrets.openaiApiKey`.
 
 ```bash

--- a/apps/docs/docs/operation/installation.md
+++ b/apps/docs/docs/operation/installation.md
@@ -21,7 +21,9 @@ the architecture, see [Overview](../overview).
 
 ## Helm install
 
-The only hard-required env var is `HERMEUM_DATABASE_URL`; see
+`HERMEUM_DATABASE_URL` is required by the app; the chart supplies it via
+`secrets.databaseUrl`, which defaults to the bundled sqlite path
+(`file:/var/lib/hermeum/db.sqlite`). See
 [Configuration reference](../configuration-reference) for the full list. For
 production you'll also want:
 
@@ -40,12 +42,13 @@ for the full mapping.
 
 ### SQLite (default)
 
-Recommended for a first install or a single-replica deployment.
+Recommended for a first install or a single-replica deployment. No database
+configuration is needed — the chart defaults `secrets.databaseUrl` to
+`file:/var/lib/hermeum/db.sqlite`.
 
 ```bash
 helm install hermeum oci://ghcr.io/hermeum/charts/hermeum \
   --namespace hermeum --create-namespace \
-  --set secrets.databaseUrl=file:/var/lib/hermeum/db.sqlite \
   --set secrets.betterAuthSecret=$(openssl rand -base64 32) \
   --set secrets.smtpUrl=smtps://user:pass@mail.example.com:465 \
   --set secrets.openaiApiKey=sk-...
@@ -71,7 +74,9 @@ helm install hermeum oci://ghcr.io/hermeum/charts/hermeum \
 ```
 
 The PVC is automatically disabled when `config.databaseDialect=postgres`, and
-`replicaCount` can scale up. Use `secrets.existingSecret` to reference a Secret
+`replicaCount` can scale up. Note that `secrets.databaseUrl` must be
+overridden here — the default points at the bundled sqlite path. Use
+`secrets.existingSecret` to reference a Secret
 you manage yourself (e.g. via External Secrets) instead of templating one. See
 [Database](../database) for more.
 
@@ -108,7 +113,6 @@ agentConfig:
 ```bash
 helm install hermeum oci://ghcr.io/hermeum/charts/hermeum \
   --namespace hermeum --create-namespace \
-  --set secrets.databaseUrl=file:/var/lib/hermeum/db.sqlite \
   --set secrets.betterAuthSecret=$(openssl rand -base64 32) \
   --set secrets.smtpUrl=smtps://user:pass@mail.example.com:465 \
   --set secrets.openaiApiKey=sk-... \

--- a/apps/docs/docs/operation/installation.md
+++ b/apps/docs/docs/operation/installation.md
@@ -21,11 +21,7 @@ the architecture, see [Overview](../overview).
 
 ## Helm install
 
-`HERMEUM_DATABASE_URL` is required by the app; the chart supplies it via
-`secrets.databaseUrl`, which defaults to the bundled sqlite path
-(`file:/var/lib/hermeum/db.sqlite`). See
-[Configuration reference](../configuration-reference) for the full list. For
-production you'll also want:
+Everything installs with working defaults. For production you'll want:
 
 - `BETTER_AUTH_SECRET` — session signing secret for Better Auth (generate with
   `openssl rand -base64 32`).
@@ -34,9 +30,10 @@ production you'll also want:
 - `HERMEUM_OPENAI_API_KEY` — API key for the OpenAI-compatible API used by the
   AI config generator.
 
-Everything else has working defaults. The
-chart maps each env var to a value key (e.g. `HERMEUM_DATABASE_URL` ←
-`secrets.databaseUrl`); see the chart's
+See
+[Configuration reference](../configuration-reference) for the full list. The
+chart maps each env var to a value key (e.g. `BETTER_AUTH_SECRET` ←
+`secrets.betterAuthSecret`); see the chart's
 [`values.yaml`](https://github.com/hermeum/hermeum/blob/main/charts/hermeum/values.yaml)
 for the full mapping.
 

--- a/charts/hermeum/Chart.yaml
+++ b/charts/hermeum/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hermeum
 description: Hermeum — control plane for HermesAgent custom resources.
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.0.1"
 home: https://github.com/hermeum/hermeum
 sources:

--- a/charts/hermeum/README.md
+++ b/charts/hermeum/README.md
@@ -36,10 +36,10 @@ helm dependency build charts/hermeum
 ## Install
 
 ```bash
-# Required: HERMEUM_DATABASE_URL (the only hard-required env var).
+# HERMEUM_DATABASE_URL defaults to file:/var/lib/hermeum/db.sqlite (bundled
+# sqlite + PVC); override it with secrets.databaseUrl for other setups.
 helm install hermeum charts/hermeum \
-  --namespace hermeum --create-namespace \
-  --set secrets.databaseUrl=file:/var/lib/hermeum/db.sqlite
+  --namespace hermeum --create-namespace
 ```
 
 With an external Postgres:
@@ -56,7 +56,6 @@ With an agentConfig override that drives the mutating webhook:
 ```bash
 helm install hermeum charts/hermeum \
   --namespace hermeum --create-namespace \
-  --set secrets.databaseUrl=file:/var/lib/hermeum/db.sqlite \
   --values values.agentconfig.yaml
 ```
 
@@ -84,9 +83,10 @@ agentConfig:
 
 ## Required values
 
-| Value                          | Source                              | Notes                                            |
-|--------------------------------|-------------------------------------|--------------------------------------------------|
-| `secrets.databaseUrl`          | `HERMEUM_DATABASE_URL`              | Required unless `secrets.existingSecret` is set. |
+None — every value has a working default. `secrets.databaseUrl` defaults to
+`file:/var/lib/hermeum/db.sqlite` (the bundled sqlite path); set
+`secrets.betterAuthSecret` for auth to actually issue sessions, e.g. via
+`--set secrets.betterAuthSecret=$(openssl rand -base64 32)`.
 
 All other env vars have defaults (see `apps/app/src/server/libs/config.ts`
 for the authoritative list + semantics, and `values.yaml` for the chart-side
@@ -131,8 +131,8 @@ the kube-apiserver.
 ## Database
 
 - **sqlite** (default): a PVC is mounted at `persistence.mountPath`
-  (`/var/lib/hermeum`); point `secrets.databaseUrl` at `file:<mountPath>/db.sqlite`.
-  `replicaCount` must stay 1 (ReadWriteOnce PVC).
+  (`/var/lib/hermeum`); `secrets.databaseUrl` defaults to
+  `file:<mountPath>/db.sqlite`. `replicaCount` must stay 1 (ReadWriteOnce PVC).
 - **postgres**: set `config.databaseDialect=postgres` and `secrets.databaseUrl`
   to the Postgres connection URL. The PVC is skipped and `replicaCount` can
   scale up.
@@ -168,7 +168,7 @@ helm show values charts/hermeum
 | `image.repository`                   | `ghcr.io/hermeum/hermeum`       | Hermeum image. No published image yet — set this. |
 | `operator.enabled`                   | `true`                           | Install `hermes-agent-operator` as a dependency. |
 | `config.databaseDialect`             | `sqlite`                         | `sqlite` or `postgres`.                       |
-| `secrets.databaseUrl`                | `""`                             | **Required.** `HERMEUM_DATABASE_URL`.         |
+| `secrets.databaseUrl`                | `"file:/var/lib/hermeum/db.sqlite"` | `HERMEUM_DATABASE_URL`. Override for postgres. |
 | `secrets.existingSecret`             | `""`                             | Use an existing Secret instead of templating one. |
 | `agentConfig`                        | `{}`                             | Full `config.yaml` content (mounted as a ConfigMap). |
 | `webhook.enabled`                    | `true`                           | Ship the MutatingWebhookConfiguration.        |

--- a/charts/hermeum/values.yaml
+++ b/charts/hermeum/values.yaml
@@ -96,9 +96,11 @@ config:
 
 # ── Sensitive env (HERMEUM_* + BETTER_AUTH_* → Secret) ─────────────────────
 secrets:
-  # REQUIRED when no existingSecret is set. Connection URL for the hermeum
-  # database (HERMEUM_DATABASE_URL). For sqlite use "file:/var/lib/hermeum/db.sqlite".
-  databaseUrl: ""
+  # Connection URL for the hermeum database (HERMEUM_DATABASE_URL).
+  # Defaults to the bundled sqlite path; override (together with
+  # config.databaseDialect=postgres) for a postgres backend. Ignored when
+  # existingSecret is set.
+  databaseUrl: "file:/var/lib/hermeum/db.sqlite"
   # REQUIRED — session signing secret for Better Auth (BETTER_AUTH_SECRET).
   # Generate with: openssl rand -base64 32
   betterAuthSecret: ""


### PR DESCRIPTION
## Summary

`secrets.databaseUrl` now ships a working default (`file:/var/lib/hermeum/db.sqlite`), so sqlite installs need no `--set flags for the database.

- `charts/hermeum/values.yaml` — default `secrets.databaseUrl` to the bundled sqlite path; comment updated (override for postgres, ignored with `existingSecret`)
- `charts/hermeum/README.md` — install examples drop the redundant `--set`; "Required values" section now documents that no values are hard-required; Database section + notable-values table reflect the default
- Root `README.md` / `apps/docs` installation guide — quick-install prose no longer mentions the database URL; leads with the production env vars (`BETTER_AUTH_SECRET`, `HERMEUM_SMTP_URL`, `HERMEUM_OPENAI_API_KEY`); postgres section notes the override requirement

No schema changes needed — the `oneOf` in `values.schema.json` is satisfied by the default. App-level `HERMEUM_DATABASE_URL` remains required (`config.ts` untouched); the chart is the defaulting layer.

## Verification

- `helm dependency build` + `helm template` render OK; Secret contains `database-url: "file:/var/lib/hermeum/db.sqlite"`
- `helm lint` passes (0 failures)