### PR TITLE
feat(app): add patchAgentConfig tool for partial config updates

### DIFF
--- a/apps/app/src/client/ui/components/agent-config-chat.tsx
+++ b/apps/app/src/client/ui/components/agent-config-chat.tsx
@@ -20,7 +20,7 @@ import {
 import { Textarea } from "@hermeum/components/ui/textarea";
 import { Streamdown } from "streamdown";
 import type { AgentInput } from "@/entities";
-import { AgentInputObjectSchema } from "@/entities";
+import { AgentInputObjectSchema, AgentPatchSchema, applyAgentPatch, type AgentPatch } from "@/entities";
 
 // Mirrors the server-executed tools declared in ChatUseCase.getAgentConfigContext
 // so the UI can render their lifecycle as markers alongside the client tools.
@@ -32,14 +32,16 @@ type ReadSharedEnvSetOutput = {
 };
 type SearchSkillsOutput = { results: { name: string; identifier: string; description: string }[] };
 
-// Max consecutive failed `updateAgentConfig` tool calls the model may make in
-// a row before it is told to stop retrying and explain the problem instead.
+// Max consecutive failed config-writing tool calls (replaceAgentConfig or
+// patchAgentConfig) the model may make in a row before it is told to stop
+// retrying and explain the problem instead.
 const MAX_CONFIG_UPDATE_FAILURES = 1;
 
-// Max successful `updateAgentConfig` calls per conversation turn. The
-// auto-resubmit loop re-runs after every tool call, so without a cap the model
-// can chain unlimited "successful" updates, iterating its own mistakes as
-// noisy edit history. When exceeded, it is told to stop and explain in text.
+// Max successful config-writing tool calls (replaceAgentConfig or
+// patchAgentConfig) per conversation turn. The auto-resubmit loop re-runs
+// after every tool call, so without a cap the model can chain unlimited
+// "successful" updates, iterating its own mistakes as noisy edit history.
+// When exceeded, it is told to stop and explain in text.
 const MAX_CONFIG_UPDATE_SUCCESSES = 2;
 
 type AgentConfigChatMessage = UIMessage<
@@ -47,7 +49,8 @@ type AgentConfigChatMessage = UIMessage<
   UIDataTypes,
   {
     // Client-executed (handled in onToolCall).
-    updateAgentConfig: { input: AgentInput; output: string };
+    replaceAgentConfig: { input: AgentInput; output: string };
+    patchAgentConfig: { input: AgentPatch; output: string };
     readAgentConfig: { input: undefined; output: AgentInput | undefined };
     // Server-executed (lifecycle only — no client handler).
     readDocument: { input: { names: string[] }; output: ReadDocumentOutput };
@@ -135,14 +138,72 @@ export function AgentConfigChat({
   const callbacksRef = useRef({ getConfig, onConfigUpdate });
   callbacksRef.current = { getConfig, onConfigUpdate };
 
-  // `updateAgentConfig` call counters for the current auto-resubmit loop,
-  // reset when the user sends a new message. `successes` caps the chained
-  // "successful" updates the model can make per turn (the loop re-runs after
-  // every tool call, so without a cap it can iterate its own mistakes as
-  // noisy edit history); `failures` caps consecutive validation errors before
-  // the model is told to explain the problem in text instead.
+  // Config-writing tool call counters (replaceAgentConfig or patchAgentConfig)
+  // for the current auto-resubmit loop, reset when the user sends a new
+  // message. `successes` caps the chained "successful" updates the model can
+  // make per turn (the loop re-runs after every tool call, so without a cap
+  // it can iterate its own mistakes as noisy edit history); `failures` caps
+  // consecutive validation errors before the model is told to explain the
+  // problem in text instead.
   const configUpdateSuccessesRef = useRef(0);
   const configUpdateFailuresRef = useRef(0);
+
+  // Shared apply path for both config-writing tools: validate the final
+  // config that will land in the editor, report the outcome to the model,
+  // and carry the applied draft in the automatic follow-up request body.
+  // Parsed with AgentInputObjectSchema, NOT AgentInputSchema — drafts
+  // legitimately carry "<fill-me>" placeholder env values that the user
+  // fills in later; the superRefine cross-field rules would reject those.
+  function applyConfig(
+    toolName: "replaceAgentConfig" | "patchAgentConfig",
+    toolCallId: string,
+    config: unknown
+  ): boolean {
+    if (configUpdateSuccessesRef.current >= MAX_CONFIG_UPDATE_SUCCESSES) {
+      addToolOutput({
+        tool: toolName,
+        toolCallId,
+        state: "output-error",
+        errorText:
+          `Update limit reached: the agent config has already been updated ` +
+          `${configUpdateSuccessesRef.current} times this turn. Do not call ` +
+          "config-writing tools again — summarize the applied state to the " +
+          "user in plain text instead.",
+      });
+      return false;
+    }
+    const parsed = AgentInputObjectSchema.safeParse(config);
+    if (!parsed.success) {
+      const issue = parsed.error.issues[0]!;
+      const path = `/${issue.path.join("/")}`;
+      const exhausted = configUpdateFailuresRef.current >= MAX_CONFIG_UPDATE_FAILURES;
+      configUpdateFailuresRef.current += 1;
+      addToolOutput({
+        tool: toolName,
+        toolCallId,
+        state: "output-error",
+        errorText: exhausted
+          ? `Invalid agent config: ${issue.message} (path: ${path}). ` +
+            `Failed to update the agent config after ${MAX_CONFIG_UPDATE_FAILURES + 1} ` +
+            "attempts. Do not call config-writing tools again — explain the " +
+            "problem to the user in plain text instead."
+          : `Invalid agent config: ${issue.message} (path: ${path})`,
+      });
+      return false;
+    }
+    configUpdateFailuresRef.current = 0;
+    configUpdateSuccessesRef.current += 1;
+    callbacksRef.current.onConfigUpdate(parsed.data);
+    addToolOutput({
+      tool: toolName,
+      toolCallId,
+      output: "Applied to the editor.",
+      // The automatic follow-up request should also carry the draft it
+      // just produced.
+      options: { body: { config: parsed.data } },
+    });
+    return true;
+  }
 
   const { messages, sendMessage, stop, status, error, addToolOutput } =
     useChat<AgentConfigChatMessage>({
@@ -159,50 +220,35 @@ export function AgentConfigChat({
           });
           return;
         }
-        if (toolCall.toolName !== "updateAgentConfig") return;
-        if (configUpdateSuccessesRef.current >= MAX_CONFIG_UPDATE_SUCCESSES) {
-          addToolOutput({
-            tool: "updateAgentConfig",
-            toolCallId: toolCall.toolCallId,
-            state: "output-error",
-            errorText:
-              `Update limit reached: the agent config has already been updated ` +
-              `${configUpdateSuccessesRef.current} times this turn. Do not call ` +
-              "updateAgentConfig again — summarize the applied state to the user " +
-              "in plain text instead.",
-          });
+        if (toolCall.toolName === "replaceAgentConfig") {
+          applyConfig("replaceAgentConfig", toolCall.toolCallId, toolCall.input);
           return;
         }
-        const parsed = AgentInputObjectSchema.safeParse(toolCall.input);
+        if (toolCall.toolName !== "patchAgentConfig") return;
+        const parsed = AgentPatchSchema.safeParse(toolCall.input);
         if (!parsed.success) {
           const issue = parsed.error.issues[0]!;
           const path = `/${issue.path.join("/")}`;
-          const exhausted =
-            configUpdateFailuresRef.current >= MAX_CONFIG_UPDATE_FAILURES;
+          const exhausted = configUpdateFailuresRef.current >= MAX_CONFIG_UPDATE_FAILURES;
           configUpdateFailuresRef.current += 1;
           addToolOutput({
-            tool: "updateAgentConfig",
+            tool: "patchAgentConfig",
             toolCallId: toolCall.toolCallId,
             state: "output-error",
             errorText: exhausted
-              ? `Invalid agent config: ${issue.message} (path: ${path}). ` +
+              ? `Invalid agent config patch: ${issue.message} (path: ${path}). ` +
                 `Failed to update the agent config after ${MAX_CONFIG_UPDATE_FAILURES + 1} ` +
-                "attempts. Do not call updateAgentConfig again — explain the problem " +
-                "to the user in plain text instead."
-              : `Invalid agent config: ${issue.message} (path: ${path})`,
+                "attempts. Do not call config-writing tools again — explain the " +
+                "problem to the user in plain text instead."
+              : `Invalid agent config patch: ${issue.message} (path: ${path})`,
           });
           return;
         }
-        configUpdateSuccessesRef.current += 1;
-        callbacksRef.current.onConfigUpdate(parsed.data);
-        addToolOutput({
-          tool: "updateAgentConfig",
-          toolCallId: toolCall.toolCallId,
-          output: "Applied to the editor.",
-          // The automatic follow-up request should also carry the draft it
-          // just produced.
-          options: { body: { config: parsed.data } },
-        });
+        applyConfig(
+          "patchAgentConfig",
+          toolCall.toolCallId,
+          applyAgentPatch(callbacksRef.current.getConfig(), parsed.data)
+        );
       },
     });
 
@@ -271,14 +317,25 @@ export function AgentConfigChat({
                               />
                             );
                           }
-                          if (part.type === "tool-updateAgentConfig") {
+                          if (part.type === "tool-replaceAgentConfig") {
                             return (
                               <ToolMarker
                                 key={index}
                                 state={part.state}
-                                runningLabel="Updating the config…"
-                                doneLabel="Config updated"
-                                errorLabel="Couldn’t update the config"
+                                runningLabel="Replacing the config…"
+                                doneLabel="Config replaced"
+                                errorLabel="Couldn’t replace the config"
+                              />
+                            );
+                          }
+                          if (part.type === "tool-patchAgentConfig") {
+                            return (
+                              <ToolMarker
+                                key={index}
+                                state={part.state}
+                                runningLabel="Patching the config…"
+                                doneLabel="Config patched"
+                                errorLabel="Couldn’t patch the config"
                               />
                             );
                           }

--- a/apps/app/src/entities/agent.test.ts
+++ b/apps/app/src/entities/agent.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from "vitest";
 import { z } from "zod";
 
-import { AgentInputObjectSchema, AgentInputSchema, isApiServerEnabled, getApiServerPort, isWebhookEnabled, getWebhookPort, isTeamsEnabled, getTeamsPort, ToolsetId, deriveToolsetAvailability, PlatformId, derivePlatformAvailability, type Agent } from "./agent";
+import { AgentInputObjectSchema, AgentInputSchema, isApiServerEnabled, getApiServerPort, isWebhookEnabled, getWebhookPort, isTeamsEnabled, getTeamsPort, ToolsetId, deriveToolsetAvailability, PlatformId, derivePlatformAvailability, type Agent, type AgentInput } from "./agent";
+import { AgentPatchSchema, applyAgentPatch, type AgentPatch } from "./agent/patch";
 import { SkillIdentifierSchema } from "./skill";
 
 function makeInput(overrides: Record<string, unknown> = {}) {
@@ -708,6 +709,147 @@ describe("AgentInputObjectSchema as LLM structured-output schema", () => {
 
   it("is convertible to JSON Schema for the AI SDK", () => {
     expect(() => z.toJSONSchema(AgentInputObjectSchema)).not.toThrow();
+  });
+});
+
+describe("AgentPatchSchema envelope validation", () => {
+  it("accepts a top-level scalar patch", () => {
+    expect(AgentPatchSchema.safeParse({ name: "pr-reviewer" }).success).toBe(true);
+  });
+
+  it("accepts a nested config patch", () => {
+    const result = AgentPatchSchema.safeParse({
+      config: { web: { port: 8900 } },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts null values for deletion at any depth", () => {
+    const result = AgentPatchSchema.safeParse({
+      soul: null,
+      config: { slack: { channel_prompts: { "C123": null } } },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts complete array replacements", () => {
+    const result = AgentPatchSchema.safeParse({
+      env: [{ name: "OPENAI_API_KEY", value: "<fill-me>", sensitive: true }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an empty patch", () => {
+    const result = AgentPatchSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an unknown top-level field", () => {
+    const result = AgentPatchSchema.safeParse({ skils: ["typescript"] });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues[0]!.path).toEqual(["skils"]);
+    expect(result.error.issues[0]!.message).toContain("Unknown top-level field");
+  });
+
+  it("lets unknown nested keys pass through (looseObject policy)", () => {
+    const result = AgentPatchSchema.safeParse({
+      config: { someUntypedHermesField: { anything: true } },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  // Regression: an empty `looseObject({})` emitted "properties": {} to the
+  // model, which then had no visible keys to patch and sent `{}`. The patch
+  // schema must surface every top-level AgentInput field name in its JSON
+  // Schema, and the derivation keeps that list drift-proof.
+  it("exposes every AgentInputObjectSchema field name in its emitted JSON Schema", () => {
+    const jsonSchema = z.toJSONSchema(AgentPatchSchema);
+    const properties = (jsonSchema as { properties: Record<string, unknown> }).properties;
+    expect(Object.keys(properties).sort()).toEqual(
+      Object.keys(AgentInputObjectSchema.shape).sort()
+    );
+  });
+});
+
+describe("applyAgentPatch", () => {
+  const draft = {
+    name: "pr-reviewer",
+    soul: "You review PRs.",
+    env: [{ name: "GH_TOKEN", value: "x", sensitive: true }],
+    config: { web: { port: 8900, enabled: true }, model: { provider: "anthropic" } },
+  } as unknown as AgentInput;
+
+  it("replaces provided scalars and leaves others untouched", () => {
+    const merged = applyAgentPatch(draft, { name: "renamed" });
+    expect(merged).toEqual({ ...draft, name: "renamed" });
+  });
+
+  it("merges plain objects recursively", () => {
+    const merged = applyAgentPatch(draft, { config: { web: { port: 9000 } } });
+    expect(merged.config).toEqual({
+      web: { port: 9000, enabled: true },
+      model: { provider: "anthropic" },
+    });
+  });
+
+  it("deletes a key at any depth via null", () => {
+    const merged = applyAgentPatch(draft, { config: { web: { enabled: null } } });
+    expect(merged.config).toEqual({ web: { port: 8900 }, model: { provider: "anthropic" } });
+  });
+
+  it("deletes a top-level field via null", () => {
+    const merged = applyAgentPatch(draft, { soul: null });
+    expect(merged).not.toHaveProperty("soul");
+    expect(merged).toHaveProperty("name", "pr-reviewer");
+  });
+
+  it("replaces arrays wholesale", () => {
+    const merged = applyAgentPatch(draft, {
+      env: [{ name: "OTHER", value: "y", sensitive: false }],
+    });
+    expect(merged.env).toEqual([{ name: "OTHER", value: "y", sensitive: false }]);
+  });
+
+  it("replaces a non-object current value with a merged object when patching over a scalar", () => {
+    const merged = applyAgentPatch(draft, { description: "text", config: { web: { port: 1 } } });
+    // "description" absent in draft: merged in as-is.
+    expect(merged.description).toBe("text");
+    // A scalar current value is replaced by the patch object's merge result.
+    const overScalar = applyAgentPatch({ name: "x", soul: "text" } as AgentInput, {
+      soul: { bold: true },
+    });
+    expect(overScalar.soul).toEqual({ bold: true });
+  });
+
+  it("seeds a new draft when there is no current config", () => {
+    const merged = applyAgentPatch(undefined, { name: "first", config: { web: { port: 1 } } });
+    expect(merged).toEqual({ name: "first", config: { web: { port: 1 } } });
+  });
+
+  it("does not mutate its inputs", () => {
+    const draftCopy = structuredClone(draft);
+    const patch = { config: { web: { port: null } } } as unknown as AgentPatch;
+    applyAgentPatch(draft, patch);
+    expect(draft).toEqual(draftCopy);
+    expect(patch.config).toEqual({ web: { port: null } });
+  });
+
+  it("merged results pass AgentInputSchema and re-apply pinned defaults", () => {
+    // null-deleting a .default() field re-materializes the default when the
+    // merged result is validated — pinned policy (e.g. Slack
+    // unauthorized_dm_behavior: "ignore") is not weakened.
+    const withSlack = {
+      config: { slack: { unauthorized_dm_behavior: "pair", enabled: true } },
+    } as unknown as AgentInput;
+    const merged = applyAgentPatch(withSlack, {
+      config: { slack: { unauthorized_dm_behavior: null } },
+    });
+    const parsed = AgentInputSchema.safeParse(merged);
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    const slack = (parsed.data.config as { slack?: { unauthorized_dm_behavior?: string } }).slack;
+    expect(slack?.unauthorized_dm_behavior).toBe("ignore");
   });
 });
 

--- a/apps/app/src/entities/agent/index.ts
+++ b/apps/app/src/entities/agent/index.ts
@@ -1,3 +1,4 @@
 export * from "./schema";
 export * from "./platform";
 export * from "./toolsets";
+export * from "./patch";

--- a/apps/app/src/entities/agent/patch.ts
+++ b/apps/app/src/entities/agent/patch.ts
@@ -1,0 +1,87 @@
+// Partial-update support for the agent config chat's `patchAgentConfig` tool.
+//
+// Merge semantics (described to the model in the tool description, mirrored
+// here in `applyAgentPatch`):
+// - Plain objects merge recursively.
+// - `null` deletes the key (at any depth).
+// - Arrays and scalars replace the current value wholesale.
+// - Keys absent from the patch leave the draft untouched.
+//
+// The patch schema is deliberately untyped at the value level: field
+// semantics and validation live in `AgentInputObjectSchema`/`AgentInputSchema`
+// (present every turn via `replaceAgentConfig` and applied to the merged
+// result). What it DOES declare is the top-level field names — an empty
+// `looseObject({})` emitted `"properties": {}` to the model, which then had
+// no visible keys to patch and sent `{}` (observed in the field). The nested
+// shape is learned from `replaceAgentConfig`'s input schema, the embedded
+// draft JSON, and the tool description's example.
+import { z } from "zod";
+
+import { AgentInputObjectSchema, type AgentInput } from "./schema";
+
+// Top-level patch keys mirror `AgentInputObjectSchema`'s shape (derived, so
+// they can't drift); values are `unknown` — the model sees the keys in the
+// tool's JSON Schema and copies value shapes from `replaceAgentConfig`'s
+// schema, while real validation happens on the merged result.
+const patchShape = Object.fromEntries(
+  Object.keys(AgentInputObjectSchema.shape).map((key) => [key, z.unknown().optional()])
+) as {
+  [K in keyof typeof AgentInputObjectSchema.shape]: z.ZodOptional<z.ZodUnknown>;
+};
+
+export const AgentPatchSchema = z.looseObject(patchShape).superRefine((patch, ctx) => {
+  const keys = Object.keys(patch);
+  if (keys.length === 0) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Patch must set at least one field.",
+    });
+    return;
+  }
+  for (const key of keys) {
+    if (!(key in AgentInputObjectSchema.shape)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: [key],
+        message:
+          `Unknown top-level field "${key}". Use replaceAgentConfig for a ` +
+          "full rewrite if the field is needed.",
+      });
+    }
+  }
+});
+
+export type AgentPatch = z.infer<typeof AgentPatchSchema>;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function mergePatch(
+  current: Record<string, unknown>,
+  patch: Record<string, unknown>
+): Record<string, unknown> {
+  const result = { ...current };
+  for (const [key, value] of Object.entries(patch)) {
+    if (value === null) {
+      delete result[key];
+      continue;
+    }
+    const existing = result[key];
+    result[key] =
+      isPlainObject(value) && isPlainObject(existing)
+        ? mergePatch(existing, value)
+        : value;
+  }
+  return result;
+}
+
+// Deep-merge `patch` onto `current` per the semantics above. Pure: neither
+// input is mutated and a fresh object is returned. `undefined` current seeds
+// a new draft from the patch alone.
+export function applyAgentPatch(
+  current: AgentInput | undefined,
+  patch: AgentPatch
+): Record<string, unknown> {
+  return mergePatch(current === undefined ? {} : { ...current }, patch);
+}

--- a/apps/app/src/server/usecases/chat.test.ts
+++ b/apps/app/src/server/usecases/chat.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
+import { z } from "zod";
 import type { ToolExecutionOptions } from "@/entities";
 import { stringify } from "yaml";
 
@@ -171,20 +172,23 @@ describe("ChatUseCase.getAgentConfigContext", () => {
     expect(prompt).toContain('"pr-reviewer"');
   });
 
-  it("exposes a client-side updateAgentConfig tool", async () => {
+  it("exposes a client-side replaceAgentConfig tool", async () => {
     const useCase = new ChatUseCase(makeRuntime(), makeFiles());
 
     const { tools } = await useCase.getAgentConfigContext();
 
-    expect(tools.updateAgentConfig).toBeDefined();
-    expect(tools.updateAgentConfig!.inputSchema).toBeDefined();
+    expect(tools.replaceAgentConfig).toBeDefined();
+    expect(tools.replaceAgentConfig!.inputSchema).toBeDefined();
     // No execute: the tool runs on the client, which applies the config to
     // the editor and reports back.
-    expect(tools.updateAgentConfig!.execute).toBeUndefined();
+    expect(tools.replaceAgentConfig!.execute).toBeUndefined();
     // The single-call rule lives in the tool description so the model sees
     // it alongside the tool definition.
-    expect(tools.updateAgentConfig!.description).toContain("single call");
-    expect(tools.updateAgentConfig!.description).toContain("readDocument");
+    expect(tools.replaceAgentConfig!.description).toContain("single call");
+    expect(tools.replaceAgentConfig!.description).toContain("readDocument");
+    // Cross-reference: for small edits to an existing draft the model is
+    // steered toward patchAgentConfig instead.
+    expect(tools.replaceAgentConfig!.description).toContain("patchAgentConfig");
   });
 
   it("instructs the model about the config wrapper key and the single-update rule", async () => {
@@ -193,7 +197,41 @@ describe("ChatUseCase.getAgentConfigContext", () => {
     const { instructions } = await useCase.getAgentConfigContext();
 
     expect(instructions).toContain('"config" key');
-    expect(instructions).toContain("single updateAgentConfig call");
+    expect(instructions).toContain("config-writing call");
+  });
+
+  it("exposes a client-side patchAgentConfig tool with the merge rules in its description", async () => {
+    const useCase = new ChatUseCase(makeRuntime(), makeFiles());
+
+    const { tools } = await useCase.getAgentConfigContext();
+
+    expect(tools.patchAgentConfig).toBeDefined();
+    expect(tools.patchAgentConfig!.inputSchema).toBeDefined();
+    // No execute: the client merges the patch onto its editor draft,
+    // validates the merged result, and reports back.
+    expect(tools.patchAgentConfig!.execute).toBeUndefined();
+    // The merge semantics must be stated in prose (the patch schema is an
+    // untyped envelope): recursive object merge, null deletes, arrays and
+    // scalars replace wholesale, omitted fields stay untouched.
+    expect(tools.patchAgentConfig!.description).toContain("merge recursively");
+    expect(tools.patchAgentConfig!.description).toContain("null");
+    expect(tools.patchAgentConfig!.description).toContain("COMPLETE array");
+    expect(tools.patchAgentConfig!.description).toContain("replaceAgentConfig");
+  });
+
+  it("exposes the patchable top-level field names in the patchAgentConfig tool schema", async () => {
+    const useCase = new ChatUseCase(makeRuntime(), makeFiles());
+
+    const { tools } = await useCase.getAgentConfigContext();
+
+    // Regression guard: the schema the model sees must list the top-level
+    // fields — an empty-properties emission leaves the model nothing to
+    // patch, and it falls back to the full-config tool.
+    const jsonSchema = z.toJSONSchema(tools.patchAgentConfig!.inputSchema);
+    const properties = (jsonSchema as { properties: Record<string, unknown> }).properties;
+    expect(Object.keys(properties)).toContain("config");
+    expect(Object.keys(properties)).toContain("soul");
+    expect(Object.keys(properties)).toContain("env");
   });
 
   it("exposes a client-side readAgentConfig tool and instructs the model to use it when stale", async () => {

--- a/apps/app/src/server/usecases/chat.ts
+++ b/apps/app/src/server/usecases/chat.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import { AgentInput, AgentInputObjectSchema, tool, ToolSet } from "@/entities";
+import { AgentInput, AgentInputObjectSchema, AgentPatchSchema, tool, ToolSet } from "@/entities";
 import { config } from "@/server/libs/config";
 
 import { BaseUseCase, HermeumConfigLoadable } from "./mixin";
@@ -69,17 +69,32 @@ export class ChatUseCase extends HermeumConfigLoadable(BaseUseCase) {
           // No `execute`: the client returns the latest editor draft and
           // reports it back.
         }),
-        updateAgentConfig: tool({
+        replaceAgentConfig: tool({
           description:
             "Replace the agent config draft with a full updated definition. " +
             "Always pass the COMPLETE config, keeping every field not affected " +
             "by the requested change unchanged. Apply each user request in a " +
             "single call — do not iterate with successive updates. If unsure " +
             "about a section's shape, call readDocument for that section " +
-            "before the call.",
+            "before the call. For small changes to an existing draft, prefer " +
+            "patchAgentConfig instead.",
           inputSchema: AgentInputObjectSchema,
           // No `execute`: the client applies the config to its editor and
           // reports the result back.
+        }),
+        patchAgentConfig: tool({
+          description:
+            "Apply a partial update to the current agent config draft. Send " +
+            "ONLY the part being changed: plain objects merge recursively " +
+            "(e.g. { config: { web: { port: 8900 } } } changes just that " +
+            "port); set a field to null to delete it at any depth; arrays " +
+            "and scalars replace the whole current value, so always send a " +
+            "COMPLETE array. Fields you omit are left untouched. Prefer this " +
+            "over replaceAgentConfig for small edits to an existing draft; " +
+            "use replaceAgentConfig to create a draft or rewrite most of it.",
+          inputSchema: AgentPatchSchema,
+          // No `execute`: the client merges the patch onto its editor draft,
+          // validates the merged result, and reports the outcome back.
         }),
       },
     };
@@ -252,9 +267,9 @@ export class ChatUseCase extends HermeumConfigLoadable(BaseUseCase) {
 
 // Behavioral rules for the agent-config chat. Tool-specific guidance (when to
 // call `readDocument`, `readSharedEnvSet`, `readAgentConfig`,
-// `updateAgentConfig`, and the available doc/shared-env-set lists) lives in
-// the tool `description` fields, not here, so the model sees each tool's usage
-// rules alongside its definition.
+// `replaceAgentConfig`, `patchAgentConfig`, and the available doc/shared-env-set
+// lists) lives in the tool `description` fields, not here, so the model sees
+// each tool's usage rules alongside its definition.
 export const AGENT_CONFIG_CHAT_SYSTEM_PROMPT = `\
 You help a user workshop the definition of a new autonomous agent through
 conversation. The current draft is shown to you as JSON; the user also sees
@@ -267,6 +282,7 @@ section, settle it with the documentation before writing it into the draft.
 - The draft wraps the Hermes config under a top-level "config" key: fields
 the Hermes docs describe as top-level (e.g. "slack:") live under "config."
 in the draft.
-- Apply each user request with a single updateAgentConfig call.
+- Apply each user request with a single config-writing call (replaceAgentConfig
+or patchAgentConfig).
 
 `;


### PR DESCRIPTION
## Summary

The agent-config chat previously had only `updateAgentConfig`, which requires the model to echo the entire config draft on every change — prohibitively expensive for large configs and error-prone (whole-field copy risk). This PR adds a `patchAgentConfig` tool for partial updates: the model sends only the part being changing, and the client merges it onto the latest editor draft.

## Changes

- **New `entities/agent/patch.ts`**:
  - `AgentPatchSchema` — loose envelope that declares the top-level `AgentInput` field names (derived from `AgentInputObjectSchema.shape`, drift-proof), with non-empty and unknown-key checks. Field names are declared because an empty `looseObject({})` emits `"properties": {}` in the tool's JSON Schema, which leaves the model nothing to patch (observed in the field). Values stay untyped — real validation happens on the merged result.
  - `applyAgentPatch` — pure deep-merge: plain objects merge recursively, `null` deletes a key at any depth, arrays/scalars replace the current value wholesale, keys absent from the patch leave the draft untouched.
- **Server (`chat.ts`)**: `patchAgentConfig` client-executed tool with the merge rules in its description; `updateAgentConfig` steers small edits to the patch tool; system prompt single-call rule generalized to "single config-writing call".
- **Client (`agent-config-chat.tsx`)**: patch handler parses the patch, merges onto the latest editor draft via `applyAgentPatch`, and validates the **merged result** with `AgentInputObjectSchema` (not `AgentInputSchema` — drafts legitimately carry `<fill-me>` placeholder env values). Shared `applyConfig` path for both tools, per-turn success/failure caps generalized, dedicated "Config patched" marker.
- **Tests (17 new)**: envelope validation, merge semantics (recursive merge, null-delete, array wholesale replace, immutability, pinned-default re-materialization), tool exposure/description checks, and JSON-Schema field-name visibility regression guards.

## Design notes

- Patch values are deliberately untyped; nested shapes are learned from `updateAgentConfig`'s input schema (present every turn), the embedded draft JSON, and the description's example — avoiding a duplicated field tree in the prompt. Malformed nested values are caught one round-trip later by merged-result validation with path+message reporting, reusing the existing failure loop.
- `null`-deleting a `.default()` field re-materializes the pinned default when the merged result is validated (e.g. Slack `unauthorized_dm_behavior: "ignore"`) — documented by test; Hermeum policy is not weakened.

## Test plan

- [x] `pnpm --filter @hermeum/app test` — 364 passed
- [x] `pnpm --filter @hermeum/app typecheck` — clean (pre-existing base errors only)
- [x] `pnpm --filter @hermeum/app lint` — clean (pre-existing warnings only)
- [x] Manual verification: patch flows apply to the editor and the model falls back to `updateAgentConfig` cleanly when a patch is rejected