### PR TITLE
feat(app): add templates and persist storage for agent types

### DIFF
--- a/apps/app/config.default.yaml
+++ b/apps/app/config.default.yaml
@@ -85,7 +85,7 @@ templates:
       name: Software Engineer
       description: An autonomous software engineer. Given a task, it reads the code, implements the change with tests, and opens a pull request. Also reviews code on request and debugs failures to root cause.
 
-      type: medium
+      type: large
       soul: |-
         You are a software engineer. You own engineering work end-to-end:
         writing code, opening pull requests, reviewing changes, and debugging
@@ -139,7 +139,8 @@ agentTypes:
   medium:
     description: >-
       Standard performance — handles everyday workloads reliably, including
-      browsing and web search. A good fit for most agents.
+      browsing and web search. A good fit for most agents. Persists the agent
+      workspace on a 10Gi volume.
     mutatingWebhookJsonPatch:
       # Both sidecars enabled.
       - - op: test
@@ -157,6 +158,12 @@ agentTypes:
             limits:
               cpu: "4"
               memory: 2Gi
+        - op: add
+          path: /spec/hermes/storage
+          value:
+            persistence:
+              enabled: true
+              size: 10Gi
         - op: add
           path: /spec/searxng/resources
           value:
@@ -189,6 +196,12 @@ agentTypes:
               cpu: "4"
               memory: 2Gi
         - op: add
+          path: /spec/hermes/storage
+          value:
+            persistence:
+              enabled: true
+              size: 10Gi
+        - op: add
           path: /spec/searxng/resources
           value:
             requests:
@@ -211,6 +224,12 @@ agentTypes:
               cpu: "4"
               memory: 2Gi
         - op: add
+          path: /spec/hermes/storage
+          value:
+            persistence:
+              enabled: true
+              size: 10Gi
+        - op: add
           path: /spec/camofox/resources
           value:
             requests:
@@ -229,10 +248,17 @@ agentTypes:
             limits:
               cpu: "4"
               memory: 2Gi
+        - op: add
+          path: /spec/hermes/storage
+          value:
+            persistence:
+              enabled: true
+              size: 10Gi
   large:
     description: >-
       High performance — extra capacity for demanding tasks, such as very long
       conversations, heavy document analysis, or many concurrent users.
+      Persists the agent workspace on a 20Gi volume.
     mutatingWebhookJsonPatch:
       # Both sidecars enabled.
       - - op: test
@@ -250,6 +276,12 @@ agentTypes:
             limits:
               cpu: "8"
               memory: 4Gi
+        - op: add
+          path: /spec/hermes/storage
+          value:
+            persistence:
+              enabled: true
+              size: 20Gi
         - op: add
           path: /spec/searxng/resources
           value:
@@ -282,6 +314,12 @@ agentTypes:
               cpu: "8"
               memory: 4Gi
         - op: add
+          path: /spec/hermes/storage
+          value:
+            persistence:
+              enabled: true
+              size: 20Gi
+        - op: add
           path: /spec/searxng/resources
           value:
             requests:
@@ -304,6 +342,12 @@ agentTypes:
               cpu: "8"
               memory: 4Gi
         - op: add
+          path: /spec/hermes/storage
+          value:
+            persistence:
+              enabled: true
+              size: 20Gi
+        - op: add
           path: /spec/camofox/resources
           value:
             requests:
@@ -322,3 +366,9 @@ agentTypes:
             limits:
               cpu: "8"
               memory: 4Gi
+        - op: add
+          path: /spec/hermes/storage
+          value:
+            persistence:
+              enabled: true
+              size: 20Gi

--- a/apps/app/config.default.yaml
+++ b/apps/app/config.default.yaml
@@ -135,6 +135,60 @@ templates:
         - skills/software-development/github
         - skills/software-development/requesting-code-review
         - openai/skills/skills/.curated/gh-fix-ci
+  - id: marketer
+    name: Marketing Content Agent
+    description: Plans campaigns, drafts and publishes X posts and blog articles, and monitors competitors.
+    agentInput:
+      name: Marketing Content Agent
+      description: A hands-on marketing agent. Plans campaigns, drafts and publishes X posts and blog articles, repurposes content across formats, and monitors competitors and market news.
+      type: medium
+      soul: |-
+        You are a marketing agent. You own marketing work end-to-end:
+        campaign planning, social posts, blog articles, and market
+        intelligence. You do not hand back half-done work — when you take a
+        task, you carry it to a ready-to-post deliverable.
+
+        Write like a marketer, not like an AI: no hype language, no filler,
+        no "delve" or "game-changer". Ground every claim about competitors
+        or the market in sources you actually found. When you couldn't
+        verify something, say so.
+
+        Publishing is a two-step: draft, get human approval, then post.
+        Never publish on your own initiative. If a brief is ambiguous,
+        ask before writing.
+
+        When authenticating xurl with OAuth2, always use the `--headless` option.
+      config:
+        model:
+          provider: openai-api
+          default: gpt-5.6-terra
+      env:
+        - name: OPENAI_API_KEY
+          value: <fill-me>
+          sensitive: true
+        - name: FAL_KEY
+          value: <fill-me>
+          sensitive: true
+        - name: SLACK_BOT_TOKEN
+          value: <fill-me>
+          sensitive: true
+        - name: SLACK_APP_TOKEN
+          value: <fill-me>
+          sensitive: true
+        - name: SLACK_ALLOWED_USERS
+          value: <fill-me>
+        - name: SLACK_HOME_CHANNEL
+          value: <fill-me>
+      skills:
+        - skills/research/rss-feeds
+        - optional-skills/research/blogwatcher
+        - skills/research/competitor-news-monitor
+        - skills/media/youtube-content
+        - skills/creative/humanizer
+        - skills/social-media/xurl
+      packages:
+        pip:
+          - youtube-transcript-api
 agentTypes:
   medium:
     description: >-

--- a/apps/app/config.default.yaml
+++ b/apps/app/config.default.yaml
@@ -13,7 +13,7 @@ templates:
       config:
         model:
           provider: openai-api
-          default: gpt-5.5
+          default: gpt-5.6-sol
       env:
         - name: OPENAI_API_KEY
           value: <fill-me>
@@ -34,7 +34,7 @@ templates:
       config:
         model:
           provider: openai-api
-          default: gpt-5.5
+          default: gpt-5.6-sol
         platforms:
           webhook:
             enabled: true
@@ -78,56 +78,63 @@ templates:
           value: <fill-me>
         - name: SLACK_HOME_CHANNEL
           value: <fill-me>
-  - id: code-reviewer
-    name: Code Reviewer
-    description: Reviews GitHub pull requests and post a feedback back to the PR.
+  - id: software-engineer
+    name: Software Engineer
+    description: Implements changes with tests, opens pull requests, and debugs failures.
     agentInput:
-      name: GitHub PR Code Reviewer
-      description: Reviews GitHub pull requests received via webhook and posts review feedback back to the PR.
+      name: Software Engineer
+      description: An autonomous software engineer. Given a task, it reads the code, implements the change with tests, and opens a pull request. Also reviews code on request and debugs failures to root cause.
+
       type: medium
-      soul: You are a pragmatic senior software engineer reviewing pull requests. Focus on correctness, maintainability, security, performance, and test coverage; be direct, specific, and constructive.
+      soul: |-
+        You are a software engineer. You own engineering work end-to-end:
+        writing code, opening pull requests, reviewing changes, and debugging
+        failures. You do not hand the work back half-done — when you take a
+        task, you carry it to review-ready.
+
+        Work from evidence. Read the issue, the surrounding code, and the
+        tests before writing anything; read the actual error before
+        proposing a fix. Keep every change minimal and reviewable — one
+        concern per pull request — and write tests for new behavior. Run
+        the test suite before opening a PR; if you couldn't, say so in the
+        description rather than implying it passes.
+
+        When reviewing, be direct and specific: correctness first, then
+        security, maintainability, and performance. Cite file and line, and
+        suggest the fix rather than just the flaw.
+
+        When debugging, reproduce before theorizing. Separate facts from
+        hypotheses, and fix the root cause, not the symptom.
+
+        Never push to a protected branch or rewrite history — finished work
+        goes through a pull request. If a task is ambiguous or larger than
+        one focused change, say what you'd cut or ask for direction before
+        writing code.
       config:
         model:
           provider: openai-api
-          default: gpt-5.5
-        platforms:
-          webhook:
-            enabled: true
-            extra:
-              port: 8644
-              routes:
-                github-pr-review:
-                  events:
-                    - pull_request
-                  prompt: |-
-                    Review this GitHub pull request using the loaded GitHub code review skill.
-
-                    Repository: {repository.full_name}
-                    PR #{number}: {pull_request.title}
-                    Author: {pull_request.user.login}
-                    URL: {pull_request.html_url}
-                    Diff URL: {pull_request.diff_url}
-                    Action: {action}
-
-                    Provide concise, actionable review feedback. Prioritize high-impact issues and include file/line references where possible.
-                  skills:
-                    - github-code-review
-                  deliver: github_comment
-                  deliver_extra:
-                    repo: "{repository.full_name}"
-                    pr_number: "{number}"
+          default: gpt-5.6-sol
       env:
         - name: OPENAI_API_KEY
-          value: <fill-me>
-          sensitive: true
-        - name: WEBHOOK_SECRET
           value: <fill-me>
           sensitive: true
         - name: GITHUB_TOKEN
           value: <fill-me>
           sensitive: true
-skills:
-  - skills/github/github-code-review
+        - name: SLACK_BOT_TOKEN
+          value: <fill-me>
+          sensitive: true
+        - name: SLACK_APP_TOKEN
+          value: <fill-me>
+          sensitive: true
+        - name: SLACK_ALLOWED_USERS
+          value: <fill-me>
+        - name: SLACK_HOME_CHANNEL
+          value: <fill-me>
+      skills:
+        - skills/software-development/github
+        - skills/software-development/requesting-code-review
+        - openai/skills/skills/.curated/gh-fix-ci
 agentTypes:
   medium:
     description: >-

--- a/apps/app/config.default.yaml
+++ b/apps/app/config.default.yaml
@@ -1,15 +1,19 @@
 templates:
   - id: support-agent
     name: Support Agent
-    description: Answers support questions using the docs and Notion knowledge base.
+    description: Handles customer-support conversations through email using the docs and Notion knowledge base.
     agentInput:
       name: Support Agent
-      description: Answers support questions using the docs and Notion knowledge base, and escalates to a human when the answer is missing, uncertain, or requires account-specific handling.
+      description: Handles customer-support conversations through email using the docs and Notion knowledge base, and communicates with owners through Slack for escalations, guidance, and account-specific decisions.
       type: medium
       soul: |-
-        You are a helpful support agent grounded in the company's documentation and Notion knowledge base. Answer clearly and practically, cite or reference the source material when possible, and do not invent policies or product behavior.
+        You are a dependable customer-support agent. Be clear, practical, and empathetic. Ground every answer in the company's documentation and Notion knowledge base, and never invent policies, promises, or product behavior.
 
-        Escalate when the knowledge base does not contain enough information, the user reports a bug or outage, the issue involves billing/account/security/privacy, or the user needs a human decision. When escalating, summarize the user's question, relevant context, what you checked, and the next action needed.
+        Escalate to the owners when information is missing or uncertain, a customer reports a bug or outage, the issue involves billing, accounts, security, or privacy, or a human decision is needed. Provide the relevant context and get owner confirmation before sending the customer an answer that depends on the escalation.
+
+        Email: Use the Himalaya skill for customer support. Read `EMAIL_ADDRESS` and `EMAIL_PASSWORD` from the deployment `.env`, and never disclose credentials.
+
+        Slack: Use it only for internal communication with owners, including escalations and confirmations. Never expose internal discussions to customers.
       config:
         model:
           provider: openai-api
@@ -21,8 +25,79 @@ templates:
         - name: NOTION_API_KEY
           value: <fill-me>
           sensitive: true
+        - name: EMAIL_ADDRESS
+          value: <fill-me>
+        - name: EMAIL_PASSWORD
+          value: <fill-me>
+          sensitive: true
+        - name: SLACK_BOT_TOKEN
+          value: <fill-me>
+          sensitive: true
+        - name: SLACK_APP_TOKEN
+          value: <fill-me>
+          sensitive: true
+        - name: SLACK_ALLOWED_USERS
+          value: <fill-me>
+        - name: SLACK_HOME_CHANNEL
+          value: <fill-me>
       skills:
         - skills/productivity/notion
+        - skills/creative/humanizer
+        - skills/email/himalaya
+  - id: marketer
+    name: Marketing Content Agent
+    description: Plans campaigns, drafts and publishes X posts and blog articles, and monitors competitors.
+    agentInput:
+      name: Marketing Content Agent
+      description: A hands-on marketing agent. Plans campaigns, drafts and publishes X posts and blog articles, repurposes content across formats, and monitors competitors and market news.
+      type: medium
+      soul: |-
+        You are a marketing agent. You own marketing work end-to-end:
+        campaign planning, social posts, blog articles, and market
+        intelligence. You do not hand back half-done work — when you take a
+        task, you carry it to a ready-to-post deliverable.
+
+        Write like a marketer, not like an AI: no hype language, no filler,
+        no "delve" or "game-changer". Ground every claim about competitors
+        or the market in sources you actually found. When you couldn't
+        verify something, say so.
+
+        Publishing is a two-step: draft, get human approval, then post.
+        Never publish on your own initiative. If a brief is ambiguous,
+        ask before writing.
+
+        When authenticating xurl with OAuth2, always use the `--headless` option.
+      config:
+        model:
+          provider: openai-api
+          default: gpt-5.6-terra
+      env:
+        - name: OPENAI_API_KEY
+          value: <fill-me>
+          sensitive: true
+        - name: FAL_KEY
+          value: <fill-me>
+          sensitive: true
+        - name: SLACK_BOT_TOKEN
+          value: <fill-me>
+          sensitive: true
+        - name: SLACK_APP_TOKEN
+          value: <fill-me>
+          sensitive: true
+        - name: SLACK_ALLOWED_USERS
+          value: <fill-me>
+        - name: SLACK_HOME_CHANNEL
+          value: <fill-me>
+      skills:
+        - skills/research/rss-feeds
+        - optional-skills/research/blogwatcher
+        - skills/research/competitor-news-monitor
+        - skills/media/youtube-content
+        - skills/creative/humanizer
+        - skills/social-media/xurl
+      packages:
+        pip:
+          - youtube-transcript-api
   - id: incident-commander
     name: Incident Commander
     description: Receives incident alerts by webhook, investigates likely causes, and posts a structured triage summary to Slack.
@@ -34,7 +109,7 @@ templates:
       config:
         model:
           provider: openai-api
-          default: gpt-5.6-sol
+          default: gpt-5.6-terra
         platforms:
           webhook:
             enabled: true
@@ -135,60 +210,6 @@ templates:
         - skills/software-development/github
         - skills/software-development/requesting-code-review
         - openai/skills/skills/.curated/gh-fix-ci
-  - id: marketer
-    name: Marketing Content Agent
-    description: Plans campaigns, drafts and publishes X posts and blog articles, and monitors competitors.
-    agentInput:
-      name: Marketing Content Agent
-      description: A hands-on marketing agent. Plans campaigns, drafts and publishes X posts and blog articles, repurposes content across formats, and monitors competitors and market news.
-      type: medium
-      soul: |-
-        You are a marketing agent. You own marketing work end-to-end:
-        campaign planning, social posts, blog articles, and market
-        intelligence. You do not hand back half-done work — when you take a
-        task, you carry it to a ready-to-post deliverable.
-
-        Write like a marketer, not like an AI: no hype language, no filler,
-        no "delve" or "game-changer". Ground every claim about competitors
-        or the market in sources you actually found. When you couldn't
-        verify something, say so.
-
-        Publishing is a two-step: draft, get human approval, then post.
-        Never publish on your own initiative. If a brief is ambiguous,
-        ask before writing.
-
-        When authenticating xurl with OAuth2, always use the `--headless` option.
-      config:
-        model:
-          provider: openai-api
-          default: gpt-5.6-terra
-      env:
-        - name: OPENAI_API_KEY
-          value: <fill-me>
-          sensitive: true
-        - name: FAL_KEY
-          value: <fill-me>
-          sensitive: true
-        - name: SLACK_BOT_TOKEN
-          value: <fill-me>
-          sensitive: true
-        - name: SLACK_APP_TOKEN
-          value: <fill-me>
-          sensitive: true
-        - name: SLACK_ALLOWED_USERS
-          value: <fill-me>
-        - name: SLACK_HOME_CHANNEL
-          value: <fill-me>
-      skills:
-        - skills/research/rss-feeds
-        - optional-skills/research/blogwatcher
-        - skills/research/competitor-news-monitor
-        - skills/media/youtube-content
-        - skills/creative/humanizer
-        - skills/social-media/xurl
-      packages:
-        pip:
-          - youtube-transcript-api
 agentTypes:
   medium:
     description: >-

--- a/apps/app/src/server/libs/config.ts
+++ b/apps/app/src/server/libs/config.ts
@@ -42,7 +42,7 @@ export const ConfigSchema = z.object({
   openaiModel: z
     .string()
     .min(1)
-    .default("gpt-5.5")
+    .default("gpt-5.6-sol")
     .describe("OpenAI model id used by the AI config generator (HERMEUM_OPENAI_MODEL)."),
   openaiBaseUrl: z
     .url()

--- a/apps/app/src/server/routers/ai-sdk/agent-config.ts
+++ b/apps/app/src/server/routers/ai-sdk/agent-config.ts
@@ -37,7 +37,7 @@ function model() {
   if (!config.openaiModel) {
     throw new Error(
       "AI config generation is not configured: set HERMEUM_OPENAI_MODEL to an " +
-        'OpenAI model id, e.g. "gpt-5.5".'
+        'OpenAI model id, e.g. "gpt-5.6-sol".'
     );
   }
   const baseURL = config.openaiBaseUrl ? { baseURL: config.openaiBaseUrl } : {};

--- a/apps/app/src/server/usecases/chat.ts
+++ b/apps/app/src/server/usecases/chat.ts
@@ -258,8 +258,7 @@ conversation. The current draft is shown to you as JSON; the user also sees
 it in an editor and may change it by hand between messages.
 
 Note 
-- Only write fields the user has asked for or that are strictly required. Skip
-every optional field unless the user requests it.
+- Skip every optional field unless the user requests it.
 - Never guess at field semantics. When you're not fully sure about a config
 section, settle it with the documentation before writing it into the draft.
 

--- a/apps/docs/docs/operation/configuration-reference.md
+++ b/apps/docs/docs/operation/configuration-reference.md
@@ -60,7 +60,7 @@ draft agent `config.yaml` blocks from natural-language prompts.
 
 | Variable | Default | Description |
 | --- | --- | --- |
-| `HERMEUM_OPENAI_MODEL` | `gpt-5.5` | Model id passed to the completion call. Must be a model the configured endpoint serves. |
+| `HERMEUM_OPENAI_MODEL` | `gpt-5.6-sol` | Model id passed to the completion call. Must be a model the configured endpoint serves. |
 | `HERMEUM_OPENAI_BASE_URL` | — | Override the OpenAI API base URL. Point this at any OpenAI-compatible gateway (vLLM, Ollama, Azure OpenAI, etc.). When unset, the OpenAI default is used. |
 | `HERMEUM_OPENAI_API_KEY` | — | API key for the OpenAI-compatible endpoint. Required when targeting the hosted OpenAI API; may be unused for local gateways. |
 

--- a/charts/hermeum/values.yaml
+++ b/charts/hermeum/values.yaml
@@ -54,7 +54,7 @@ config:
   # Container image tag for the Hermes agent (HERMEUM_HERMES_IMAGE_TAG).
   hermesImageTag: v2026.8.31
   # OpenAI model id used by the AI config generator (HERMEUM_OPENAI_MODEL).
-  openaiModel: gpt-5.5
+  openaiModel: gpt-5.6-sol
   # Log verbosity level (HERMEUM_LOG_LEVEL): debug | info | warn | error.
   logLevel: info
   # Restrict sign-ups to this email domain (HERMEUM_ALLOWED_EMAIL_DOMAIN).


### PR DESCRIPTION
## Summary

- Add a **Software Engineer** template (implements changes with tests, opens PRs, debugs failures) and a **Marketing Content Agent** template (campaigns, X posts, blog articles, competitor monitoring).
- Expand the **Support Agent** template with email (Himalaya) and Slack communication, plus humanizer skill.
- Bump the default OpenAI model from `gpt-5.5` to `gpt-5.6-sol` across config schema, chart values, docs, and templates.
- Persist the hermes agent workspace via `spec.hermes.storage.persistence` on the `medium` (10Gi) and `large` (20Gi) agent types.

## Test plan

- [x] `config.default.yaml` parses and all template agent types reference configured `agentTypes`
- [x] `pnpm --filter @hermeum/app test -- src/server/usecases/agent.test.ts src/server/usecases/chat.test.ts` (45 passed)
- [x] `pnpm --filter @hermeum/app dev` — verify templates render in the agent creation picker