### PR TITLE
fix(app): cap agent config chat updates per turn and clarify prompt rules

### DIFF
--- a/apps/app/src/client/ui/components/agent-config-chat.tsx
+++ b/apps/app/src/client/ui/components/agent-config-chat.tsx
@@ -34,7 +34,13 @@ type SearchSkillsOutput = { results: { name: string; identifier: string; descrip
 
 // Max consecutive failed `updateAgentConfig` tool calls the model may make in
 // a row before it is told to stop retrying and explain the problem instead.
-const MAX_CONFIG_UPDATE_ATTEMPTS = 1;
+const MAX_CONFIG_UPDATE_FAILURES = 1;
+
+// Max successful `updateAgentConfig` calls per conversation turn. The
+// auto-resubmit loop re-runs after every tool call, so without a cap the model
+// can chain unlimited "successful" updates, iterating its own mistakes as
+// noisy edit history. When exceeded, it is told to stop and explain in text.
+const MAX_CONFIG_UPDATE_SUCCESSES = 2;
 
 type AgentConfigChatMessage = UIMessage<
   unknown,
@@ -129,8 +135,13 @@ export function AgentConfigChat({
   const callbacksRef = useRef({ getConfig, onConfigUpdate });
   callbacksRef.current = { getConfig, onConfigUpdate };
 
-  // Consecutive failed `updateAgentConfig` calls in the current auto-resubmit
-  // loop. Reset when the user sends a new message.
+  // `updateAgentConfig` call counters for the current auto-resubmit loop,
+  // reset when the user sends a new message. `successes` caps the chained
+  // "successful" updates the model can make per turn (the loop re-runs after
+  // every tool call, so without a cap it can iterate its own mistakes as
+  // noisy edit history); `failures` caps consecutive validation errors before
+  // the model is told to explain the problem in text instead.
+  const configUpdateSuccessesRef = useRef(0);
   const configUpdateFailuresRef = useRef(0);
 
   const { messages, sendMessage, stop, status, error, addToolOutput } =
@@ -149,11 +160,25 @@ export function AgentConfigChat({
           return;
         }
         if (toolCall.toolName !== "updateAgentConfig") return;
+        if (configUpdateSuccessesRef.current >= MAX_CONFIG_UPDATE_SUCCESSES) {
+          addToolOutput({
+            tool: "updateAgentConfig",
+            toolCallId: toolCall.toolCallId,
+            state: "output-error",
+            errorText:
+              `Update limit reached: the agent config has already been updated ` +
+              `${configUpdateSuccessesRef.current} times this turn. Do not call ` +
+              "updateAgentConfig again — summarize the applied state to the user " +
+              "in plain text instead.",
+          });
+          return;
+        }
         const parsed = AgentInputObjectSchema.safeParse(toolCall.input);
         if (!parsed.success) {
           const issue = parsed.error.issues[0]!;
           const path = `/${issue.path.join("/")}`;
-          const exhausted = configUpdateFailuresRef.current >= MAX_CONFIG_UPDATE_ATTEMPTS;
+          const exhausted =
+            configUpdateFailuresRef.current >= MAX_CONFIG_UPDATE_FAILURES;
           configUpdateFailuresRef.current += 1;
           addToolOutput({
             tool: "updateAgentConfig",
@@ -161,14 +186,14 @@ export function AgentConfigChat({
             state: "output-error",
             errorText: exhausted
               ? `Invalid agent config: ${issue.message} (path: ${path}). ` +
-                `Failed to update the agent config after ${MAX_CONFIG_UPDATE_ATTEMPTS + 1} ` +
+                `Failed to update the agent config after ${MAX_CONFIG_UPDATE_FAILURES + 1} ` +
                 "attempts. Do not call updateAgentConfig again — explain the problem " +
                 "to the user in plain text instead."
               : `Invalid agent config: ${issue.message} (path: ${path})`,
           });
           return;
         }
-        configUpdateFailuresRef.current = 0;
+        configUpdateSuccessesRef.current += 1;
         callbacksRef.current.onConfigUpdate(parsed.data);
         addToolOutput({
           tool: "updateAgentConfig",
@@ -184,6 +209,7 @@ export function AgentConfigChat({
   function handleSend() {
     const text = input.trim();
     if (text.length === 0 || status !== "ready") return;
+    configUpdateSuccessesRef.current = 0;
     configUpdateFailuresRef.current = 0;
     sendMessage({ text }, { body: { config: callbacksRef.current.getConfig() } });
     setInput("");

--- a/apps/app/src/server/usecases/chat.test.ts
+++ b/apps/app/src/server/usecases/chat.test.ts
@@ -181,6 +181,19 @@ describe("ChatUseCase.getAgentConfigContext", () => {
     // No execute: the tool runs on the client, which applies the config to
     // the editor and reports back.
     expect(tools.updateAgentConfig!.execute).toBeUndefined();
+    // The single-call rule lives in the tool description so the model sees
+    // it alongside the tool definition.
+    expect(tools.updateAgentConfig!.description).toContain("single call");
+    expect(tools.updateAgentConfig!.description).toContain("readDocument");
+  });
+
+  it("instructs the model about the config wrapper key and the single-update rule", async () => {
+    const useCase = new ChatUseCase(makeRuntime(), makeFiles());
+
+    const { instructions } = await useCase.getAgentConfigContext();
+
+    expect(instructions).toContain('"config" key');
+    expect(instructions).toContain("single updateAgentConfig call");
   });
 
   it("exposes a client-side readAgentConfig tool and instructs the model to use it when stale", async () => {

--- a/apps/app/src/server/usecases/chat.ts
+++ b/apps/app/src/server/usecases/chat.ts
@@ -73,7 +73,10 @@ export class ChatUseCase extends HermeumConfigLoadable(BaseUseCase) {
           description:
             "Replace the agent config draft with a full updated definition. " +
             "Always pass the COMPLETE config, keeping every field not affected " +
-            "by the requested change unchanged.",
+            "by the requested change unchanged. Apply each user request in a " +
+            "single call — do not iterate with successive updates. If unsure " +
+            "about a section's shape, call readDocument for that section " +
+            "before the call.",
           inputSchema: AgentInputObjectSchema,
           // No `execute`: the client applies the config to its editor and
           // reports the result back.
@@ -257,9 +260,13 @@ You help a user workshop the definition of a new autonomous agent through
 conversation. The current draft is shown to you as JSON; the user also sees
 it in an editor and may change it by hand between messages.
 
-Note 
+Note
 - Skip every optional field unless the user requests it.
 - Never guess at field semantics. When you're not fully sure about a config
 section, settle it with the documentation before writing it into the draft.
+- The draft wraps the Hermes config under a top-level "config" key: fields
+the Hermes docs describe as top-level (e.g. "slack:") live under "config."
+in the draft.
+- Apply each user request with a single updateAgentConfig call.
 
 `;


### PR DESCRIPTION
## Problem

When asked to apply a config change (e.g. "set a different system prompt for a specific Slack channel"), the model chained **5 consecutive successful `updateAgentConfig` calls** for a single request — three self-corrections from schema-placement confusion, one correct update, and one unnecessary cleanup pass — each rendered as a "✓ Config updated" marker.

Root cause: `sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls` re-runs the loop after every tool call, and the only guard (`MAX_CONFIG_UPDATE_ATTEMPTS`) counted *validation failures* — successful updates were unbounded. Combined with a full-config-replacement tool and no read-before-write enforcement, the model could iterate its own mistakes as noisy edit history.

## Changes

**Per-turn success cap** (`agent-config-chat.tsx`):
- New `MAX_CONFIG_UPDATE_SUCCESSES = 2`; past the cap, further `updateAgentConfig` calls in the same auto-resubmit loop get an `output-error` telling the model to summarize the applied state in plain text instead.
- Rename `MAX_CONFIG_UPDATE_ATTEMPTS` → `MAX_CONFIG_UPDATE_FAILURES` to mirror the new counter.
- Both counters reset when the user sends a new message.

**Prompt & tool-description rules** (`chat.ts`):
- `updateAgentConfig` description: apply each user request in a single call; call `readDocument` for a section before updating it if unsure of its shape.
- System prompt: explain that the draft wraps the Hermes config under a top-level `config` key (docs' top-level `slack:` lives at `config.slack` in the draft) — the schema confusion that caused the wasted attempts — and state the single-call rule.

**Tests** (`chat.test.ts`):
- Assert the tool description carries the single-call / readDocument rules.
- New test asserting the system prompt's `config` wrapper note and single-update rule.

## Verification

- `pnpm --filter @hermeum/app typecheck` — no new errors (4 pre-existing in unrelated files)
- `pnpm --filter @hermeum/app lint` — 0 errors
- `pnpm --filter @hermeum/app test` — 345 passed

## Follow-up

A follow-up PR will add a patch-style tool that updates part of the configuration (delta updates instead of full replacement), structurally eliminating the copy-omission failure mode.