### PR TITLE
feat(app): allow cancelling a running agent-config chat

### DIFF
--- a/apps/app/src/client/ui/components/agent-config-chat.tsx
+++ b/apps/app/src/client/ui/components/agent-config-chat.tsx
@@ -2,7 +2,7 @@ import { useRef, useState } from "react";
 import { useChat } from "@ai-sdk/react";
 import { DefaultChatTransport, lastAssistantMessageIsCompleteWithToolCalls } from "ai";
 import type { UIDataTypes, UIMessage } from "ai";
-import { ArrowUp, Check, LoaderCircle } from "lucide-react";
+import { ArrowUp, Check, LoaderCircle, Square } from "lucide-react";
 
 import { Button } from "@hermeum/components/ui/button";
 import { Bubble, BubbleContent } from "@hermeum/components/ui/bubble";
@@ -133,7 +133,7 @@ export function AgentConfigChat({
   // loop. Reset when the user sends a new message.
   const configUpdateFailuresRef = useRef(0);
 
-  const { messages, sendMessage, status, error, addToolOutput } =
+  const { messages, sendMessage, stop, status, error, addToolOutput } =
     useChat<AgentConfigChatMessage>({
       transport: new DefaultChatTransport({ api: "/chat/agent-config" }),
       sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
@@ -360,14 +360,25 @@ export function AgentConfigChat({
           className="min-h-16 border-transparent px-0 py-0 focus-visible:border-transparent"
         />
         <div className="flex justify-end">
-          <Button
-            size="icon-sm"
-            aria-label="Send message"
-            onClick={handleSend}
-            disabled={input.trim().length === 0 || isBusy}
-          >
-            {isBusy ? <LoaderCircle className="animate-spin" /> : <ArrowUp />}
-          </Button>
+          {isBusy ? (
+            <Button
+              size="icon-sm"
+              variant="outline"
+              aria-label="Stop generating"
+              onClick={() => void stop()}
+            >
+              <Square className="size-3 fill-current" />
+            </Button>
+          ) : (
+            <Button
+              size="icon-sm"
+              aria-label="Send message"
+              onClick={handleSend}
+              disabled={input.trim().length === 0}
+            >
+              <ArrowUp />
+            </Button>
+          )}
         </div>
       </div>
     </div>

--- a/apps/app/src/server/routers/ai-sdk/agent-config.ts
+++ b/apps/app/src/server/routers/ai-sdk/agent-config.ts
@@ -64,11 +64,19 @@ aiSdkRouter.post("/agent-config", async (req, res) => {
   }
 
   const { instructions, prompt, tools } = await usecase.getAgentConfigContext(parsed.data.config);
+  // Abort generation when the client goes away (user cancelled the chat or
+  // closed the page), so the model call and in-flight tool executions stop
+  // instead of running to completion against a closed response.
+  const abortController = new AbortController();
+  res.on("close", () => {
+    if (!res.writableEnded) abortController.abort();
+  });
   const result = streamText({
     model: model(),
     system: `${instructions}\n\n${prompt}`,
     messages: await convertToModelMessages(parsed.data.messages),
     tools: toAiToolSet(tools),
+    abortSignal: abortController.signal,
     // AgentInputObjectSchema uses looseObject/record/optionals, which strict
     // JSON schema mode rejects; Responses API models default it to true.
     providerOptions: {


### PR DESCRIPTION
## Summary
- Add a stop button to the agent-config chat composer: while a request is `submitted`/`streaming`, the send button becomes a stop button that calls `useChat`'s `stop()`, aborting the fetch, keeping already-streamed tokens, and suppressing the automatic tool-loop resubmit (per the [AI SDK chatbot docs](https://ai-sdk.dev/docs/ai-sdk-ui/chatbot#cancellation-and-regeneration)).
- Server: pass `abortSignal` to `streamText` and abort it via `res.on("close")` when the client disconnects, so generation and in-flight tool executions stop instead of running to completion against a closed connection.

## Test plan
- [x] `pnpm --filter @hermeum/app test` — 310/310 pass
- [x] `pnpm --filter @hermeum/app lint` — 0 errors (2 pre-existing warnings in unrelated files)
- [x] `pnpm --filter @hermeum/app typecheck` — no new errors vs. baseline (4 pre-existing errors unchanged)
- [x] Manual: start a chat, click stop mid-stream, verify tokens persist and status returns to ready