### PR TITLE
feat(app): move agent config title into the code editor with a copy button

### DIFF
--- a/apps/app/src/client/ui/components/code-editor.tsx
+++ b/apps/app/src/client/ui/components/code-editor.tsx
@@ -1,6 +1,7 @@
 import CodeMirror, { EditorView } from "@uiw/react-codemirror";
 import { yaml as yamlLang } from "@codemirror/lang-yaml";
 import { cn } from "@hermeum/components/lib/utils";
+import { CopyButton } from "@/client/ui/components/copy-button";
 
 interface CodeEditorProps {
   value: string;
@@ -9,6 +10,7 @@ interface CodeEditorProps {
   invalid?: boolean;
   maxHeight?: string;
   height?: string;
+  title?: React.ReactNode;
 }
 
 export function CodeEditor({
@@ -18,6 +20,7 @@ export function CodeEditor({
   invalid = false,
   maxHeight,
   height,
+  title,
 }: CodeEditorProps) {
   return (
     <div
@@ -25,30 +28,39 @@ export function CodeEditor({
         "min-w-0 overflow-hidden rounded-[0.25rem] border text-sm",
         // With a percentage height the border must span the parent, not the content.
         height !== undefined && "h-full",
+        title !== undefined && "flex flex-col",
         invalid && "border-destructive"
       )}
     >
-      <CodeMirror
-        value={value}
-        extensions={[yamlLang(), EditorView.lineWrapping]}
-        {...(onChange !== undefined && { onChange })}
-        editable={!readOnly}
-        {...(maxHeight !== undefined && { maxHeight })}
-        {...(height !== undefined && { height })}
-        style={{ wordSpacing: "2.5px" }}
-        basicSetup={{
-          lineNumbers: true,
-          foldGutter: false,
-          searchKeymap: false,
-          autocompletion: false,
-          lintKeymap: false,
-          highlightActiveLine: !readOnly,
-          highlightActiveLineGutter: !readOnly,
-        }}
-        className={cn(
-          "h-full [&_.cm-content]:outline-none [&_.cm-editor.cm-focused]:outline-none [&_.cm-scroller]:font-sans! [&_.cm-scroller]:overflow-auto! [&_.cm-line]:py-[0.15rem]! [&_.cm-gutters]:border-r-0! [&_.cm-gutters]:bg-transparent! [&_.cm-gutterElement]:pl-3! [&_.cm-gutterElement]:pr-2! [&_.cm-gutterElement]:text-muted-foreground/60"
-        )}
-      />
+      {title !== undefined && (
+        <div className="flex h-8 shrink-0 items-center gap-1 pl-3 pr-1 text-sm font-medium">
+          <div className="min-w-0 flex-1 truncate">{title}</div>
+          <CopyButton text={value} />
+        </div>
+      )}
+      <div className={cn("min-w-0", title !== undefined && "min-h-0 flex-1")}>
+        <CodeMirror
+          value={value}
+          extensions={[yamlLang(), EditorView.lineWrapping]}
+          {...(onChange !== undefined && { onChange })}
+          editable={!readOnly}
+          {...(maxHeight !== undefined && { maxHeight })}
+          {...(height !== undefined && { height })}
+          style={{ wordSpacing: "2.5px" }}
+          basicSetup={{
+            lineNumbers: true,
+            foldGutter: false,
+            searchKeymap: false,
+            autocompletion: false,
+            lintKeymap: false,
+            highlightActiveLine: !readOnly,
+            highlightActiveLineGutter: !readOnly,
+          }}
+          className={cn(
+            "h-full [&_.cm-content]:outline-none [&_.cm-editor.cm-focused]:outline-none [&_.cm-scroller]:font-sans! [&_.cm-scroller]:overflow-auto! [&_.cm-line]:py-[0.15rem]! [&_.cm-gutters]:border-r-0! [&_.cm-gutters]:bg-transparent! [&_.cm-gutterElement]:pl-3! [&_.cm-gutterElement]:pr-2! [&_.cm-gutterElement]:text-muted-foreground/60"
+          )}
+        />
+      </div>
     </div>
   );
 }

--- a/apps/app/src/client/ui/routes/agents/$id/edit.tsx
+++ b/apps/app/src/client/ui/routes/agents/$id/edit.tsx
@@ -125,7 +125,6 @@ function EditAgentPage() {
 
   const configPane: ReactNode = (
     <div className="flex min-h-0 flex-1 flex-col gap-2">
-      <p className="shrink-0 text-sm font-medium">Agent config</p>
       <AgentPickerBar config={getConfig()} onChange={handlePickerChange} />
       <div className="min-h-0 flex-1">
         <CodeEditor
@@ -133,6 +132,7 @@ function EditAgentPage() {
           onChange={setEditorValue}
           invalid={!!validationError}
           height="100%"
+          title="Agent config"
         />
       </div>
       {validationError && (

--- a/apps/app/src/client/ui/routes/agents/new.tsx
+++ b/apps/app/src/client/ui/routes/agents/new.tsx
@@ -144,8 +144,8 @@ function NewAgentPage() {
       const { template } = view;
       return (
         <div className="flex min-h-0 flex-1 flex-col gap-2">
-          <div className="flex shrink-0 items-center justify-between gap-2">
-            <div className="flex min-w-0 items-center gap-1">
+          <div className="flex shrink-0 items-center justify-end gap-2">
+            <div className="flex min-w-0 flex-1 items-center gap-1">
               <Button
                 variant="ghost"
                 size="icon-xs"
@@ -154,10 +154,6 @@ function NewAgentPage() {
               >
                 <ArrowLeft />
               </Button>
-              <p className="min-w-0 truncate text-sm font-medium">
-                {template.name}
-                <span className="text-muted-foreground"> · Template</span>
-              </p>
             </div>
             <Button size="sm" onClick={() => handleUseTemplate(template)}>
               Use template
@@ -168,6 +164,12 @@ function NewAgentPage() {
               value={stringify(template.agentInput, YAML_OPTIONS).trim()}
               readOnly
               height="100%"
+              title={
+                <span className="min-w-0 truncate">
+                  {template.name}
+                  <span className="text-muted-foreground"> · Template</span>
+                </span>
+              }
             />
           </div>
         </div>
@@ -176,7 +178,6 @@ function NewAgentPage() {
 
     return (
       <div className="flex min-h-0 flex-1 flex-col gap-2">
-        <p className="shrink-0 text-sm font-medium">Agent config</p>
         <AgentPickerBar config={getConfig()} onChange={handlePickerChange} />
         <div className="min-h-0 flex-1">
           <CodeEditor
@@ -184,6 +185,7 @@ function NewAgentPage() {
             onChange={setEditorValue}
             invalid={!!validationError}
             height="100%"
+            title="Agent config"
           />
         </div>
         {validationError && (


### PR DESCRIPTION
## Summary

- Add an optional `title` prop to `CodeEditor` that renders a transparent, borderless header bar inside the editor's bordered container, with a copy button (reuses `CopyButton`) at the top-right corner that copies the editor's value.
- Replace the standalone `<p>Agent config</p>` above the editor with `title="Agent config"` on the create and edit agent pages.
- Move the template name (`<name> · Template`) from the preview row into the read-only editor's title on the create page.

## Notes

- Untitled usages (agent detail page, edit dialog) are unchanged — the title bar only renders when `title` is passed.
- `pnpm --filter @hermeum/app lint` and `test` pass; typecheck errors are pre-existing in `src/server/` (verified on a clean tree via stash).