### PR TITLE
feat(app): foldable agent config editor with diff view

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -21,6 +21,7 @@
     "@ai-sdk/react": "^4.0.27",
     "@codemirror/lang-json": "^6.0.2",
     "@codemirror/lang-yaml": "^6.1.3",
+    "@codemirror/merge": "^6.12.2",
     "@hermeum/components": "workspace:*",
     "@kubernetes/client-node": "^1.4.0",
     "@replit/codemirror-indentation-markers": "^6.5.3",

--- a/apps/app/src/client/ui/components/agent-config-editor.tsx
+++ b/apps/app/src/client/ui/components/agent-config-editor.tsx
@@ -4,7 +4,7 @@ import { unifiedMergeView } from "@codemirror/merge";
 import { cn } from "@hermeum/components/lib/utils";
 import { CopyButton } from "@/client/ui/components/copy-button";
 
-interface CodeEditorProps {
+interface AgentConfigEditorProps {
   value: string;
   onChange?: (value: string) => void;
   readOnly?: boolean;
@@ -16,7 +16,7 @@ interface CodeEditorProps {
   originalValue?: string;
 }
 
-export function CodeEditor({
+export function AgentConfigEditor({
   value,
   onChange,
   readOnly = false,
@@ -26,7 +26,7 @@ export function CodeEditor({
   title,
   foldable = false,
   originalValue,
-}: CodeEditorProps) {
+}: AgentConfigEditorProps) {
   return (
     <div
       className={cn(
@@ -77,7 +77,7 @@ export function CodeEditor({
             highlightActiveLineGutter: !readOnly,
           }}
           className={cn(
-            "h-full [&_.cm-content]:outline-none [&_.cm-editor.cm-focused]:outline-none [&_.cm-scroller]:font-sans! [&_.cm-scroller]:overflow-auto! [&_.cm-line]:py-[0.15rem]! [&_.cm-gutters]:border-r-0! [&_.cm-gutters]:bg-transparent! [&_.cm-gutterElement]:pl-3! [&_.cm-gutterElement]:pr-2! [&_.cm-gutterElement]:text-muted-foreground/60"
+            "h-full [&_.cm-content]:outline-none! [&_.cm-editor.cm-focused]:outline-none! [&_.cm-scroller]:font-sans! [&_.cm-scroller]:overflow-auto! [&_.cm-line]:py-[0.15rem]! [&_.cm-gutters]:border-r-0! [&_.cm-gutters]:bg-transparent! [&_.cm-gutterElement]:pl-3! [&_.cm-gutterElement]:pr-2! [&_.cm-gutterElement]:text-muted-foreground/60"
           )}
         />
       </div>

--- a/apps/app/src/client/ui/components/code-editor.tsx
+++ b/apps/app/src/client/ui/components/code-editor.tsx
@@ -11,6 +11,7 @@ interface CodeEditorProps {
   maxHeight?: string;
   height?: string;
   title?: React.ReactNode;
+  foldable?: boolean;
 }
 
 export function CodeEditor({
@@ -21,6 +22,7 @@ export function CodeEditor({
   maxHeight,
   height,
   title,
+  foldable = false,
 }: CodeEditorProps) {
   return (
     <div
@@ -49,7 +51,7 @@ export function CodeEditor({
           style={{ wordSpacing: "2.5px" }}
           basicSetup={{
             lineNumbers: true,
-            foldGutter: false,
+            foldGutter: foldable,
             searchKeymap: false,
             autocompletion: false,
             lintKeymap: false,

--- a/apps/app/src/client/ui/components/code-editor.tsx
+++ b/apps/app/src/client/ui/components/code-editor.tsx
@@ -1,5 +1,6 @@
 import CodeMirror, { EditorView } from "@uiw/react-codemirror";
 import { yaml as yamlLang } from "@codemirror/lang-yaml";
+import { unifiedMergeView } from "@codemirror/merge";
 import { cn } from "@hermeum/components/lib/utils";
 import { CopyButton } from "@/client/ui/components/copy-button";
 
@@ -12,6 +13,7 @@ interface CodeEditorProps {
   height?: string;
   title?: React.ReactNode;
   foldable?: boolean;
+  originalValue?: string;
 }
 
 export function CodeEditor({
@@ -23,6 +25,7 @@ export function CodeEditor({
   height,
   title,
   foldable = false,
+  originalValue,
 }: CodeEditorProps) {
   return (
     <div
@@ -43,7 +46,22 @@ export function CodeEditor({
       <div className={cn("min-w-0", title !== undefined && "min-h-0 flex-1")}>
         <CodeMirror
           value={value}
-          extensions={[yamlLang(), EditorView.lineWrapping]}
+          extensions={[
+            yamlLang(),
+            EditorView.lineWrapping,
+            ...(originalValue !== undefined && !readOnly
+              ? [
+                  unifiedMergeView({
+                    original: originalValue,
+                    // Show the diff (line highlights + deleted-content
+                    // widgets) without merge interactivity or text-level
+                    // underline marks.
+                    highlightChanges: false,
+                    mergeControls: false,
+                  }),
+                ]
+              : []),
+          ]}
           {...(onChange !== undefined && { onChange })}
           editable={!readOnly}
           {...(maxHeight !== undefined && { maxHeight })}

--- a/apps/app/src/client/ui/routes/agents/$id/-components/edit-agent-dialog.tsx
+++ b/apps/app/src/client/ui/routes/agents/$id/-components/edit-agent-dialog.tsx
@@ -5,7 +5,7 @@ import { toast } from "sonner";
 import { useTRPC } from "@/router";
 import type { Agent, AgentInput } from "@/entities";
 import { AgentInputObjectSchema, AgentInputSchema } from "@/entities";
-import { CodeEditor } from "@/client/ui/components/code-editor";
+import { AgentConfigEditor } from "@/client/ui/components/agent-config-editor";
 import { Button } from "@hermeum/components/ui/button";
 import {
   Dialog,
@@ -98,7 +98,7 @@ export function EditInstanceDialog({ instance, open, onOpenChange }: EditInstanc
         </DialogHeader>
 
         <div className="min-h-0 min-w-0 flex-1 overflow-y-auto space-y-2 p-px">
-          <CodeEditor
+          <AgentConfigEditor
             value={editorValue}
             onChange={setEditorValue}
             invalid={!!validationError}

--- a/apps/app/src/client/ui/routes/agents/$id/edit.tsx
+++ b/apps/app/src/client/ui/routes/agents/$id/edit.tsx
@@ -15,7 +15,7 @@ import { useTRPC } from "@/router";
 import { AgentInputObjectSchema, AgentInputSchema } from "@/entities";
 import type { AgentInput } from "@/entities";
 import { AgentConfigChat } from "@/client/ui/components/agent-config-chat";
-import { CodeEditor } from "@/client/ui/components/code-editor";
+import { AgentConfigEditor } from "@/client/ui/components/agent-config-editor";
 import { AgentEditorMobileTabs } from "../-components/agent-editor-mobile-tabs";
 import { AgentPickerBar } from "../-components/agent-picker-bar";
 
@@ -131,7 +131,7 @@ function EditAgentPage() {
     <div className="flex min-h-0 flex-1 flex-col gap-2">
       <AgentPickerBar config={getConfig()} onChange={handlePickerChange} />
       <div className="min-h-0 flex-1">
-        <CodeEditor
+        <AgentConfigEditor
           value={editorValue}
           onChange={setEditorValue}
           invalid={!!validationError}

--- a/apps/app/src/client/ui/routes/agents/$id/edit.tsx
+++ b/apps/app/src/client/ui/routes/agents/$id/edit.tsx
@@ -137,6 +137,7 @@ function EditAgentPage() {
           invalid={!!validationError}
           height="100%"
           title="Agent config"
+          originalValue={agentToYaml(agent)}
         />
       </div>
       {validationError && (

--- a/apps/app/src/client/ui/routes/agents/$id/index.tsx
+++ b/apps/app/src/client/ui/routes/agents/$id/index.tsx
@@ -367,6 +367,7 @@ function AgentDetailPage() {
                   value={stringifyYaml(agent.config, { blockQuote: "literal", lineWidth: 0 }).trim()}
                   readOnly
                   maxHeight="300px"
+                  foldable
                 />
               ) : (
                 <p className="text-sm text-muted-foreground">Not set — use Edit to configure.</p>

--- a/apps/app/src/client/ui/routes/agents/$id/index.tsx
+++ b/apps/app/src/client/ui/routes/agents/$id/index.tsx
@@ -25,7 +25,7 @@ import {
 import { PhaseBadge } from "@/client/ui/components/phase-badge";
 import { Button } from "@hermeum/components/ui/button";
 import { EditInstanceDialog } from "./-components/edit-agent-dialog";
-import { CodeEditor } from "@/client/ui/components/code-editor";
+import { AgentConfigEditor } from "@/client/ui/components/agent-config-editor";
 import { CopyButton } from "@/client/ui/components/copy-button";
 import {
   Accordion,
@@ -363,7 +363,7 @@ function AgentDetailPage() {
             <div className="py-8 flex flex-col gap-3">
               <p className="text-sm font-bold">Configuration</p>
               {agent.config ? (
-                <CodeEditor
+                <AgentConfigEditor
                   value={stringifyYaml(agent.config, { blockQuote: "literal", lineWidth: 0 }).trim()}
                   readOnly
                   maxHeight="300px"

--- a/apps/app/src/client/ui/routes/agents/new.tsx
+++ b/apps/app/src/client/ui/routes/agents/new.tsx
@@ -16,7 +16,7 @@ import { useTRPC } from "@/router";
 import { AgentInputObjectSchema, AgentInputSchema } from "@/entities";
 import type { AgentInput, Template } from "@/entities";
 import { AgentConfigChat } from "@/client/ui/components/agent-config-chat";
-import { CodeEditor } from "@/client/ui/components/code-editor";
+import { AgentConfigEditor } from "@/client/ui/components/agent-config-editor";
 import { AgentEditorMobileTabs } from "./-components/agent-editor-mobile-tabs";
 import { AgentPickerBar } from "./-components/agent-picker-bar";
 
@@ -164,7 +164,7 @@ function NewAgentPage() {
             </Button>
           </div>
           <div className="min-h-0 flex-1">
-            <CodeEditor
+            <AgentConfigEditor
               value={stringify(template.agentInput, YAML_OPTIONS).trim()}
               readOnly
               height="100%"
@@ -184,7 +184,7 @@ function NewAgentPage() {
       <div className="flex min-h-0 flex-1 flex-col gap-2">
         <AgentPickerBar config={getConfig()} onChange={handlePickerChange} />
         <div className="min-h-0 flex-1">
-          <CodeEditor
+          <AgentConfigEditor
             value={editorValue}
             onChange={setEditorValue}
             invalid={!!validationError}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@codemirror/lang-yaml':
         specifier: ^6.1.3
         version: 6.1.3
+      '@codemirror/merge':
+        specifier: ^6.12.2
+        version: 6.12.2
       '@hermeum/components':
         specifier: workspace:*
         version: link:../../packages/components
@@ -1151,6 +1154,9 @@ packages:
 
   '@codemirror/lint@6.9.7':
     resolution: {integrity: sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==}
+
+  '@codemirror/merge@6.12.2':
+    resolution: {integrity: sha512-V8JvyAPjHbPupqP7BeMcsdsYCbyPij74jxIbaIJDORI+VZzW44zFmon8bF+oxGWvOKhcRmkiUMXd8MxHr3YA2w==}
 
   '@codemirror/search@6.7.1':
     resolution: {integrity: sha512-uMe5UO6PamJtSHrXhhHOzSX3ReWtiJrva6GnPMwSOrZtiExb5X5eExhr2OUZQVvdxPsKpY3Ro2mFbQadpPWmHA==}
@@ -5297,6 +5303,7 @@ packages:
   eslint@9.39.5:
     resolution: {integrity: sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -10381,6 +10388,14 @@ snapshots:
       '@codemirror/state': 6.7.1
       '@codemirror/view': 6.43.8
       crelt: 1.0.7
+
+  '@codemirror/merge@6.12.2':
+    dependencies:
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.1
+      '@codemirror/view': 6.43.8
+      '@lezer/highlight': 1.2.3
+      style-mod: 4.1.3
 
   '@codemirror/search@6.7.1':
     dependencies:


### PR DESCRIPTION
## Summary

Improves readability of the agent configuration editor:

- **Foldable config display**: the read-only config editor on the agent detail page now shows CodeMirror's fold gutter so long YAML can be collapsed per block (`foldable` prop on the editor).
- **Diff against original**: the guided edit page highlights changes (added lines + deleted-content widgets) against the persisted agent config, via `@codemirror/merge`'s `unifiedMergeView` — diff-only display: no accept/reject buttons and no text-level underline marks (`mergeControls: false`, `highlightChanges: false`).
- **Rename `CodeEditor` → `AgentConfigEditor`**: clearer name for what the component is (an agent config editor), with the new `originalValue` prop.
- **Fix focus outline**: CodeMirror's runtime-injected (unlayered) focus outline beat Tailwind's layered utilities; use `outline-none!` so clicking the editor no longer shows the dotted rectangle.

## Test plan

- [x] Agent detail page: config editor shows fold gutter; blocks fold/unfold
- [x] Guided edit page: editing or letting the chat rewrite the config highlights changed lines vs. the original; no accept/reject buttons
- [x] Clicking into the editor shows no dotted focus outline
- [x] `pnpm --filter @hermeum/app typecheck` (no new client errors) and `lint` pass