### PR TITLE
feat(app): add source links to skills in the agent picker bar

### DIFF
--- a/apps/app/src/client/ui/routes/agents/-components/agent-picker-bar.tsx
+++ b/apps/app/src/client/ui/routes/agents/-components/agent-picker-bar.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
-import { Check, LoaderCircle, Plus } from "lucide-react";
+import { Check, ExternalLink, LoaderCircle, Plus } from "lucide-react";
 
 import { Button } from "@hermeum/components/ui/button";
 import { Input } from "@hermeum/components/ui/input";
@@ -178,7 +178,25 @@ function SkillsPicker({
                       }`}
                     />
                     <span className="min-w-0">
-                      <span className="font-mono">{s.name}</span>
+                      <span className="flex items-center gap-1">
+                        <span className="font-mono">{s.name}</span>
+                        {s.sourceUrl && (
+                          <a
+                            href={s.sourceUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            title="View source"
+                            className="shrink-0 text-muted-foreground hover:text-foreground"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              e.preventDefault();
+                              window.open(s.sourceUrl, "_blank", "noopener,noreferrer");
+                            }}
+                          >
+                            <ExternalLink className="size-3" />
+                          </a>
+                        )}
+                      </span>
                       {s.description && (
                         <span className="block opacity-80">{s.description}</span>
                       )}

--- a/apps/app/src/client/ui/routes/agents/-components/agent-picker-bar.tsx
+++ b/apps/app/src/client/ui/routes/agents/-components/agent-picker-bar.tsx
@@ -155,7 +155,7 @@ function SkillsPicker({
             value={input}
             onChange={(e) => setInput(e.target.value)}
             placeholder="Search skills by keyword…"
-            className="h-7 border-b-foreground/30 text-xs placeholder:opacity-70"
+            className="h-7 px-2 border-b-foreground/30 text-xs placeholder:opacity-70"
           />
           <div className="relative mt-1 max-h-64 overflow-y-auto">
             <div className="flex flex-col gap-0.5">
@@ -168,7 +168,7 @@ function SkillsPicker({
                   <button
                     key={s.identifier}
                     type="button"
-                    className="flex w-full items-start gap-2 rounded-none px-2 py-1.5 text-left text-xs hover:bg-background/20"
+                    className="flex w-full items-start gap-2 rounded-none py-1.5 text-left text-xs hover:bg-background/20"
                     title={s.identifier}
                     onClick={() => toggle(s.identifier)}
                   >

--- a/apps/app/src/entities/skill.ts
+++ b/apps/app/src/entities/skill.ts
@@ -185,6 +185,10 @@ export const SkillSummarySchema = z.object({
   name: z.string(),
   identifier: z.string(),
   description: z.string(),
+  // Where the skill's source lives (skills.sh detail page, GitHub tree, …).
+  // Optional — entries without a locatable source simply omit it and the UI
+  // hides the link.
+  sourceUrl: z.string().optional(),
 });
 
 export type SkillSummary = z.infer<typeof SkillSummarySchema>;

--- a/apps/app/src/server/infras/hermes-skill-index.test.ts
+++ b/apps/app/src/server/infras/hermes-skill-index.test.ts
@@ -48,9 +48,24 @@ describe("HermesSkillIndex", () => {
       const results = await adaptor.searchSkills("", 3);
 
       expect(results).toEqual([
-        { name: "kubernetes", identifier: "official/k8s/kubernetes", description: "Manage K8s clusters." },
-        { name: "kube-deploy", identifier: "github/openai/kube-deploy", description: "Deploy to kubernetes." },
-        { name: "git-pr-review", identifier: "github/openai/git-pr-review", description: "Review pull requests." },
+        {
+          name: "kubernetes",
+          identifier: "official/k8s/kubernetes",
+          description: "Manage K8s clusters.",
+          sourceUrl: "https://github.com/openai/skills/tree/HEAD/skills/git-pr-review",
+        },
+        {
+          name: "kube-deploy",
+          identifier: "github/openai/kube-deploy",
+          description: "Deploy to kubernetes.",
+          sourceUrl: "https://github.com/openai/skills/tree/HEAD/skills/git-pr-review",
+        },
+        {
+          name: "git-pr-review",
+          identifier: "github/openai/git-pr-review",
+          description: "Review pull requests.",
+          sourceUrl: "https://github.com/openai/skills/tree/HEAD/skills/git-pr-review",
+        },
       ]);
     });
 
@@ -95,13 +110,74 @@ describe("HermesSkillIndex", () => {
       expect(results).toHaveLength(2);
     });
 
-    it("only returns name, identifier, and description", async () => {
+    it("only returns name, identifier, description, and sourceUrl", async () => {
       vi.mocked(fetch).mockResolvedValue(jsonResponse(entries));
       const adaptor = new HermesSkillIndex();
 
       const [first] = await adaptor.searchSkills("kubernetes", 1);
 
-      expect(Object.keys(first ?? {}).sort()).toEqual(["description", "identifier", "name"]);
+      expect(Object.keys(first ?? {}).sort()).toEqual([
+        "description",
+        "identifier",
+        "name",
+        "sourceUrl",
+      ]);
+    });
+  });
+
+  describe("sourceUrl derivation", () => {
+    it("prefers extra.detail_url when present", async () => {
+      vi.mocked(fetch).mockResolvedValue(jsonResponse([
+        makeEntry({
+          source: "skills.sh",
+          identifier: "skills-sh/anthropics/skills/algorithmic-art",
+          repo: "anthropics/skills",
+          path: "algorithmic-art",
+          extra: {
+            detail_url: "https://skills.sh/anthropics/skills/algorithmic-art",
+            repo_url: "https://github.com/anthropics/skills",
+          },
+        }),
+      ]));
+      const adaptor = new HermesSkillIndex();
+
+      const [result] = await adaptor.searchSkills("algorithmic", 5);
+
+      expect(result?.sourceUrl).toBe("https://skills.sh/anthropics/skills/algorithmic-art");
+    });
+
+    it("builds a GitHub tree URL from repo + path", async () => {
+      vi.mocked(fetch).mockResolvedValue(jsonResponse([makeEntry()]));
+      const adaptor = new HermesSkillIndex();
+
+      const [result] = await adaptor.searchSkills("review", 5);
+
+      expect(result?.sourceUrl).toBe(
+        "https://github.com/openai/skills/tree/HEAD/skills/git-pr-review"
+      );
+    });
+
+    it("falls back to the bare repo URL when path is empty", async () => {
+      vi.mocked(fetch).mockResolvedValue(jsonResponse([
+        makeEntry({ source: "claude-marketplace", identifier: "anthropics/skills/", path: "" }),
+      ]));
+      const adaptor = new HermesSkillIndex();
+
+      const [result] = await adaptor.searchSkills("review", 5);
+
+      expect(result?.sourceUrl).toBe("https://github.com/openai/skills");
+    });
+
+    it("omits sourceUrl when neither detail_url nor repo is available", async () => {
+      const noSource = makeEntry();
+      delete noSource.repo;
+      delete noSource.path;
+      vi.mocked(fetch).mockResolvedValue(jsonResponse([noSource]));
+      const adaptor = new HermesSkillIndex();
+
+      const [result] = await adaptor.searchSkills("review", 5);
+
+      expect(result?.sourceUrl).toBeUndefined();
     });
   });
 

--- a/apps/app/src/server/infras/hermes-skill-index.ts
+++ b/apps/app/src/server/infras/hermes-skill-index.ts
@@ -24,6 +24,24 @@ export interface SkillIndexEntry {
   resolved_github_id?: string;
 }
 
+// Human-browsable source URL for a skill entry. Prefer the index's own detail
+// page (skills.sh entries carry `extra.detail_url`); fall back to the GitHub
+// tree for `repo`-backed entries (`tree/HEAD` resolves the default branch).
+// Returns undefined when no source can be located.
+function toSourceUrl(entry: SkillIndexEntry): string | undefined {
+  const detailUrl = entry.extra?.detail_url;
+  if (typeof detailUrl === "string" && detailUrl.length > 0) {
+    return detailUrl;
+  }
+  if (entry.repo !== undefined && entry.repo.length > 0) {
+    const base = `https://github.com/${entry.repo}`;
+    return entry.path !== undefined && entry.path.length > 0
+      ? `${base}/tree/HEAD/${entry.path}`
+      : base;
+  }
+  return undefined;
+}
+
 export class HermesSkillIndex implements SkillIndexAdaptor {
   #cache: { fetchedAt: number; skills: SkillIndexEntry[] } | null = null;
 
@@ -70,6 +88,7 @@ export class HermesSkillIndex implements SkillIndexAdaptor {
       name: entry.name,
       identifier: entry.identifier,
       description: entry.description,
+      sourceUrl: toSourceUrl(entry),
     });
 
     const queryLower = query.trim().toLowerCase();

--- a/apps/app/src/server/scripts/test-hermes-skill-index.ts
+++ b/apps/app/src/server/scripts/test-hermes-skill-index.ts
@@ -9,5 +9,7 @@ const results = await index.searchSkills(query, limit);
 
 console.log(`query=${JSON.stringify(query)} limit=${limit} count=${results.length}`);
 for (const r of results) {
-  console.log(`\n- ${r.name}  [${r.identifier}]\n  ${r.description}`);
+  console.log(
+    `\n- ${r.name}  [${r.identifier}]\n  ${r.description}\n  source: ${r.sourceUrl ?? "(none)"}`
+  );
 }


### PR DESCRIPTION
## Summary

Each skill row in the agent picker bar's `SkillsPicker` now shows an external-link icon next to the skill name, opening the skill's source in a new tab (without toggling selection), so users can understand a skill before adding it to an agent.

## Changes

- **`entities/skill.ts`** — `SkillSummarySchema` gains an optional `sourceUrl` field; entries without a locatable source simply omit it and the UI hides the link.
- **`server/infras/hermes-skill-index.ts`** — `toSourceUrl()` derives the URL per entry shape: prefers `extra.detail_url` (skills.sh detail pages), falls back to `https://github.com/{repo}/tree/HEAD/{path}` for `repo`-backed entries, then the bare `https://github.com/{repo}` when only `repo` exists.
- **`agent-picker-bar.tsx`** — external-link icon `<a>` next to the skill name (`target="_blank" rel="noopener noreferrer"`, `stopPropagation` so it doesn't toggle selection), rendered only when `sourceUrl` is present.
- **`test-hermes-skill-index.ts`** — manual verification script now prints the derived source.

## Verification

- Unit tests: 4 new branch tests (detail_url / repo+path / repo-only / none) + updated key-set test — all 13 pass; full app suite 327 passed.
- Live index run confirms both branches:
  - skills.sh entry → `https://skills.sh/anthropics/skills/algorithmic-art`
  - github/official entry → `https://github.com/anthropics/skills/tree/HEAD/skills/algorithmic-art`
- Lint and typecheck clean for all touched files (pre-existing errors elsewhere untouched).