### PR TITLE
feat(app): add reserved default agent type as webhook fallback for typeless agents

### DIFF
--- a/apps/app/config.default.yaml
+++ b/apps/app/config.default.yaml
@@ -216,7 +216,7 @@ agentTypes:
       Standard performance — handles everyday workloads reliably, including
       browsing and web search. A good fit for most agents. Persists the agent
       workspace on a 10Gi volume.
-    mutatingWebhookJsonPatch:
+    mutatingWebhookJsonPatch: &mediumPatch
       # Both sidecars enabled.
       - - op: test
           path: /spec/searxng/enabled
@@ -329,6 +329,12 @@ agentTypes:
             persistence:
               enabled: true
               size: 10Gi
+  default:
+    description: >-
+      Fallback for agents without an explicit type — same resources as
+      medium. The reserved `default` key applies to typeless agents via the
+      mutating webhook and is hidden from the agent-type picker.
+    mutatingWebhookJsonPatch: *mediumPatch
   large:
     description: >-
       High performance — extra capacity for demanding tasks, such as very long

--- a/apps/app/src/entities/agent-type.ts
+++ b/apps/app/src/entities/agent-type.ts
@@ -4,6 +4,12 @@ import { z } from "zod";
 // picker-facing summary shape. Agent types are defined in Hermeum's own
 // configuration (see hermeum-config.ts); agents reference them by `type` key.
 
+// Reserved agent type key: agents without an explicit `type` fall back to
+// `agentTypes[DEFAULT_AGENT_TYPE_KEY]` when the mutating webhook resolves
+// their patch. It is a normal, settable type everywhere else, but hidden
+// from the picker and the AI config generator's type list.
+export const DEFAULT_AGENT_TYPE_KEY = "default";
+
 export const AgentTypeKeySchema = z
   .string()
   .min(1)

--- a/apps/app/src/server/usecases/agent-type.test.ts
+++ b/apps/app/src/server/usecases/agent-type.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("../infras/kubernetes/client", () => ({ KubernetesClient: vi.fn() }));
+vi.mock("../infras/local-files", () => ({ LocalFiles: vi.fn() }));
+vi.mock("../infras/posthog", () => ({
+  telemetry: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    heartbeat: vi.fn(),
+    shutdown: vi.fn(),
+  },
+}));
+vi.mock("@/server/libs/config", () => ({
+  config: { configPath: "./config.yaml", hermesDocsPath: "./docs/hermes-config" },
+}));
+
+import { stringify } from "yaml";
+
+import { AgentTypeUseCase } from "./agent-type";
+import type { FileAdaptor } from "./adaptors/file";
+import type { HermeumConfig } from "@/entities";
+
+function makeConfig(agentTypes: HermeumConfig["agentTypes"]): FileAdaptor {
+  return {
+    listFiles: vi.fn(),
+    readFile: vi.fn().mockResolvedValue({
+      path: "./config.yaml",
+      name: "config",
+      content: stringify({ agentTypes, templates: [] }),
+      data: {},
+    }),
+  };
+}
+
+describe("AgentTypeUseCase.list", () => {
+  it("hides the reserved default type from the picker", async () => {
+    const useCase = new AgentTypeUseCase(
+      {} as never,
+      makeConfig({
+        medium: { description: "Medium", mutatingWebhookJsonPatch: [] },
+        default: { description: "Fallback", mutatingWebhookJsonPatch: [] },
+      })
+    );
+
+    await expect(useCase.list()).resolves.toEqual([
+      { key: "medium", description: "Medium" },
+    ]);
+  });
+
+  it("returns all types when no default type is configured", async () => {
+    const useCase = new AgentTypeUseCase(
+      {} as never,
+      makeConfig({
+        medium: { description: "Medium", mutatingWebhookJsonPatch: [] },
+        large: { mutatingWebhookJsonPatch: [] },
+      })
+    );
+
+    await expect(useCase.list()).resolves.toEqual([
+      { key: "medium", description: "Medium" },
+      { key: "large" },
+    ]);
+  });
+
+  it("returns an empty array when agentTypes is undefined", async () => {
+    const useCase = new AgentTypeUseCase({} as never, makeConfig(undefined));
+
+    await expect(useCase.list()).resolves.toEqual([]);
+  });
+});

--- a/apps/app/src/server/usecases/agent-type.ts
+++ b/apps/app/src/server/usecases/agent-type.ts
@@ -1,14 +1,16 @@
-import { AgentTypeSummary } from "@/entities";
+import { AgentTypeSummary, DEFAULT_AGENT_TYPE_KEY } from "@/entities";
 import { BaseUseCase, HermeumConfigLoadable } from "@/server/usecases/mixin";
 
 export class AgentTypeUseCase extends HermeumConfigLoadable(BaseUseCase) {
   async list(): Promise<AgentTypeSummary[]> {
     const { agentTypes } = await this.loadHermeumConfig();
     return agentTypes
-      ? Object.entries(agentTypes).map(([key, t]) => ({
-          key,
-          ...(t.description !== undefined ? { description: t.description } : {}),
-        }))
+      ? Object.entries(agentTypes)
+          .filter(([key]) => key !== DEFAULT_AGENT_TYPE_KEY)
+          .map(([key, t]) => ({
+            key,
+            ...(t.description !== undefined ? { description: t.description } : {}),
+          }))
       : [];
   }
 }

--- a/apps/app/src/server/usecases/agent.test.ts
+++ b/apps/app/src/server/usecases/agent.test.ts
@@ -88,13 +88,52 @@ function makeSharedEnvSet(overrides: Partial<SharedEnvSet> = {}): SharedEnvSet {
 }
 
 describe("AgentUseCase.getmutatingWebhookJsonPatch", () => {
-  it("returns null when agent.type is undefined", async () => {
+  it("returns null when agent.type is undefined and no default type is configured", async () => {
     const useCase = new AgentUseCase(
       makeRuntime(),
       makeConfig({ "some-type": { mutatingWebhookJsonPatch: [] } })
     );
     const result = await useCase.getmutatingWebhookJsonPatch(makeAgent({ type: undefined }));
     expect(result).toBeNull();
+  });
+
+  it("falls back to the default agent type when agent.type is undefined", async () => {
+    const patch: JsonPatchOp[] = [{ op: "add", path: "/a", value: 1 }];
+    const useCase = new AgentUseCase(
+      makeRuntime(),
+      makeConfig({
+        "some-type": { mutatingWebhookJsonPatch: [] },
+        default: { mutatingWebhookJsonPatch: patch },
+      })
+    );
+    const result = await useCase.getmutatingWebhookJsonPatch(makeAgent({ type: undefined }));
+    expect(result).toEqual(patch);
+  });
+
+  it("does not fall back to the default agent type when a set type is unknown", async () => {
+    const patch: JsonPatchOp[] = [{ op: "add", path: "/a", value: 1 }];
+    const useCase = new AgentUseCase(
+      makeRuntime(),
+      makeConfig({ default: { mutatingWebhookJsonPatch: patch } })
+    );
+    const result = await useCase.getmutatingWebhookJsonPatch(makeAgent({ type: "unknown-type" }));
+    expect(result).toBeNull();
+  });
+
+  it("evaluates the default type's candidates against the incoming object", async () => {
+    const candidates: JsonPatchOp[][] = [
+      [{ op: "test", path: "/spec/model", value: "gpt-4" }, { op: "add", path: "/a", value: 1 }],
+      [{ op: "add", path: "/b", value: 2 }],
+    ];
+    const useCase = new AgentUseCase(
+      makeRuntime(),
+      makeConfig({ default: { mutatingWebhookJsonPatch: candidates } })
+    );
+    const result = await useCase.getmutatingWebhookJsonPatch(
+      makeAgent({ type: undefined }),
+      { spec: { model: "claude" } },
+    );
+    expect(result).toEqual(candidates[1]);
   });
 
   it("returns null when config.agentTypes is undefined", async () => {

--- a/apps/app/src/server/usecases/agent.ts
+++ b/apps/app/src/server/usecases/agent.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import * as fastJsonPatch from "fast-json-patch";
 
-import { Agent, AgentInput, AgentInputSchema, Context, Env, JsonPatchOp } from "@/entities";
+import { Agent, AgentInput, AgentInputSchema, Context, Env, JsonPatchOp, DEFAULT_AGENT_TYPE_KEY } from "@/entities";
 
 import { BaseUseCase, HermeumConfigLoadable, OwnershipGuarded } from "./mixin";
 
@@ -129,9 +129,10 @@ export class AgentUseCase extends OwnershipGuarded(HermeumConfigLoadable(BaseUse
     agent: Agent,
     incomingObject?: unknown,
   ): Promise<JsonPatchOp[] | null> {
-    if (!agent.type) return null;
     const { agentTypes } = await this.loadHermeumConfig();
-    const agentType = agentTypes?.[agent.type];
+    // Agents without an explicit type fall back to the reserved `default`
+    // agent type; a set-but-unknown type stays a no-op.
+    const agentType = agentTypes?.[agent.type ?? DEFAULT_AGENT_TYPE_KEY];
     if (!agentType) return null;
     // mutatingWebhookJsonPatch is normalized to JsonPatchOp[][] by the schema
     // transform. When an incoming object is provided, select the first

--- a/apps/app/src/server/usecases/chat.test.ts
+++ b/apps/app/src/server/usecases/chat.test.ts
@@ -125,6 +125,7 @@ describe("ChatUseCase.getAgentConfigContext", () => {
         {
           "pr-review": { description: "Reviews pull requests", mutatingWebhookJsonPatch: [] },
           plain: { mutatingWebhookJsonPatch: [] },
+          default: { description: "Fallback", mutatingWebhookJsonPatch: [] },
         }
       )
     );
@@ -138,6 +139,8 @@ describe("ChatUseCase.getAgentConfigContext", () => {
     expect(tools.listAgentTypes).toBeDefined();
     expect(tools.listAgentTypes?.execute).toBeDefined();
     const result = await tools.listAgentTypes!.execute!({}, callOptions);
+    // The reserved `default` type is hidden from the model — it applies
+    // automatically to typeless agents via the webhook.
     expect(result).toEqual({
       agentTypes: [
         { key: "pr-review", description: "Reviews pull requests" },

--- a/apps/app/src/server/usecases/chat.ts
+++ b/apps/app/src/server/usecases/chat.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import { AgentInput, AgentInputObjectSchema, AgentPatchSchema, tool, ToolSet } from "@/entities";
+import { AgentInput, AgentInputObjectSchema, AgentPatchSchema, tool, ToolSet, DEFAULT_AGENT_TYPE_KEY } from "@/entities";
 import { config } from "@/server/libs/config";
 
 import { BaseUseCase, HermeumConfigLoadable } from "./mixin";
@@ -178,11 +178,15 @@ export class ChatUseCase extends HermeumConfigLoadable(BaseUseCase) {
   // empty array when no agent types are configured.
   private async buildListAgentTypesTool(): Promise<ToolSet[string]> {
     const { agentTypes } = await this.loadHermeumConfig();
+    // The reserved `default` type is the typeless fallback for the webhook —
+    // not offered as an explicit choice to the model.
     const entries = agentTypes
-      ? Object.entries(agentTypes).map(([key, t]) => ({
-          key,
-          ...(t.description !== undefined ? { description: t.description } : {}),
-        }))
+      ? Object.entries(agentTypes)
+          .filter(([key]) => key !== DEFAULT_AGENT_TYPE_KEY)
+          .map(([key, t]) => ({
+            key,
+            ...(t.description !== undefined ? { description: t.description } : {}),
+          }))
       : [];
     return tool({
       description:

--- a/apps/docs/docs/operation/instance-config.md
+++ b/apps/docs/docs/operation/instance-config.md
@@ -87,6 +87,26 @@ agent's `type` field references. Each type has:
 | `description`             | no       | Human-readable description; surfaced to the AI config generator so it can pick the right type. |
 | `mutatingWebhookJsonPatch`| yes      | A JSON-Patch ([RFC 6902](https://datatracker.ietf.org/doc/html/rfc6902)) applied to the `HermesAgent` CR on `CREATE`/`UPDATE`. Accepts a flat `op` array (one candidate) or an array of arrays (multiple candidates; first match wins). |
 
+### The reserved `default` type
+
+The key `default` is reserved: when an agent is created **without** a
+`type`, the mutating webhook falls back to
+`agentTypes.default.mutatingWebhookJsonPatch` — so typeless agents receive
+that patch. If `default` is not configured, typeless agents get no patch, as
+before. An agent whose `type` is set but unknown does **not** fall back; the
+webhook stays a no-op for it.
+
+`default` is hidden from the agent-type picker and from the AI config
+generator's type list — the fallback applies automatically. It remains a
+valid type key otherwise: agents can be given `type: default` explicitly, and
+templates can reference it.
+
+:::note
+The bundled `config.default.yaml` defines `default` with the same patch as
+`medium`, so out of the box every agent gets the standard resources whether
+or not a type was chosen.
+:::
+
 When Hermeum receives an admission review, it looks up
 `agentTypes[agent.type].mutatingWebhookJsonPatch` and returns it as the
 patch. If multiple candidates are provided, Hermeum evaluates each

--- a/apps/docs/docs/operation/mutating-webhook.md
+++ b/apps/docs/docs/operation/mutating-webhook.md
@@ -31,7 +31,9 @@ webhook:
 1. Reads the incoming object's `type` (from the `hermeum.app/type`
    annotation).
 2. Looks up `agentTypes[<type>].mutatingWebhookJsonPatch` in the loaded
-   instance config — a list of candidate patches.
+   instance config — a list of candidate patches. When the agent has **no**
+   `type`, Hermeum looks up the reserved `default` type instead (see
+   [Instance config](../instance-config#the-reserved-default-type)).
 3. If candidates begin with `test` ops, evaluates each candidate's `test`
    ops against the incoming object and returns the **first** one whose tests
    all pass (first-match-wins). If none match, no patch is returned.
@@ -39,8 +41,10 @@ webhook:
    as the admission response's `patch`.
 
 If the type is unknown or has no `mutatingWebhookJsonPatch`, the webhook
-returns no patch — i.e. it is a no-op. The webhook is therefore inert until
-you populate at least one `agentTypes` entry with a non-empty patch.
+returns no patch — i.e. it is a no-op. Typeless agents fall back to the
+reserved `default` type when it is configured; otherwise they are a no-op
+too. The webhook is therefore inert until you populate at least one
+`agentTypes` entry with a non-empty patch.
 
 ## Configuring a patch
 

--- a/charts/hermeum/README.md
+++ b/charts/hermeum/README.md
@@ -110,7 +110,9 @@ When `webhook.enabled` (default `true`), the chart ships:
 The webhook returns a JSON-Patch drawn from
 `agentConfig.agentTypes[agent.type].mutatingWebhookJsonPatch` — so it is a
 no-op until the operator populates `agentConfig` with at least one
-`agentTypes` entry whose `mutatingWebhookJsonPatch` is non-empty.
+`agentTypes` entry whose `mutatingWebhookJsonPatch` is non-empty. Agents
+without a `type` fall back to the reserved `agentTypes.default` entry; the
+bundled `config.default.yaml` defines one (mirroring the `medium` patch).
 
 ### Operator-supplied cert
 

--- a/charts/hermeum/values.yaml
+++ b/charts/hermeum/values.yaml
@@ -133,7 +133,8 @@ secrets:
 #
 # The mutating webhook for HermesAgent is driven by
 # `agentTypes.<type>.mutatingWebhookJsonPatch` — populate this to apply
-# JSON-Patch mutations to matching HermesAgent CRs on CREATE/UPDATE.
+# JSON-Patch mutations to matching HermesAgent CRs on CREATE/UPDATE. Agents
+# without a `type` fall back to the reserved `agentTypes.default` entry.
 #
 # Example:
 #   agentConfig:
@@ -160,7 +161,8 @@ agentConfig: {}
 # The hermeum app serves POST /webhook/mutating on the HTTPS port below. The
 # MutatingWebhookConfiguration admits CREATE/UPDATE on hermesagents and
 # dispatches AdmissionReviews here; the hermeum app returns the JSON-Patch from
-# agentConfig.agentTypes[agent.type].mutatingWebhookJsonPatch.
+# agentConfig.agentTypes[agent.type].mutatingWebhookJsonPatch (falling back to
+# the reserved `default` type for agents without a type).
 #
 # The hermeum app starts its webhook HTTPS listener only when both
 # HERMEUM_WEBHOOK_TLS_CERT_FILE and HERMEUM_WEBHOOK_TLS_KEY_FILE are set; the


### PR DESCRIPTION
## Summary

Adds a reserved `default` agent type key. When an agent has no explicit `type`, the mutating webhook now falls back to `agentTypes.default.mutatingWebhookJsonPatch` instead of returning no patch.

- **Webhook fallback only** — `type` remains optional with no default value on the agent itself; a set-but-unknown type stays a no-op (no fallback).
- **Hidden from pickers** — `default` is filtered from the agent-type picker (`AgentTypeUseCase.list`) and the AI config generator's `listAgentTypes` tool, since it applies automatically.
- **Still a normal type elsewhere** — `type: "default"` is settable on create/update and valid in templates.
- **Bundled config ships one** — `config.default.yaml` defines `default` aliasing the `medium` patch via a YAML anchor, so typeless agents get standard resources out of the box.

## Changes

- `apps/app/src/entities/agent-type.ts` — `DEFAULT_AGENT_TYPE_KEY` constant.
- `apps/app/src/server/usecases/agent.ts` — webhook lookup falls back to `default` when `agent.type` is missing.
- `apps/app/src/server/usecases/agent-type.ts`, `chat.ts` — filter `default` from the surfaced type lists.
- `apps/app/config.default.yaml` — new `default` entry mirroring `medium`.
- Docs: `instance-config.md` (reserved-type section), `mutating-webhook.md` (lookup flow + fallback), chart `README.md` / `values.yaml` comments.

## Behavior change

Existing typeless agents on installs using the bundled config will now receive the `medium` resource patch on their next CREATE/UPDATE admission (intended outcome of shipping a bundled default).

## Test plan

- [x] `pnpm --filter @hermeum/app test` — 370/370 pass (incl. 4 new: fallback applies, no fallback for unknown-but-set type, candidate `test`-op selection through the fallback, picker/chat list exclusion)
- [x] `pnpm --filter @hermeum/app lint` — clean
- [x] `pnpm --filter @hermeum/docs build` — passes