### PR TITLE
feat: upgrade hermes-agent to v2026.8.31

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,28 @@ When upgrading the Hermeum app version, update every place that mirrors it, in l
 
 The chart `image.tag` (`charts/hermeum/values.yaml`) defaults to `appVersion` when empty — leave it empty unless pinning to a non-`appVersion` tag.
 
+### Upgrading the hermes-agent image tag
+
+When upgrading `hermesImageTag` (the pinned hermes-agent release), update every place that mirrors it, in lockstep:
+
+- `vendor/hermes-agent` — check out the new release tag in the submodule.
+- `charts/hermeum/values.yaml` — `config.hermesImageTag`.
+- `apps/app/src/server/libs/config.ts` — the `hermesImageTag` Zod default.
+- `apps/docs/docs/operation/configuration-reference.md` — the `HERMEUM_HERMES_IMAGE_TAG` default.
+- `charts/hermeum/Chart.yaml` — bump the chart `version` patch (the chart is republished for the upgrade; `appVersion` tracks the Hermeum app release, not the agent image, and stays untouched).
+
+Then sync `apps/app/src/entities/hermes-config/` (Zod schemas) and `apps/app/docs/hermes-config/` (field-semantics docs) against the official docs at the new submodule pin. Both directories always reflect the pinned submodule version — never mention the version string in their comments or prose; the submodule pointer implies it.
+
+**Apply the standing Hermeum policy deltas instead of re-deciding them per upgrade.** When an upstream change touches one of these, keep Hermeum's behavior and record the omission in a header comment on the schema file ("Skipped on purpose: …") and/or an upstream-differs `:::note` in the doc — do not adopt the upstream shape:
+
+- **OAuth-gated providers are omitted.** `nous` (the managed Tool Gateway) is not surfaced anywhere — `web.backend`, `browser.cloud_provider`, `image_gen.provider` — because Nous Portal OAuth is not supported in container mode. Values still pass through via `looseObject` if hand-written.
+- **Credentials stay env-only.** Never document or type secret-bearing fields in `config.yaml` (e.g. Teams `client_id`/`client_secret`/`tenant_id`, API server `key`, webhook route `secret`) even when upstream accepts them in config; pair the config-path enablement with a `superRefine` requirement for the `sensitive: true` env var.
+- **Operator-level concerns are not exposed via agent configuration.** Webhook route `filters`/`script`/`toolsets` are not typed — they pass through unvalidated.
+- **Behavior pinned by Hermeum policy stays pinned.** e.g. Slack `unauthorized_dm_behavior` stays literal `"ignore"` (deny-by-default) rather than upstream's `"pair"` default; `browser.cloud_provider: local` is surfaced.
+- **Env-vs-config precedence is per platform, taken from the upstream doc** — don't assume one direction: api-server env vars win over config; webhook/teams config wins over env vars. Verify per platform and state the direction in the doc.
+
+Fields not worth validating are left out of the schemas (they pass through via `looseObject`) but must still be reflected in the docs when they change semantics — the docs track upstream, the schemas track only what Hermeum needs to enforce.
+
 ## `@hermeum/app` (`apps/app`)
 
 ### Commands

--- a/apps/app/docs/hermes-config/api-server.md
+++ b/apps/app/docs/hermes-config/api-server.md
@@ -1,7 +1,7 @@
 ---
 name: api-server
 category: platforms
-description: API server configuration — OpenAI-compatible HTTP endpoint env vars.
+description: API server configuration (`gateway.api_server`) — OpenAI-compatible HTTP endpoint, config.yaml fields, and env vars.
 ---
 
 # API server configuration
@@ -13,29 +13,81 @@ toolset (terminal, file operations, web search, memory, skills).
 
 ## Configuration
 
-The API server is configured entirely through environment variables —
-`config.yaml` support is not yet available. Set the env vars below on the agent.
+The API server can be configured through either `config.gateway.api_server`
+(`enabled`, `port`) **or** env vars (`API_SERVER_ENABLED`,
+`API_SERVER_PORT`). Environment variables take precedence over the
+`config.yaml` values when both are set; the config block acts as a
+fallback for deployments that prefer `config.yaml`.
+
+### config.yaml
+
+Only non-secret settings live under `config.gateway.api_server` (flat
+fields, matching the upstream block):
+
+- `enabled` — whether the API server is enabled (bool).
+- `port` — HTTP server port (default `8642`).
+- `host` — bind address. Defaults to localhost only (`127.0.0.1`); set
+  to `0.0.0.0` to expose on a LAN.
+- `cors_origins` — comma-separated allowed browser origins. Required
+  only if a browser must call Hermes directly.
+- `model_name` — model name advertised on `/v1/models`. Defaults to the
+  profile name.
+- `max_concurrent_runs` — concurrent-run cap across the
+  OpenAI-compatible and Runs endpoints (default `10`; `0` disables the
+  limit — new run-starting requests get HTTP 429 when the cap is
+  reached).
+
+The bearer token is **not** surfaced by Hermeum in `config.yaml` — it
+lives in the `API_SERVER_KEY` environment variable (see
+[Environment variables](#environment-variables)) to avoid exposing
+credentials in plain text. Upstream also accepts a `key:` field in the
+config block; Hermeum does not write it, though a hand-written value
+passes through unchanged.
 
 ## Environment variables
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `API_SERVER_ENABLED` | `false` | Enable the API server. |
-| `API_SERVER_PORT` | `8642` | HTTP server port. |
+| `API_SERVER_ENABLED` | `false` | Enable the API server. Takes precedence over `gateway.api_server.enabled`. |
+| `API_SERVER_PORT` | `8642` | HTTP server port. Takes precedence over `gateway.api_server.port`. |
 | `API_SERVER_HOST` | `127.0.0.1` | Bind address. Defaults to localhost only; set to `0.0.0.0` to expose on a LAN. |
 | `API_SERVER_KEY` | _(required)_ | Bearer token for auth. Required for every deployment, including loopback. Set via env var, not `config.yaml`, to avoid exposing credentials in plain text. |
 | `API_SERVER_CORS_ORIGINS` | _(none)_ | Comma-separated allowed browser origins. Required only if a browser must call Hermes directly. |
 | `API_SERVER_MODEL_NAME` | _(profile name)_ | Model name advertised on `/v1/models`. Defaults to the profile name, or `hermes-agent` for the default profile. |
 
+Upstream also exposes an authenticated `/api/model/options` endpoint for
+Hermes-aware UIs; it is outside the surface Hermeum configures.
+
 ## Example
+
+### Full `gateway.api_server` block
+
+```yaml
+config:
+  gateway:
+    api_server:
+      enabled: true
+      port: 8642
+      host: 127.0.0.1
+      cors_origins: http://localhost:3000
+      model_name: my-hermes
+      max_concurrent_runs: 10
+```
 
 ### Enabling the API server with an auth key
 
 ```yaml
+config:
+  gateway:
+    api_server:
+      enabled: true
+      port: 8642
 env:
-  - name: API_SERVER_ENABLED
-    value: "true"
   - name: API_SERVER_KEY
     value: change-me-local-dev
     sensitive: true
 ```
+
+The `gateway.api_server` block is optional — omitting it and setting
+`API_SERVER_ENABLED=true` + `API_SERVER_PORT` via env vars works the
+same way. When both are set, the env vars win.

--- a/apps/app/docs/hermes-config/browser.md
+++ b/apps/app/docs/hermes-config/browser.md
@@ -22,12 +22,15 @@ different backend when the user explicitly requests one.
 
 - `cloud_provider` — explicitly selects the browser backend. Values:
   `camofox` (Hermeum default — local anti-detection Firefox),
-  `browserbase`, `browser-use`, `firecrawl`, `local`. When set to
-  `local`, cloud fallback is disabled and the local `agent-browser`
-  CLI / CDP path is used. When unset, the backend is auto-detected
-  from credentials (Browser Use → Browserbase). Selecting `camofox`
-  routes all browser tools through the Camofox server; `CAMOFOX_URL`
-  and `CAMOFOX_API_KEY` are set automatically by Hermeum.
+  `browserbase`, `browser-use`, `firecrawl`, `local` (Lightpanda /
+  `agent-browser` local engine). When set to `local`, cloud fallback is
+  disabled and the local `agent-browser` CLI / CDP path is used. When
+  unset, the backend is auto-detected from credentials (Browser Use →
+  Browserbase), and never-configured setups autodetect while an existing
+  selection always wins (a selected provider with a missing key errors
+  instead of silently rerouting). Selecting `camofox` routes all browser
+  tools through the Camofox server; `CAMOFOX_URL` and `CAMOFOX_API_KEY`
+  are set automatically by Hermeum.
 - `inactivity_timeout` — seconds of inactivity before a browser session
   is auto-cleaned up (default `120`).
 - `command_timeout` — timeout in seconds for individual browser commands
@@ -39,8 +42,12 @@ different backend when the user explicitly requests one.
   (`localhost`, `127.0.0.1`, `192.168.x.x`, `10.x.x.x`, etc.)
   (default `false`).
 - `engine` — browser engine for local mode: `auto` (default Chrome),
-  `lightpanda` (faster, no screenshots), `chrome` (default `auto`).
-  Also settable via `AGENT_BROWSER_ENGINE`.
+  `lightpanda` (faster, no screenshots — a headless
+  Zig-built browser that works in Browser Use mode and with the built-in
+  tools, with automatic Chrome fallback for unsupported actions),
+  `chrome` (default `auto`). Also settable via `AGENT_BROWSER_ENGINE`.
+  `engine` is the lowest-precedence browser setting — a cloud provider,
+  Camofox, a `cdp_url` override, or `use_real_profile` all shadow it.
 - `auto_local_for_private_urls` — when a cloud provider is configured,
   auto-spawn a local Chromium sidecar for LAN/loopback URLs instead of
   sending them to the cloud (default `true`). Public URLs continue to
@@ -86,7 +93,7 @@ different backend when the user explicitly requests one.
 | `FIRECRAWL_API_KEY` | Firecrawl API key. Enables Firecrawl as a cloud browser provider. | _(none)_ |
 | `FIRECRAWL_API_URL` | Firecrawl API URL for self-hosted instances. | _(cloud)_ |
 | `FIRECRAWL_BROWSER_TTL` | Firecrawl browser session TTL in seconds. | `300` |
-| `CAMOFOX_URL` | Camofox browser server URL for local anti-detection browsing. Set automatically by Hermeum when Camofox is the selected backend. | _(auto)_ |
+| `CAMOFOX_URL` | Camofox browser server URL for local anti-detection browsing. Set automatically by Hermeum when Camofox is the selected backend. Setting it no longer selects the backend by itself once a browser selection exists. | _(auto)_ |
 | `CAMOFOX_API_KEY` | Optional bearer token sent as `Authorization` header to a remote/authenticated Camofox server. Set automatically by Hermeum when Camofox is the selected backend. | _(auto)_ |
 | `CAMOFOX_USER_ID` | Env-var mirror of `browser.camofox.user_id`. Takes precedence over `config.yaml`. | _(none)_ |
 | `CAMOFOX_SESSION_KEY` | Env-var mirror of `browser.camofox.session_key`. Takes precedence over `config.yaml`. | _(none)_ |

--- a/apps/app/docs/hermes-config/image-gen.md
+++ b/apps/app/docs/hermes-config/image-gen.md
@@ -8,13 +8,21 @@ description: Image generation configuration (`config.image_gen`) — FAL.ai mode
 
 Configures the `image_generate` tool, which lets the agent generate images
 from text prompts (and edit existing images on edit-capable models). It is
-backed by FAL.ai.
+backed by FAL.ai or other provider plugins.
 
 The toolset auto-enables when `FAL_KEY` is set. Without it, the
 `image_generate` tool does not register.
 
 ## Fields
 
+- `provider` — the single selection key for the image-gen backend.
+  A vendor name (`fal`, `openai`, `xai`, `krea`, `openrouter`, ...) goes
+  direct with your own key. The stored selection always wins:
+  `provider: fal` without `FAL_KEY` errors rather than silently
+  rerouting. Default `fal` when `FAL_KEY` is set. Upstream also accepts
+  `nous` (the managed Tool Gateway), but Hermeum does not surface it —
+  it requires Nous Portal OAuth, which is not supported in container
+  mode.
 - `model` — FAL.ai model id. Default
   `fal-ai/flux-2/klein/9b`. Eleven models are supported out of the box;
   `fal-ai/flux-2-pro` (studio photorealism),
@@ -25,10 +33,16 @@ The toolset auto-enables when `FAL_KEY` is set. Without it, the
   `fal-ai/recraft/v4/pro/text-to-image` (design / brand systems),
   `fal-ai/qwen-image` (LLM-based, complex text),
   `fal-ai/krea/v2/{medium,large}/text-to-image` (illustration / photorealism).
+  With `provider: openrouter`, the picker lists OpenRouter's entire live
+  image catalog instead.
 - `max_parallel_requests` — concurrent images per tool-call batch
   (default `4`). Hermes clamps it to at least one and to the global
   tool-worker limit, so image providers receive bounded parallel requests
   without allowing an image batch to bypass the agent's concurrency cap.
+
+Upscaling is now **opt-in only** — no model upscales by default; it runs
+solely when the agent explicitly requests it (upscalers are creative
+enhancers that can degrade rendered text and fine detail).
 
 ## Environment variables
 
@@ -38,9 +52,12 @@ The toolset auto-enables when `FAL_KEY` is set. Without it, the
 
 ## Example
 
+### FAL.ai with a direct key
+
 ```yaml
 config:
   image_gen:
+    provider: fal
     model: fal-ai/flux-2/klein/9b
     max_parallel_requests: 4
 env:

--- a/apps/app/docs/hermes-config/model.md
+++ b/apps/app/docs/hermes-config/model.md
@@ -6,6 +6,14 @@ description: LLM model configuration (`config.model`) — providers, model ids, 
 
 # LLM model configuration (`config.model`)
 
+> **TODO (pending PR):** the current upstream adds the providers `router`,
+> `fireworks`, `ai-gateway`, `actual`, `alibaba-token-plan` (+ `-cn`),
+> `commandcode`, `nebius-token-factory`, `opencode-free`,
+> `tencent-tokenplan`, and accepts `model: { model: id }` as an alias for
+> `model: { default: id }`. The provider list below is still the
+> v2026.7.7.2 set — it will be updated in a separate PR, in lockstep with
+> `src/entities/hermes-config/model.ts`. Do not edit until then.
+
 Configures which LLM provider and model the Hermes agent uses. Only set this
 when the request names a specific provider or model; otherwise omit it so the
 platform default applies.

--- a/apps/app/docs/hermes-config/model.md
+++ b/apps/app/docs/hermes-config/model.md
@@ -6,38 +6,70 @@ description: LLM model configuration (`config.model`) — providers, model ids, 
 
 # LLM model configuration (`config.model`)
 
-> **TODO (pending PR):** the current upstream adds the providers `router`,
-> `fireworks`, `ai-gateway`, `actual`, `alibaba-token-plan` (+ `-cn`),
-> `commandcode`, `nebius-token-factory`, `opencode-free`,
-> `tencent-tokenplan`, and accepts `model: { model: id }` as an alias for
-> `model: { default: id }`. The provider list below is still the
-> v2026.7.7.2 set — it will be updated in a separate PR, in lockstep with
-> `src/entities/hermes-config/model.ts`. Do not edit until then.
-
 Configures which LLM provider and model the Hermes agent uses. Only set this
 when the request names a specific provider or model; otherwise omit it so the
 platform default applies.
 
 ## Fields
 
-- `provider` — the LLM provider that serves the model. Supported values:
-  `nous`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `openrouter`,
-  `novita`, `zai`, `kimi-coding`, `kimi-coding-cn`, `arcee`, `gmi`, `minimax`,
-  `minimax-cn`, `xai`, `xai-oauth`, `alibaba`, `alibaba-coding-plan`,
-  `kilocode`, `xiaomi`, `tencent-tokenhub`, `opencode-zen`, `opencode-go`,
-  `deepseek`, `huggingface`, `gemini`, `vertex`, `openai-api`, `azure-foundry`,
-  `bedrock`, `nvidia`, `ollama-cloud`, `qwen-oauth`, `minimax-oauth`,
-  `stepfun`, `lmstudio`, `custom`.
+- `provider` — the LLM provider that serves the model. OAuth-gated providers are
+  **omitted** there — Hermeum does not support browser OAuth in container
+  mode: `nous`, `openai-codex`, `copilot`, `copilot-acp`, `xai-oauth`,
+  `qwen-oauth`, `minimax-oauth`, and `vertex`. 
 - `default` — default model identifier used for requests, e.g.
-  `moonshotai/kimi-k2.5` or `gpt-5`.
+  `moonshotai/kimi-k2.5` or `gpt-5`. Upstream also accepts `model:` as
+  an alias key for the same value — both work identically; Hermeum
+  documents `default`.
 - `base_url` — base URL of the provider's API endpoint, e.g.
   `https://api.novita.ai/openai/v1`. Omit to use the provider default.
 
 ## Requirements
 
 Setting a model requires an env var holding the provider's API key, marked
-`sensitive: true` — e.g. `ANTHROPIC_API_KEY` for `provider: anthropic`,
-`OPENAI_API_KEY` for `provider: openai-api`.
+`sensitive: true`. The table below maps every API-key provider to its env
+var (per the official
+[providers document](https://hermes-agent.nousresearch.com/docs/integrations/providers)).
+
+| Provider               | Env var                       | Notes                                                                                                               |
+| ---------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `anthropic`            | `ANTHROPIC_API_KEY`           | Pay-per-token; independent of Claude subscriptions.                                                                 |
+| `openrouter`           | `OPENROUTER_API_KEY`          |                                                                                                                     |
+| `router`               | `RAMP_ROUTER_API_KEY`         | Alias `ROUTER_API_KEY` also accepted.                                                                               |
+| `fireworks`            | `FIREWORKS_API_KEY`           | Endpoint overrides go through `model.base_url` in config, not env.                                                  |
+| `novita`               | `NOVITA_API_KEY`              |                                                                                                                     |
+| `ai-gateway`           | `AI_GATEWAY_API_KEY`          |                                                                                                                     |
+| `zai`                  | `GLM_API_KEY`                 | Aliases `ZAI_API_KEY` / `Z_AI_API_KEY`; endpoint auto-detected.                                                     |
+| `kimi-coding`          | `KIMI_API_KEY`                | `KIMI_CODING_API_KEY` accepted alongside.                                                                           |
+| `kimi-coding-cn`       | `KIMI_CN_API_KEY`             | China endpoint.                                                                                                     |
+| `arcee`                | `ARCEEAI_API_KEY`             |                                                                                                                     |
+| `gmi`                  | `GMI_API_KEY`                 |                                                                                                                     |
+| `nebius-token-factory` | `NEBIUS_API_KEY`              | `NEBIUS_TOKEN_FACTORY_API_KEY` also accepted.                                                                       |
+| `actual`               | `ACTUAL_API_KEY`              | Hosted relay. For the local daemon set `ACTUAL_BASE_URL=http://127.0.0.1:8080` instead — no key needed on loopback. |
+| `minimax`              | `MINIMAX_API_KEY`             | Global endpoint.                                                                                                    |
+| `minimax-cn`           | `MINIMAX_CN_API_KEY`          | China endpoint.                                                                                                     |
+| `xai`                  | `XAI_API_KEY`                 | Also used by `x_search`, TTS, and image gen.                                                                        |
+| `alibaba`              | `DASHSCOPE_API_KEY`           | Qwen Cloud (Alibaba DashScope).                                                                                     |
+| `alibaba-coding-plan`  | `ALIBABA_CODING_PLAN_API_KEY` | Falls back to `DASHSCOPE_API_KEY`. Separate billing SKU.                                                            |
+| `alibaba-token-plan`   | `ALIBABA_TOKEN_PLAN_API_KEY`  | Model Studio flat-token tier.                                                                                       |
+| `kilocode`             | `KILOCODE_API_KEY`            |                                                                                                                     |
+| `xiaomi`               | `XIAOMI_API_KEY`              |                                                                                                                     |
+| `tencent-tokenhub`     | `TOKENHUB_API_KEY`            |                                                                                                                     |
+| `tencent-tokenplan`    | `TOKENPLAN_API_KEY`           | Anthropic Messages endpoint.                                                                                        |
+| `opencode-zen`         | `OPENCODE_ZEN_API_KEY`        |                                                                                                                     |
+| `opencode-go`          | `OPENCODE_GO_API_KEY`         |                                                                                                                     |
+| `opencode-free`        | _(none)_                      | Keyless — requests are sent anonymously.                                                                            |
+| `commandcode`          | `COMMANDCODE_API_KEY`         | Claude models via the `commandcode-anthropic` alias.                                                                |
+| `deepseek`             | `DEEPSEEK_API_KEY`            |                                                                                                                     |
+| `huggingface`          | `HF_TOKEN`                    | Token must have "Make calls to Inference Providers" enabled.                                                        |
+| `gemini`               | `GOOGLE_API_KEY`              | `GEMINI_API_KEY` accepted as an alias.                                                                              |
+| `openai-api`           | `OPENAI_API_KEY`              | Optional `OPENAI_BASE_URL`.                                                                                         |
+| `azure-foundry`        | `AZURE_FOUNDRY_API_KEY`       | Microsoft Foundry / Azure OpenAI endpoint and key.                                                                  |
+| `bedrock`              | _(none)_                      | Standard AWS credential chain via boto3 — no static key; `AWS_PROFILE` / `AWS_REGION` apply.                        |
+| `nvidia`               | `NVIDIA_API_KEY`              | NIM-hosted models on build.nvidia.com.                                                                              |
+| `ollama-cloud`         | `OLLAMA_API_KEY`              | Cloud-hosted Ollama catalog.                                                                                        |
+| `stepfun`              | `STEPFUN_API_KEY`             |                                                                                                                     |
+| `lmstudio`             | `LM_API_KEY`                  | Optional — only needed when LM Studio server auth is enabled.                                                       |
+| `custom`               | `OPENAI_API_KEY`              | Used with `OPENAI_BASE_URL` or `model.base_url`.                                                                    |
 
 ## Example
 

--- a/apps/app/docs/hermes-config/teams.md
+++ b/apps/app/docs/hermes-config/teams.md
@@ -28,6 +28,13 @@ Credentials must not be written into `config.yaml` — `config.yaml` is for
 non-secret settings only. An explicit `enabled: false` disables the bot
 while keeping credentials in env.
 
+:::note Upstream difference
+Upstream docs also show `client_id` / `client_secret` /
+`tenant_id` inside `platforms.teams.extra` in `config.yaml`. Hermeum
+forbids that — credentials stay env-only (with `sensitive: true`) to keep
+them out of plain-text config.
+:::
+
 ### Environment variables
 
 | Variable | Default | Description |

--- a/apps/app/docs/hermes-config/video-gen.md
+++ b/apps/app/docs/hermes-config/video-gen.md
@@ -11,9 +11,10 @@ from a text prompt (text-to-video) or from a prompt plus a source image
 (image-to-video). Every backend is a provider plugin; the active provider
 is picked by `video_gen.provider` in `config.yaml`.
 
-This app documents the **xAI** and **FAL** providers. DeepInfra
-and user-installed plugins are also supported and pass through unchanged;
-only xAI and FAL are covered here.
+This app documents the **xAI** and **FAL** providers. DeepInfra (bundled
+as a built-in provider) and user-installed plugins are
+also supported and pass through unchanged; only xAI and FAL are covered
+here.
 
 The toolset auto-enables when **either** `FAL_KEY` **or** `XAI_API_KEY`
 is set. Without one of them, the `video_generate` tool does not register.

--- a/apps/app/docs/hermes-config/web-search.md
+++ b/apps/app/docs/hermes-config/web-search.md
@@ -20,48 +20,52 @@ a different backend when the user explicitly requests one.
 ## Fields
 
 - `backend` — shared fallback for both `web_search` and `web_extract`.
-  Values: `firecrawl`, `searxng`, `brave-free`, `ddgs`, `tavily`, `exa`,
-  `parallel`, `xai`.
+  Values: `firecrawl`, `searxng`, `brave-free`, `ddgs`, `keenable`,
+  `exa`, `parallel`, `xai`. Upstream also accepts `nous` (the managed
+  Tool Gateway), but Hermeum does not surface it — it requires Nous
+  Portal OAuth, which is not supported in container mode.
 - `search_backend` — per-capability override for `web_search`. When set,
   takes precedence over `backend`.
 - `extract_backend` — per-capability override for `web_extract`. When set,
   takes precedence over `backend`. Note: some backends are search-only
   (SearXNG, Brave, DDGS, xAI) and cannot extract — pair them with an
   extract-capable backend via this field.
-- `extract_char_limit` — per-page character budget for `web_extract`
-  (default `15000`). Larger pages are truncated; the full text is stored
-  in `~/.hermes/cache/web/`.
 
 **Priority order (per capability):**
 
 1. `web.search_backend` / `web.extract_backend` (explicit per-capability)
 2. `web.backend` (shared fallback)
-3. Auto-detect from environment variables
+3. Auto-detect from environment variables 
 
-Auto-detection picks the first available backend based on which
-credentials are set, in this order: `FIRECRAWL_API_KEY` /
-`FIRECRAWL_API_URL` → `PARALLEL_API_KEY` → `TAVILY_API_KEY` →
-`EXA_API_KEY` → `SEARXNG_URL`. xAI is **not** in the auto-detection
-chain — having `XAI_API_KEY` set does not automatically route web
-traffic through xAI (those credentials are also used for inference /
-TTS / image gen). Opt in explicitly with `web.backend: "xai"`.
+Auto-detection only runs when no backend has ever been selected — once a
+selection exists, the runtime always uses it, and adding a key to `.env`
+does not reroute web traffic. It picks the first available backend based
+on which credentials are set, in this order: `EXA_API_KEY` →
+`PARALLEL_API_KEY` → `FIRECRAWL_API_KEY` / `FIRECRAWL_API_URL` →
+`SEARXNG_URL` → `BRAVE_SEARCH_API_KEY` → the `ddgs` package → the keyless
+free-tier ring (round-robin across Exa, Parallel, Firecrawl, and Keenable
+public free tiers). xAI is **not** in the auto-detection chain — having
+`XAI_API_KEY` set does not automatically route web traffic through xAI
+(those credentials are also used for inference / TTS / image gen). Opt in
+explicitly with `web.backend: "xai"`.
 
 ## Environment variables
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `FIRECRAWL_API_KEY` | Firecrawl API key. Enables search + extract. Free tier: 500 credits/month. | _(none)_ |
+| `FIRECRAWL_API_KEY` | Firecrawl API key. Enables search + extract. Free tier: 500 credits/month; also keyless when Firecrawl is the selected backend. | _(none)_ |
 | `FIRECRAWL_API_URL` | Firecrawl API URL for self-hosted instances. When set, the API key is optional (disable server auth with `USE_DB_AUTHENTICATION=false`). | _(cloud)_ |
 | `SEARXNG_URL` | URL of a SearXNG instance. Search-only; no API key required. Free (self-hosted). Set automatically by Hermeum when SearXNG is the selected backend. | _(auto)_ |
 | `BRAVE_SEARCH_API_KEY` | Brave Search API subscription token. Search-only. Free tier: 2,000 queries/month. | _(none)_ |
-| `TAVILY_API_KEY` | Tavily API key. Enables search + extract. Free tier: 1,000 searches/month. | _(none)_ |
-| `EXA_API_KEY` | Exa API key. Enables search + extract. Free tier: 1,000 searches/month. | _(none)_ |
-| `PARALLEL_API_KEY` | Parallel API key. Enables search + extract. Paid. | _(none)_ |
+| `EXA_API_KEY` | Exa API key. Enables search + extract. Free tier: 1,000 searches/month; also a keyless ring member. | _(none)_ |
+| `PARALLEL_API_KEY` | Parallel API key. Enables search + extract. Paid; also a keyless ring member. | _(none)_ |
+| `KEENABLE_API_KEY` | Keenable API key. Enables search + extract. Paid; also a keyless ring member. | _(none)_ |
 | `XAI_API_KEY` | xAI (Grok) API key. Search-only; not in the auto-detection chain — opt in with `web.backend: "xai"`. Paid. | _(none)_ |
 
 DDGS (DuckDuckGo) needs no env var — it is always available as a
 search-only backend via `web.backend: "ddgs"` (uses the `ddgs` Python
-package, lazy-installed on first use).
+package, lazy-installed on first use). Tavily was removed upstream and
+is no longer a valid backend value.
 
 ## Example
 

--- a/apps/app/docs/hermes-config/x-search.md
+++ b/apps/app/docs/hermes-config/x-search.md
@@ -18,7 +18,7 @@ pages, keep `web_search` / `web_extract`.
 
 **Credential path:** only the `XAI_API_KEY` path is supported here.
 SuperGrok / X Premium+ OAuth (`hermes auth add xai-oauth`) is **not**
-wired up in this app yet — set `XAI_API_KEY` instead.
+wired up in this app yet — set `XAI_API_KEY` instead. 
 
 The tool auto-enables when `XAI_API_KEY` is present and the `x_search`
 toolset is on. Disable explicitly via `hermes tools` → Search →
@@ -27,8 +27,8 @@ toolset is on. Disable explicitly via `hermes tools` → Search →
 ## Fields
 
 - `model` — xAI model id used for the Responses call. Default
-  `grok-4.20-reasoning`; any Grok model with `x_search` tool access
-  works. If the configured model lacks access, the call fails with
+  `grok-4.5`; any Grok model with `x_search` tool access works. If the
+  configured model lacks access, the call fails with
   "`x_search` is not enabled for this model".
 - `timeout_seconds` — request timeout in seconds (minimum `30`,
   default `180`). `x_search` can take 60–120s for complex queries, so
@@ -36,6 +36,10 @@ toolset is on. Disable explicitly via `hermes tools` → Search →
 - `retries` — number of automatic retries on `5xx` / `ReadTimeout` /
   `ConnectionError` (default `2`). Each retry backs off at `1.5 ×
   attempt` seconds, capped at `5s`.
+
+Upstream also supports `reasoning_effort` (`low`, `medium`, `high`,
+`xhigh`), which Hermeum deliberately does not surface — it passes
+through if written by hand.
 
 ## Environment variables
 
@@ -48,7 +52,7 @@ toolset is on. Disable explicitly via `hermes tools` → Search →
 ```yaml
 config:
   x_search:
-    model: grok-4.20-reasoning
+    model: grok-4.5
     timeout_seconds: 180
     retries: 2
 env:

--- a/apps/app/src/entities/agent.test.ts
+++ b/apps/app/src/entities/agent.test.ts
@@ -146,6 +146,32 @@ describe("AgentInputSchema api server key validation", () => {
     const result = AgentInputSchema.safeParse({ env: [{ name: "API_SERVER_ENABLED", value: "false" }] });
     expect(result.success).toBe(true);
   });
+
+  it("fails when the api server is enabled via config and API_SERVER_KEY is missing", () => {
+    const result = AgentInputSchema.safeParse({
+      config: { gateway: { api_server: { enabled: true } } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("succeeds when the api server is enabled via config and env has a sensitive API_SERVER_KEY", () => {
+    const result = AgentInputSchema.safeParse({
+      config: { gateway: { api_server: { enabled: true } } },
+      env: [{ name: "API_SERVER_KEY", value: "shh", sensitive: true }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("succeeds when config disables the api server while the env var enables it", () => {
+    const result = AgentInputSchema.safeParse({
+      config: { gateway: { api_server: { enabled: false } } },
+      env: [
+        { name: "API_SERVER_ENABLED", value: "true" },
+        { name: "API_SERVER_KEY", value: "shh", sensitive: true },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
 });
 
 describe("isApiServerEnabled", () => {
@@ -170,6 +196,34 @@ describe("isApiServerEnabled", () => {
     expect(isApiServerEnabled({ env: [] })).toBe(false);
     expect(isApiServerEnabled({ env: [{ name: "OTHER", value: "true" }] })).toBe(false);
   });
+
+  it("returns true when config.gateway.api_server.enabled is true", () => {
+    expect(
+      isApiServerEnabled({ config: { gateway: { api_server: { enabled: true } } } })
+    ).toBe(true);
+  });
+
+  it("returns false when config.gateway.api_server.enabled is false or absent", () => {
+    expect(
+      isApiServerEnabled({ config: { gateway: { api_server: { enabled: false } } } })
+    ).toBe(false);
+    expect(isApiServerEnabled({ config: { gateway: { api_server: {} } } })).toBe(false);
+  });
+
+  it("prefers the API_SERVER_ENABLED env var over config.gateway.api_server.enabled", () => {
+    expect(
+      isApiServerEnabled({
+        env: [{ name: "API_SERVER_ENABLED", value: "true" }],
+        config: { gateway: { api_server: { enabled: false } } },
+      })
+    ).toBe(true);
+    expect(
+      isApiServerEnabled({
+        env: [{ name: "API_SERVER_ENABLED", value: "false" }],
+        config: { gateway: { api_server: { enabled: true } } },
+      })
+    ).toBe(false);
+  });
 });
 
 describe("getApiServerPort", () => {
@@ -189,6 +243,30 @@ describe("getApiServerPort", () => {
     expect(getApiServerPort({ env: [{ name: "API_SERVER_PORT", value: "-1" }] })).toBe(8642);
     expect(getApiServerPort({ env: [{ name: "API_SERVER_PORT", value: "abc" }] })).toBe(8642);
     expect(getApiServerPort({ env: [{ name: "API_SERVER_PORT", value: "1.5" }] })).toBe(8642);
+  });
+
+  it("uses config.gateway.api_server.port when the env var is absent", () => {
+    expect(
+      getApiServerPort({ config: { gateway: { api_server: { port: 9000 } } } })
+    ).toBe(9000);
+  });
+
+  it("falls back to 8642 when config.gateway.api_server.port is not positive", () => {
+    expect(
+      getApiServerPort({ config: { gateway: { api_server: { port: 0 } } } })
+    ).toBe(8642);
+    expect(
+      getApiServerPort({ config: { gateway: { api_server: { port: -1 } } } })
+    ).toBe(8642);
+  });
+
+  it("prefers the API_SERVER_PORT env var over config.gateway.api_server.port", () => {
+    expect(
+      getApiServerPort({
+        env: [{ name: "API_SERVER_PORT", value: "9001" }],
+        config: { gateway: { api_server: { enabled: true, port: 9000 } } },
+      })
+    ).toBe(9001);
   });
 });
 
@@ -777,7 +855,7 @@ describe("deriveToolsetAvailability", () => {
     expect(
       deriveToolsetAvailability(
         ToolsetId.Web,
-        makeAgent({ config: { web: { search_backend: "tavily" } } })
+        makeAgent({ config: { web: { search_backend: "keenable" } } })
       ).status
     ).toBe("available");
   });
@@ -828,18 +906,12 @@ describe("deriveToolsetAvailability", () => {
     expect(deriveToolsetAvailability(ToolsetId.DiscordAdmin, agent).status).toBe("available");
   });
 
-  it("marks image_gen unavailable without FAL_KEY or gateway and available with either", () => {
+  it("marks image_gen unavailable without FAL_KEY and available with it", () => {
     expect(deriveToolsetAvailability(ToolsetId.ImageGen, makeAgent()).status).toBe("unavailable");
     expect(
       deriveToolsetAvailability(
         ToolsetId.ImageGen,
         makeAgent({ env: [{ name: "FAL_KEY", value: "fal-key", sensitive: true }] })
-      ).status
-    ).toBe("available");
-    expect(
-      deriveToolsetAvailability(
-        ToolsetId.ImageGen,
-        makeAgent({ config: { image_gen: { use_gateway: true } } })
       ).status
     ).toBe("available");
   });
@@ -885,6 +957,49 @@ describe("derivePlatformAvailability", () => {
         makeAgent({ env: [{ name: "API_SERVER_ENABLED", value: "true" }] })
       );
       expect(result).toEqual({ status: "available", port: 8642 });
+    });
+
+    it("is available when enabled via config.gateway.api_server", () => {
+      const result = derivePlatformAvailability(
+        PlatformId.ApiServer,
+        makeAgent({
+          config: { gateway: { api_server: { enabled: true } } },
+          env: [{ name: "API_SERVER_KEY", value: "shh", sensitive: true }],
+        })
+      );
+      expect(result).toEqual({ status: "available", port: 8642 });
+    });
+
+    it("uses config.gateway.api_server.port when the env var is absent", () => {
+      const result = derivePlatformAvailability(
+        PlatformId.ApiServer,
+        makeAgent({
+          config: { gateway: { api_server: { enabled: true, port: 9000 } } },
+        })
+      );
+      expect(result).toEqual({ status: "available", port: 9000 });
+    });
+
+    it("prefers API_SERVER_PORT over config.gateway.api_server.port", () => {
+      const result = derivePlatformAvailability(
+        PlatformId.ApiServer,
+        makeAgent({
+          config: { gateway: { api_server: { enabled: true, port: 9000 } } },
+          env: [{ name: "API_SERVER_PORT", value: "9001" }],
+        })
+      );
+      expect(result).toEqual({ status: "available", port: 9001 });
+    });
+
+    it("is unavailable when config disables the api server but the env var enables it", () => {
+      const result = derivePlatformAvailability(
+        PlatformId.ApiServer,
+        makeAgent({
+          config: { gateway: { api_server: { enabled: false } } },
+          env: [{ name: "API_SERVER_ENABLED", value: "true" }],
+        })
+      );
+      expect(result.status).toBe("available");
     });
 
     it("uses API_SERVER_PORT when set", () => {

--- a/apps/app/src/entities/agent/platform.ts
+++ b/apps/app/src/entities/agent/platform.ts
@@ -1,23 +1,32 @@
 import type { Agent, AgentInput } from "./schema";
 
-// API server settings are configured exclusively via env vars (see
-// docs/hermes-config/api-server.md). These helpers read those env vars off an
-// `AgentInput`.
+// API server settings can be configured via config.yaml
+// (config.gateway.api_server.enabled / port) or via env vars
+// (API_SERVER_ENABLED / API_SERVER_PORT). Environment variables take
+// precedence over the config values when both are set (upstream behavior);
+// the config block acts as a fallback when the env var is absent. The
+// bearer token (API_SERVER_KEY) is env-only — Hermeum does not surface it
+// in config.yaml.
+// See docs/hermes-config/api-server.md.
 const API_SERVER_DEFAULT_PORT = 8642;
 
 export function isApiServerEnabled(input: AgentInput): boolean {
-  return (
-    input.env?.some(
-      (v) => v.name === "API_SERVER_ENABLED" && v.value.toLowerCase() === "true"
-    ) ?? false
-  );
+  const envRaw = input.env?.find((v) => v.name === "API_SERVER_ENABLED")?.value;
+  if (envRaw !== undefined && envRaw.trim() !== "") {
+    return envRaw.toLowerCase() === "true";
+  }
+  return input.config?.gateway?.api_server?.enabled ?? false;
 }
 
 export function getApiServerPort(input: AgentInput): number {
-  const raw = input.env?.find((v) => v.name === "API_SERVER_PORT")?.value;
-  if (raw === undefined || raw.trim() === "") return API_SERVER_DEFAULT_PORT;
-  const n = Number(raw);
-  return Number.isInteger(n) && n > 0 ? n : API_SERVER_DEFAULT_PORT;
+  const envRaw = input.env?.find((v) => v.name === "API_SERVER_PORT")?.value;
+  if (envRaw !== undefined && envRaw.trim() !== "") {
+    const n = Number(envRaw);
+    return Number.isInteger(n) && n > 0 ? n : API_SERVER_DEFAULT_PORT;
+  }
+  const configPort = input.config?.gateway?.api_server?.port;
+  if (configPort !== undefined && configPort > 0) return configPort;
+  return API_SERVER_DEFAULT_PORT;
 }
 
 // Webhook settings can be configured via config.yaml
@@ -182,7 +191,10 @@ export function derivePlatformAvailability(id: PlatformId, agent: Agent): Platfo
   switch (id) {
     case PlatformId.ApiServer: {
       if (!isApiServerEnabled(agent)) {
-        return { status: "unavailable", reason: "Set API_SERVER_ENABLED=true to enable." };
+        return {
+          status: "unavailable",
+          reason: "Set API_SERVER_ENABLED=true (or config.gateway.api_server.enabled).",
+        };
       }
       const port = getApiServerPort(agent);
       return {

--- a/apps/app/src/entities/agent/schema.ts
+++ b/apps/app/src/entities/agent/schema.ts
@@ -311,7 +311,7 @@ export const AgentInputSchema = AgentInputObjectSchema.superRefine((data, ctx) =
     requireSensitiveEnv("WEBHOOK_SECRET", "webhook enabled (env var or config)");
   }
   if (isApiServerEnabled(data)) {
-    requireSensitiveEnv("API_SERVER_KEY", "env.API_SERVER_ENABLED");
+    requireSensitiveEnv("API_SERVER_KEY", "api server enabled (env var or config)");
   }
   if (isTeamsEnabled(data)) {
     requireSensitiveEnv("TEAMS_CLIENT_SECRET", "teams enabled (env var or config)");

--- a/apps/app/src/entities/agent/toolsets.ts
+++ b/apps/app/src/entities/agent/toolsets.ts
@@ -237,11 +237,9 @@ export function deriveToolsetAvailability(id: ToolsetId, agent: Agent): ToolsetA
         : { status: "unavailable", reason: "Set DISCORD_BOT_TOKEN to enable Discord." };
     }
     case ToolsetId.ImageGen: {
-      const hasFalKey = hasEnv("FAL_KEY");
-      const useGateway = config?.image_gen?.use_gateway === true;
-      return hasFalKey || useGateway
+      return hasEnv("FAL_KEY")
         ? { status: "available" }
-        : { status: "unavailable", reason: "Set FAL_KEY or enable the managed gateway." };
+        : { status: "unavailable", reason: "Set FAL_KEY to enable image generation." };
     }
     case ToolsetId.VideoGen: {
       const hasFalKey = hasEnv("FAL_KEY");

--- a/apps/app/src/entities/hermes-config/api-server.ts
+++ b/apps/app/src/entities/hermes-config/api-server.ts
@@ -1,0 +1,46 @@
+import { z } from "zod";
+
+// https://hermes-agent.nousresearch.com/docs/user-guide/features/api-server
+// Full field semantics: docs/hermes-config/api-server.md
+//
+// Mirrors the upstream `gateway.api_server:` block in config.yaml (flat
+// fields, no `extra:` nesting). Environment variables take precedence over
+// these config values when both are set.
+//
+// Only non-secret settings are typed here — `key` (the bearer token) is
+// env-only (API_SERVER_KEY, sensitive) and must not be written into
+// config.yaml. Upstream accepts it in config.yaml, but Hermeum does not
+// surface it (a hand-written key still passes through via looseObject).
+export const ApiServerSchema = z
+  .looseObject({
+    enabled: z.boolean().optional().describe("Whether the API server is enabled."),
+    port: z
+      .number()
+      .int()
+      .optional()
+      .describe("HTTP server port (default 8642)."),
+    host: z
+      .string()
+      .optional()
+      .describe("Bind address. Defaults to localhost only (127.0.0.1)."),
+    cors_origins: z
+      .string()
+      .optional()
+      .describe("Comma-separated allowed browser origins for CORS."),
+    model_name: z
+      .string()
+      .optional()
+      .describe("Model name advertised on /v1/models. Defaults to the profile name."),
+    max_concurrent_runs: z
+      .number()
+      .int()
+      .optional()
+      .describe(
+        "Concurrent-run cap across the OpenAI-compatible and Runs endpoints " +
+          "(default 10; 0 disables the limit)."
+      ),
+  })
+  .optional()
+  .describe("OpenAI-compatible API server configuration.");
+
+export type ApiServer = z.infer<typeof ApiServerSchema>;

--- a/apps/app/src/entities/hermes-config/browser.ts
+++ b/apps/app/src/entities/hermes-config/browser.ts
@@ -2,9 +2,16 @@ import { z } from "zod";
 
 // https://hermes-agent.nousresearch.com/docs/user-guide/features/browser
 // Full field semantics: docs/hermes-config/browser.md
+//
+// Skipped on purpose: cloud_provider value "nous" (managed Tool Gateway) —
+// it requires Nous Portal OAuth, which is not supported in container mode;
+// it still passes through via looseObject.
 export const BrowserCloudProviderSchema = z
-  .enum(["browserbase", "browser-use", "firecrawl", "camofox"])
-  .describe("Browser automation provider.");
+  .enum(["browserbase", "browser-use", "firecrawl", "camofox", "local"])
+  .describe(
+    "Browser automation provider. local uses the local agent-browser CLI / " +
+      "CDP path with cloud fallback disabled."
+  );
 
 export type BrowserCloudProvider = z.infer<typeof BrowserCloudProviderSchema>;
 

--- a/apps/app/src/entities/hermes-config/discord.ts
+++ b/apps/app/src/entities/hermes-config/discord.ts
@@ -4,6 +4,11 @@ import { z } from "zod";
 // Full field semantics: docs/hermes-config/discord.md
 // Only the essential fields are validated here; the rest pass through via
 // looseObject so users can configure whatever the Hermes agent supports.
+//
+// Skipped on purpose: discord.missed_message_backfill and the
+// websocket_liveness_interval_seconds / websocket_liveness_failure_threshold /
+// websocket_heartbeat_ack_max_age_seconds / websocket_max_latency_seconds
+// liveness knobs are not typed here — they pass through via looseObject.
 export const DiscordSchema = z
   .looseObject({
     require_mention: z

--- a/apps/app/src/entities/hermes-config/image-gen.ts
+++ b/apps/app/src/entities/hermes-config/image-gen.ts
@@ -2,13 +2,22 @@ import { z } from "zod";
 
 // https://hermes-agent.nousresearch.com/docs/user-guide/features/image-generation
 // Full field semantics: docs/hermes-config/image-gen.md
+//
+// Skipped on purpose: provider value "nous" (managed Tool
+// Gateway) is omitted — it requires Nous Portal OAuth, which is not
+// supported in container mode. It still passes through via looseObject if
+// written by hand. The legacy `use_gateway` boolean is no longer typed
+// here (upstream never writes it anymore).
 export const ImageGenSchema = z
   .looseObject({
-    model: z.string().optional().describe("FAL.ai model id (default fal-ai/flux-2/klein/9b)."),
-    use_gateway: z
-      .boolean()
+    provider: z
+      .string()
       .optional()
-      .describe("Use the managed Nous Subscription gateway instead of a direct FAL_KEY."),
+      .describe(
+        "Image-gen provider selection key: fal, openai, xai, krea, " +
+          "openrouter, ... The stored selection always wins over env keys."
+      ),
+    model: z.string().optional().describe("FAL.ai model id (default fal-ai/flux-2/klein/9b)."),
     max_parallel_requests: z
       .number()
       .int()
@@ -17,6 +26,6 @@ export const ImageGenSchema = z
       .describe("Concurrent images per tool-call batch (default 4)."),
   })
   .optional()
-  .describe("Image generation configuration. Requires FAL_KEY or the managed gateway.");
+  .describe("Image generation configuration. Requires FAL_KEY.");
 
 export type ImageGen = z.infer<typeof ImageGenSchema>;

--- a/apps/app/src/entities/hermes-config/index.ts
+++ b/apps/app/src/entities/hermes-config/index.ts
@@ -19,6 +19,7 @@ export {
   type Webhook,
 } from "./webhook";
 export { TeamsSchema, type Teams } from "./teams";
+export { ApiServerSchema, type ApiServer } from "./api-server";
 export { SlackSchema, ChannelSkillBindingSchema, type Slack, type ChannelSkillBinding } from "./slack";
 export { DiscordSchema, type Discord } from "./discord";
 export {
@@ -38,6 +39,7 @@ import { z } from "zod";
 import { ModelSchema } from "./model";
 import { WebhookSchema } from "./webhook";
 import { TeamsSchema } from "./teams";
+import { ApiServerSchema } from "./api-server";
 import { SlackSchema } from "./slack";
 import { DiscordSchema } from "./discord";
 import { WebSchema } from "./web";
@@ -60,10 +62,23 @@ export const PlatformsSchema = z
 
 export type Platforms = z.infer<typeof PlatformsSchema>;
 
+// Gateway-scoped server settings (config.gateway.*). Upstream documents the
+// API server block here — `gateway.api_server:` — rather than under
+// config.platforms.*.
+export const GatewaySchema = z
+  .looseObject({
+    api_server: ApiServerSchema,
+  })
+  .optional()
+  .describe("Gateway-scoped settings (API server, ...).");
+
+export type Gateway = z.infer<typeof GatewaySchema>;
+
 export const ConfigSchema = z
   .looseObject({
     model: ModelSchema,
     platforms: PlatformsSchema,
+    gateway: GatewaySchema,
     slack: SlackSchema,
     discord: DiscordSchema,
     web: WebSchema,

--- a/apps/app/src/entities/hermes-config/model.ts
+++ b/apps/app/src/entities/hermes-config/model.ts
@@ -2,6 +2,10 @@ import { z } from "zod";
 
 // https://hermes-agent.nousresearch.com/docs/integrations/providers
 // Full field semantics: docs/hermes-config/model.md
+//
+// Skipped on purpose: the provider enum and the `model:` key
+// alias for the default model id are NOT updated here yet — a separate PR
+// will update this file. Do not edit until then.
 export const ModelProviderSchema = z
   .enum([
     "nous",

--- a/apps/app/src/entities/hermes-config/model.ts
+++ b/apps/app/src/entities/hermes-config/model.ts
@@ -3,45 +3,51 @@ import { z } from "zod";
 // https://hermes-agent.nousresearch.com/docs/integrations/providers
 // Full field semantics: docs/hermes-config/model.md
 //
-// Skipped on purpose: the provider enum and the `model:` key
-// alias for the default model id are NOT updated here yet — a separate PR
-// will update this file. Do not edit until then.
+// Skipped on purpose: OAuth-gated providers are omitted — Hermeum does not
+// support browser OAuth in container mode, so there is no way to authorize
+// them. Excluded: nous, openai-codex, copilot, copilot-acp, xai-oauth,
+// qwen-oauth, minimax-oauth, vertex (service-account OAuth2 / ADC). They
+// still pass through via looseObject if written by hand.
+//
+// Upstream accepts either `default` or `model` as the key for the model id;
+// both work identically.
 export const ModelProviderSchema = z
   .enum([
-    "nous",
-    "openai-codex",
-    "copilot",
-    "copilot-acp",
     "anthropic",
     "openrouter",
+    "router",
+    "fireworks",
     "novita",
+    "ai-gateway",
     "zai",
     "kimi-coding",
     "kimi-coding-cn",
     "arcee",
     "gmi",
+    "nebius-token-factory",
+    "actual",
     "minimax",
     "minimax-cn",
     "xai",
-    "xai-oauth",
     "alibaba",
     "alibaba-coding-plan",
+    "alibaba-token-plan",
     "kilocode",
     "xiaomi",
     "tencent-tokenhub",
+    "tencent-tokenplan",
     "opencode-zen",
     "opencode-go",
+    "opencode-free",
+    "commandcode",
     "deepseek",
     "huggingface",
     "gemini",
-    "vertex",
     "openai-api",
     "azure-foundry",
     "bedrock",
     "nvidia",
     "ollama-cloud",
-    "qwen-oauth",
-    "minimax-oauth",
     "stepfun",
     "lmstudio",
     "custom",

--- a/apps/app/src/entities/hermes-config/slack.ts
+++ b/apps/app/src/entities/hermes-config/slack.ts
@@ -4,6 +4,15 @@ import { z } from "zod";
 // Full field semantics: docs/hermes-config/slack.md
 // Only the essential fields are validated here; the rest pass through via
 // looseObject so users can configure whatever the Hermes agent supports.
+//
+// Skipped on purpose: slack.require_mention_channels,
+// slack.ignore_other_user_mentions, slack.thread_require_mention,
+// slack.reaction_triggers, and the new platforms.slack.extra.* knobs
+// (unfurl_links, unfurl_media, feedback_buttons, native_task_cards,
+// suggested_prompts, assistant_thread_titles, allow_bots) and
+// platforms.slack.typing_status_text are not typed here — they pass through
+// via looseObject. unauthorized_dm_behavior stays pinned to "ignore":
+// Hermeum deployments deny-by-default rather than upstream's "pair" prompt.
 export const ChannelSkillBindingSchema = z
   .object({
     id: z.string().describe("Slack channel/DM ID the binding matches."),

--- a/apps/app/src/entities/hermes-config/web.ts
+++ b/apps/app/src/entities/hermes-config/web.ts
@@ -2,14 +2,20 @@ import { z } from "zod";
 
 // https://hermes-agent.nousresearch.com/docs/user-guide/features/web-search
 // Full field semantics: docs/hermes-config/web-search.md
+//
+// Skipped on purpose: web.extract_char_limit,
+// web.keyless_fallback, and web.keyless_rescue are validated by looseObject
+// pass-through, not typed here. The "nous" backend (managed Tool Gateway) is
+// also omitted — it requires Nous Portal OAuth, which is not supported in
+// container mode; it still passes through via looseObject if written by hand.
 export const WebSearchBackendSchema = z
-  .enum(["firecrawl", "searxng", "brave-free", "ddgs", "tavily", "exa", "parallel", "xai"])
+  .enum(["firecrawl", "searxng", "brave-free", "ddgs", "keenable", "exa", "parallel", "xai"])
   .describe("Web search backend.");
 
 export type WebSearchBackend = z.infer<typeof WebSearchBackendSchema>;
 
 export const WebExtractBackendSchema = z
-  .enum(["firecrawl", "tavily", "exa", "parallel"])
+  .enum(["firecrawl", "keenable", "exa", "parallel"])
   .describe("Web extract backend. Search-only backends are not allowed here.");
 
 export type WebExtractBackend = z.infer<typeof WebExtractBackendSchema>;

--- a/apps/app/src/entities/hermes-config/webhook.ts
+++ b/apps/app/src/entities/hermes-config/webhook.ts
@@ -2,6 +2,11 @@ import { z } from "zod";
 
 // https://hermes-agent.nousresearch.com/docs/user-guide/messaging/webhooks
 // Full field semantics: docs/hermes-config/webhooks.md
+//
+// Skipped on purpose: route fields secret, filters, script, and
+// toolsets are not typed here — Hermeum does not expose them via the agent
+// configuration UI (secrets stay env-only; filters/scripts/toolsets are
+// operator-level concerns). They still pass through via looseObject.
 export const WebhookDeliverSchema = z
   .enum([
     "log",

--- a/apps/app/src/entities/hermes-config/x-search.ts
+++ b/apps/app/src/entities/hermes-config/x-search.ts
@@ -3,13 +3,16 @@ import { z } from "zod";
 // https://hermes-agent.nousresearch.com/docs/user-guide/features/x-search
 // Full field semantics: docs/hermes-config/x-search.md
 // NOTE: only the XAI_API_KEY credential path is supported here
+//
+// Skipped on purpose: x_search.reasoning_effort (Grok-specific
+// knob) is not typed here; it passes through via looseObject.
 export const XSearchSchema = z
   .looseObject({
     model: z
       .string()
       .min(1)
       .optional()
-      .describe("xAI model id for the Responses call (default grok-4.20-reasoning)."),
+      .describe("xAI model id for the Responses call (default grok-4.5)."),
     timeout_seconds: z
       .number()
       .int()

--- a/apps/app/src/server/libs/config.ts
+++ b/apps/app/src/server/libs/config.ts
@@ -37,7 +37,7 @@ export const ConfigSchema = z.object({
     .describe("Container image repository for the Hermes agent (HERMEUM_HERMES_IMAGE_REPOSITORY)."),
   hermesImageTag: z
     .string()
-    .default("v2026.7.7.2")
+    .default("v2026.8.31")
     .describe("Container image tag for the Hermes agent (HERMEUM_HERMES_IMAGE_TAG)."),
   openaiModel: z
     .string()

--- a/apps/docs/docs/operation/configuration-reference.md
+++ b/apps/docs/docs/operation/configuration-reference.md
@@ -40,7 +40,7 @@ The container image emitted into every `HermesAgent` CR's `spec.image`.
 | Variable | Default | Description |
 | --- | --- | --- |
 | `HERMEUM_HERMES_IMAGE_REPOSITORY` | `nousresearch/hermes-agent` | Container image repository for the Hermes agent. Omit the registry host for Docker Hub, or include it (e.g. `ghcr.io/hermeum/hermes-agent`) for other registries. |
-| `HERMEUM_HERMES_IMAGE_TAG` | `v2026.7.7.2` | Container image tag for the Hermes agent. Pin to a specific release for reproducible agent pods. |
+| `HERMEUM_HERMES_IMAGE_TAG` | `v2026.8.31` | Container image tag for the Hermes agent. Pin to a specific release for reproducible agent pods. |
 
 ### Auth
 

--- a/charts/hermeum/Chart.yaml
+++ b/charts/hermeum/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hermeum
 description: Hermeum — control plane for HermesAgent custom resources.
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "0.0.1"
 home: https://github.com/hermeum/hermeum
 sources:

--- a/charts/hermeum/values.yaml
+++ b/charts/hermeum/values.yaml
@@ -52,7 +52,7 @@ config:
   # Container image repository for the Hermes agent (HERMEUM_HERMES_IMAGE_REPOSITORY).
   hermesImageRepository: nousresearch/hermes-agent
   # Container image tag for the Hermes agent (HERMEUM_HERMES_IMAGE_TAG).
-  hermesImageTag: v2026.7.7.2
+  hermesImageTag: v2026.8.31
   # OpenAI model id used by the AI config generator (HERMEUM_OPENAI_MODEL).
   openaiModel: gpt-5.5
   # Log verbosity level (HERMEUM_LOG_LEVEL): debug | info | warn | error.


### PR DESCRIPTION
## Summary

Upgrades the pinned hermes-agent release from `v2026.7.7.2` to `v2026.8.31` and syncs the Hermeum-side config schemas and docs with the official docs at the new submodule pin.

### Version bump (lockstep)

- `vendor/hermes-agent` submodule → `v2026.8.31` release commit
- `charts/hermeum/values.yaml` → `hermesImageTag: v2026.8.31`
- `apps/app/src/server/libs/config.ts` → Zod default `v2026.8.31`
- `apps/docs/docs/operation/configuration-reference.md` → `HERMEUM_HERMES_IMAGE_TAG` default
- `charts/hermeum/Chart.yaml` → chart `version` `0.1.2` (`appVersion` untouched — it tracks the Hermeum app release)

### `entities/hermes-config` + `docs/hermes-config` sync

- **web** — `tavily` backend removed upstream → replaced with `keenable` (search + extract enums); docs cover the keyless free-tier ring, one-shot keyless rescue, and the new auto-detection order. `nous` (managed Tool Gateway) omitted — requires Nous Portal OAuth, unsupported in container mode.
- **browser** — `cloud_provider` keeps `local`; `nous` omitted (OAuth) with a "Skipped on purpose" header comment.
- **image-gen** — new `provider` selection key; legacy `use_gateway` removed (availability is now `FAL_KEY`-only); `nous` omitted (OAuth).
- **x-search** — default model is now `grok-4.5`; `reasoning_effort` passes through untyped.
- **model** — `ModelProviderSchema` synced to the current upstream set minus OAuth-gated providers (`nous`, `openai-codex`, `copilot`, `copilot-acp`, `xai-oauth`, `qwen-oauth`, `minimax-oauth`, `vertex`); new API-key providers: `router`, `fireworks`, `ai-gateway`, `nebius-token-factory`, `actual`, `alibaba-token-plan`, `tencent-tokenplan`, `opencode-free`, `commandcode`. `model.md` gains a full provider→env-var requirements table sourced from the official providers doc.
- **api-server** (new) — validates the upstream `config.gateway.api_server` block (`enabled`/`port`/`host`/`cors_origins`/`model_name`/`max_concurrent_runs`) under a new `GatewaySchema`; env vars keep precedence over config per upstream; `API_SERVER_KEY` stays env-only (sensitive) with the `superRefine` requirement.
- **slack / discord / webhook** — header comments documenting deliberately skipped upstream fields (all still pass through via `looseObject`); Slack `unauthorized_dm_behavior` stays pinned to `"ignore"`.
- **teams / video-gen** — doc-only updates (upstream-differs credential note; DeepInfra now bundled).
- **agent platform plumbing** (`platform.ts`, `schema.ts`, `toolsets.ts`) updated for the api-server config path, with tests.

### Conventions

`AGENTS.md` gains an "Upgrading the hermes-agent image tag" procedure and the standing Hermeum policy deltas (OAuth-gated providers omitted, credentials env-only, operator-level concerns untyped, pinned behaviors stay pinned, per-platform env-vs-config precedence) so future upgrades don't re-litigate these decisions.

## Test plan

- `pnpm --filter @hermeum/app test` — 323 passed
- `pnpm --filter @hermeum/app typecheck` — only pre-existing baseline errors
- `pnpm --filter @hermeum/app lint` — only pre-existing warnings
- `pnpm prettier --check` on touched files — identical to baseline