### PR TITLE
chore: bump version to v0.1.0

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hermeum/app",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hermeum/docs",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "private": true,
   "scripts": {
     "dev": "docusaurus start --port 3001 --no-open",

--- a/charts/hermeum/Chart.yaml
+++ b/charts/hermeum/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: hermeum
 description: Hermeum — control plane for HermesAgent custom resources.
 type: application
-version: 0.1.2
-appVersion: "0.0.1"
+version: 0.1.3
+appVersion: "0.1.0"
 home: https://github.com/hermeum/hermeum
 sources:
   - https://github.com/hermeum/hermeum

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hermeum/components",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hermeum/typescript-config",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "private": true,
   "exports": {
     "./base.json": "./base.json",


### PR DESCRIPTION
## Summary
- Bump app version from 0.0.1 to 0.1.0 in lockstep across `apps/app`, `apps/docs`, `packages/components`, and `packages/typescript-config`
- Update `charts/hermeum/Chart.yaml`: `appVersion` → `0.1.0`, chart `version` → `0.1.3` (chart republished for the upgrade)

## Test plan
- [x] `pnpm install` — lockfile up to date, no drift
- [x] `pnpm lint` — passes (2 pre-existing warnings)
- [x] `pnpm typecheck` — only pre-existing failures (`@hermeum/docs` docusaurus types, `@hermeum/app` fast-json-patch typing), confirmed identical on the clean tree