### PR TITLE
refactor(app): remove unused getGatewayToken route and call chain

### DIFF
--- a/apps/app/src/server/infras/kubernetes/client.ts
+++ b/apps/app/src/server/infras/kubernetes/client.ts
@@ -703,41 +703,6 @@ export class KubernetesClient implements Runtime {
     }
   }
 
-  async getGatewayToken(agentId: string): Promise<string | null> {
-    let raw: HermesAgent | null = null;
-    try {
-      raw = (await this.customObjectsApi.getNamespacedCustomObject({
-        namespace: config.kubernetesNamespace,
-        group: HermesGroup.Default,
-        version: HermesVersion.V1Alpha1,
-        plural: HermesPlural.Agents,
-        name: agentId,
-      })) as HermesAgent;
-    } catch {
-      return null;
-    }
-
-    const secretName = raw?.status?.managedResources?.hermesSecret;
-    if (!secretName) {
-      return null;
-    }
-
-    try {
-      const secret = await this.coreV1Api.readNamespacedSecret({
-        name: secretName,
-        namespace: config.kubernetesNamespace,
-      });
-      const encoded = secret?.data?.["token"];
-      if (!encoded) {
-        return null;
-      }
-
-      return Buffer.from(encoded, "base64").toString("utf-8");
-    } catch {
-      return null;
-    }
-  }
-
   async createSharedEnvSet(input: CreateSharedEnvSetInput): Promise<SharedEnvSet> {
     const id = `envset-${Math.random().toString(36).slice(2, 8)}`;
     const body = sharedEnvSetToKubernetesSecret({

--- a/apps/app/src/server/routers/trpc/agent.ts
+++ b/apps/app/src/server/routers/trpc/agent.ts
@@ -49,10 +49,4 @@ export const agentRouter = t.router({
     .mutation(async ({ ctx, input }): Promise<Agent> => {
       return await usecase.resumeHermesAgent(ctx, input.id);
     }),
-
-  getGatewayToken: protectedProcedure
-    .input(z.object({ id: z.string().min(1) }))
-    .query(async ({ ctx, input }): Promise<string | null> => {
-      return await usecase.getGatewayToken(ctx, input.id);
-    }),
 });

--- a/apps/app/src/server/usecases/adaptors/runtime.ts
+++ b/apps/app/src/server/usecases/adaptors/runtime.ts
@@ -18,8 +18,6 @@ export interface Runtime {
   patchHermesAgent: (input: PatchAgentInput) => Promise<Agent>;
   archiveHermesAgent: (id: string) => Promise<Agent>;
 
-  getGatewayToken: (agentId: string) => Promise<string | null>;
-
   listSharedEnvSets: (params?: ListSharedEnvSetsFilter) => Promise<SharedEnvSet[]>;
   getSharedEnvSet: (id: string) => Promise<SharedEnvSet | null>;
   createSharedEnvSet: (input: CreateSharedEnvSetInput) => Promise<SharedEnvSet>;

--- a/apps/app/src/server/usecases/agent.ts
+++ b/apps/app/src/server/usecases/agent.ts
@@ -15,23 +15,6 @@ export const ListAgentsFilterSchema = z.object({
 export type ListAgentsFilter = z.infer<typeof ListAgentsFilterSchema>;
 
 export class AgentUseCase extends OwnershipGuarded(HermeumConfigLoadable(BaseUseCase)) {
-  async getmutatingWebhookJsonPatch(
-    agent: Agent,
-    incomingObject?: unknown,
-  ): Promise<JsonPatchOp[] | null> {
-    if (!agent.type) return null;
-    const { agentTypes } = await this.loadHermeumConfig();
-    const agentType = agentTypes?.[agent.type];
-    if (!agentType) return null;
-    // mutatingWebhookJsonPatch is normalized to JsonPatchOp[][] by the schema
-    // transform. When an incoming object is provided, select the first
-    // candidate whose `test` ops pass (first-match-wins); without one, return
-    // the first (only) candidate as-is for backwards compatibility.
-    const candidates = agentType.mutatingWebhookJsonPatch as unknown as JsonPatchOp[][];
-    if (incomingObject === undefined) return candidates[0] ?? null;
-    return this.selectPatch(candidates, incomingObject);
-  }
-
   async listHermesAgents(ctx: Context, input?: ListAgentsFilter): Promise<Agent[]> {
     const agents = await this.runtime.listHermesAgents(input);
     this.logger.info("listed hermes agents", { count: agents.length, filter: input });
@@ -140,6 +123,23 @@ export class AgentUseCase extends OwnershipGuarded(HermeumConfigLoadable(BaseUse
         throw new Error(`Shared env set "${id}" is archived`);
       }
     }
+  }
+
+  async getmutatingWebhookJsonPatch(
+    agent: Agent,
+    incomingObject?: unknown,
+  ): Promise<JsonPatchOp[] | null> {
+    if (!agent.type) return null;
+    const { agentTypes } = await this.loadHermeumConfig();
+    const agentType = agentTypes?.[agent.type];
+    if (!agentType) return null;
+    // mutatingWebhookJsonPatch is normalized to JsonPatchOp[][] by the schema
+    // transform. When an incoming object is provided, select the first
+    // candidate whose `test` ops pass (first-match-wins); without one, return
+    // the first (only) candidate as-is for backwards compatibility.
+    const candidates = agentType.mutatingWebhookJsonPatch as unknown as JsonPatchOp[][];
+    if (incomingObject === undefined) return candidates[0] ?? null;
+    return this.selectPatch(candidates, incomingObject);
   }
 
   /**

--- a/apps/app/src/server/usecases/agent.ts
+++ b/apps/app/src/server/usecases/agent.ts
@@ -119,18 +119,6 @@ export class AgentUseCase extends OwnershipGuarded(HermeumConfigLoadable(BaseUse
     return resumed;
   }
 
-  async getGatewayToken(ctx: Context, agentId: string): Promise<string | null> {
-    const agent = await this.runtime.getHermesAgent(agentId);
-    if (!agent) {
-      this.logger.warn("can't get gateway token — agent not found", { agentId });
-      throw new Error(`HermesAgent ${agentId} not found`);
-    }
-    this.verifyOwnership(ctx, agent);
-    const token = await this.runtime.getGatewayToken(agentId);
-    this.logger.info("got gateway token", { agentId, userId: this.requireUser(ctx).id });
-    return token;
-  }
-
   private async checkAgentInputAllowed(
     input: Pick<AgentInput, "type" | "sharedEnvSets">
   ): Promise<void> {

--- a/apps/app/src/server/usecases/chat.test.ts
+++ b/apps/app/src/server/usecases/chat.test.ts
@@ -42,7 +42,6 @@ function makeRuntime(sets: SharedEnvSet[] = []): Runtime {
     createHermesAgent: vi.fn(),
     patchHermesAgent: vi.fn(),
     archiveHermesAgent: vi.fn(),
-    getGatewayToken: vi.fn(),
     createSharedEnvSet: vi.fn(),
     archiveSharedEnvSet: vi.fn(),
     patchSharedEnvSet: vi.fn(),


### PR DESCRIPTION
## Summary

`agent.getGatewayToken` had no client-side caller — the tRPC endpoint was only referenced by its own definition, and the sole test reference was a `vi.fn()` stub existing solely to satisfy the `Runtime` interface. Removes the entire dead chain, inward to outward:

- `src/server/routers/trpc/agent.ts` — drop the `getGatewayToken` procedure
- `src/server/usecases/agent.ts` — drop `AgentUseCase.getGatewayToken`
- `src/server/usecases/adaptors/runtime.ts` — drop the `Runtime` interface method
- `src/server/usecases/chat.test.ts` — drop the now-unneeded interface mock stub
- `src/server/infras/kubernetes/client.ts` — drop the K8s Secret-reading implementation

`ManagedResources.hermesSecret` in `kubernetes/types/hermes-agent.ts` is kept — it mirrors the operator's CRD status shape, not this function.

Also groups the webhook patch methods together in `AgentUseCase` (pure reorder, no behavior change).

## Test plan

- [x] `pnpm --filter @hermeum/app lint` — clean (2 pre-existing, unrelated warnings)
- [x] `pnpm --filter @hermeum/app test` — 364 passed
- [x] `pnpm --filter @hermeum/app typecheck` — errors confirmed pre-existing on `main` (verified via `git stash`)